### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/alternatefutures/service-cloud-api/security/code-scanning/5](https://github.com/alternatefutures/service-cloud-api/security/code-scanning/5)

The best way to fix this problem is to explicitly set the permissions for the workflow at the root level, immediately below the `name` field and above the `on` block in `.github/workflows/ci.yml`. Given that all jobs in the workflow merely check out code, install dependencies, run tests, linting, and building, the minimum required permission is `contents: read`. This will limit the GITHUB_TOKEN used by all jobs in the workflow to only be able to read repository contents, adhering to the principle of least privilege. No changes are needed to the steps or jobs themselves.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
