### PR TITLE
ALT-93: Add explicit permissions to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary
Adds explicit `permissions: contents: read` to the CI workflow to follow the principle of least privilege and resolve CodeQL security scanning alert.

## Changes
- Added `permissions` block to `.github/workflows/ci.yml`
- Set `contents: read` as the minimum required permission for the workflow

## Security Impact
This change limits the GITHUB_TOKEN used by the CI workflow to only read repository contents, which is all that's needed for checkout, install, test, lint, and build operations. This follows GitHub's security best practices and resolves the CodeQL code scanning alert about workflows without explicit permissions.

## Related
- Closes CodeQL alert #5
- Supersedes PR #8 (which had invalid branch/title format)

## Test Plan
- [x] CI workflow continues to work with read-only permissions
- [x] All existing tests pass
- [x] Linting and build checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)