### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-infisical.yml
+++ b/.github/workflows/deploy-infisical.yml
@@ -1,5 +1,7 @@
 # Deploy Infisical secrets manager to Akash Network
 name: Deploy Infisical to Akash
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/alternatefutures/service-cloud-api/security/code-scanning/13](https://github.com/alternatefutures/service-cloud-api/security/code-scanning/13)

To address this issue, you should explicitly set the `permissions` block in your workflow to restrict the GITHUB_TOKEN to the minimum privileges needed. In most deployment workflows such as this one (which does not interact with repository contents or pull requests via the API), only `contents: read` is required. This can be set either globally at the top level of the workflow (recommended unless you have specific jobs needing broader permissions) or directly in the job. The recommended approach is to add a `permissions: contents: read` block right after the `name` (or before `on:`) at the root level of `.github/workflows/deploy-infisical.yml`. No other changes or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
