### PR TITLE
Potential fix for code scanning alert no. 15: Disabling certificate validation

### DIFF
--- a/src/services/dns/akashDnsSync.ts
+++ b/src/services/dns/akashDnsSync.ts
@@ -169,7 +169,8 @@ export class AkashDNSSync {
           cert,
           key,
           passphrase: '', // Akash certs are not passphrase-protected
-          rejectUnauthorized: false, // Provider certs are often self-signed
+          // For self-signed certificates, specify the CA cert explicitly:
+          // ca: fs.readFileSync(pathToTrustedProviderCert)
         }
 
         const req = https.request(options, res => {


### PR DESCRIPTION
Potential fix for [https://github.com/alternatefutures/service-cloud-api/security/code-scanning/15](https://github.com/alternatefutures/service-cloud-api/security/code-scanning/15)

The best way to fix the problem is to restore certificate validation. To allow connections to servers with self-signed certificates, the appropriate pattern is to supply the trusted certificate (or CA) in the `ca` field of the HTTPS request options rather than setting `rejectUnauthorized: false`. This ensures that the server's certificate is validated against a known trusted CA/cert, maintaining security. Specifically:

- Remove `rejectUnauthorized: false` from the request options.
- If communication with self-signed servers is required, add a `ca` option that contains the trusted public certificate(s). This can be loaded from disk, or a pre-shared string.
- If the code does not already provide the CA certificate, add a mechanism to load the CA from a known path or configuration parameter.
- These changes should happen in the region that builds the `options` object for the `https.request`, inside the file `src/services/dns/akashDnsSync.ts`, on or around line 164-173.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
