### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-akash.yml
+++ b/.github/workflows/deploy-akash.yml
@@ -1,4 +1,7 @@
 name: Deploy to Akash Network
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   # Automatically deploy to mainnet when pushing to main branch


### PR DESCRIPTION
Potential fix for [https://github.com/alternatefutures/service-cloud-api/security/code-scanning/8](https://github.com/alternatefutures/service-cloud-api/security/code-scanning/8)

The fix is to add a `permissions` block at the workflow (top-level) or job level to restrict the default permissions of the GITHUB_TOKEN to only what's truly needed. For this workflow, most steps require no more than `contents: read` (for checkout and Action operations), but the step that comments on pull requests requires the ability to write to pull requests. Setting these as default for the job (`contents: read`, `pull-requests: write`) enforces the principle of least privilege. This should be added as a mapping either at the very top, after the `name` key, or just inside the `deploy` job under `jobs.deploy` (before `runs-on`).

**Best practice:** Add the following block at the top level (recommended), immediately after `name:` and before `on:`, so that it applies to all jobs by default:

```yaml
permissions:
  contents: read
  pull-requests: write
```

**Detailed steps:**
- Insert the `permissions` block after the `name: Deploy to Akash Network` line (line 1).
- This block will limit the access provided to the GITHUB_TOKEN: read-only for repository contents and write for pull requests.
- No functional changes to jobs or steps are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
