### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -1,4 +1,6 @@
 name: Branch Name Check
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/alternatefutures/service-cloud-api/security/code-scanning/3](https://github.com/alternatefutures/service-cloud-api/security/code-scanning/3)

The best way to fix the problem is to specify an explicit `permissions` block that assigns the minimum required privileges for this workflow. Since all jobs in this workflow ("check-branch-name" and "check-pr-title") only need to read event data and do not modify the repository, a root-level permissions block with `permissions: { contents: read }` is best. This should be placed at the top level of the workflow, immediately after the `name:` key and before the `on:` key, so it applies to all jobs by default and does not interfere with workflow operation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
