### PR TITLE
ALT-94: Add explicit permissions to branch name check workflow

### DIFF
--- a/.github/workflows/branch-name-check.yml
+++ b/.github/workflows/branch-name-check.yml
@@ -1,4 +1,6 @@
 name: Branch Name Check
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
## Summary
Adds explicit `permissions: contents: read` to the branch-name-check workflow to follow the principle of least privilege and resolve CodeQL security scanning alert.

## Changes
- Added `permissions` block to `.github/workflows/branch-name-check.yml`
- Set `contents: read` as the minimum required permission for the workflow

## Security Impact
This change limits the GITHUB_TOKEN used by the branch-name-check workflow to only read repository contents, which is all that's needed for validating branch names and PR titles. This follows GitHub's security best practices and resolves the CodeQL code scanning alert about workflows without explicit permissions.

## Audit of All Workflows
I've verified all workflows in `.github/workflows/`:
- ✅ `ci.yml` - Already has `permissions: contents: read` (fixed in PR #9)
- ✅ `branch-name-check.yml` - **Fixed in this PR**
- ✅ `claude-code-review.yml` - Already has appropriate permissions (write access for commenting)
- ✅ `codeql.yml` - Already has appropriate job-level permissions

## Related
- Closes CodeQL alert #3
- Supersedes PR #10 (which had invalid branch/title format)

## Test Plan
- [x] Workflow continues to work with read-only permissions
- [x] Branch name validation works correctly
- [x] PR title validation works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)