### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/get-service-uris.yml
+++ b/.github/workflows/get-service-uris.yml
@@ -1,4 +1,6 @@
 name: Get Service URIs
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/alternatefutures/service-cloud-api/security/code-scanning/12](https://github.com/alternatefutures/service-cloud-api/security/code-scanning/12)

To fix the problem, add an explicit `permissions:` block limiting the GITHUB_TOKEN's scope to only what is necessary for the tasks performed in this workflow. Since the workflow does not push changes, interact with issues, pull requests, or similar, and only requires writing to step summaries and environment files via workflow commands, it is safe to use `permissions: contents: read` at the root of the workflow. This adheres to the principle of least privilege. The change should be made at the root level, right after the workflow name and before the `on:` block, in `.github/workflows/get-service-uris.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
