### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cleanup-deployments-v3.yml
+++ b/.github/workflows/cleanup-deployments-v3.yml
@@ -1,4 +1,6 @@
 name: Cleanup Akash Deployments (v3)
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/alternatefutures/service-cloud-api/security/code-scanning/9](https://github.com/alternatefutures/service-cloud-api/security/code-scanning/9)

To fix this issue, add a `permissions` block specifying least-privilege (typically `contents: read`) either at the root workflow level (under the workflow `name:` and `on:`) or at the job level. Since this workflow seems to only check out code and does not write to the repository, `contents: read` suffices. Place the following block at the top-level of the workflow file, below the `name:` and above `jobs:`, unless future workflows require more specific permissions for particular jobs.

- File to edit: `.github/workflows/cleanup-deployments-v3.yml`
- Edit region: Insert the following block after the workflow `name:` and before `on:`:  
  ```yaml
  permissions:
    contents: read
  ```

No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
