### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/setup-certificates.yml
+++ b/.github/workflows/setup-certificates.yml
@@ -1,4 +1,6 @@
 name: Setup Akash Certificates
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/alternatefutures/service-cloud-api/security/code-scanning/11](https://github.com/alternatefutures/service-cloud-api/security/code-scanning/11)

To address the issue, add a `permissions` block to the workflow (at the top level or inside the job). The most restrictive sensible permissions for this workflow would be to allow only the necessary ones. The workflow uses the following GitHub features:

- `$GITHUB_ENV` and `$GITHUB_STEP_SUMMARY` for environment propagation and summary publication (these do not require repository write permissions; summary access is provided by default).
- Uploading an artifact using `actions/upload-artifact`, which does not require extra write permissions.
- No steps modify repository contents, issues, or pull requests.

The recommended minimal permissions, per GitHub guidance for similar workflows, are:

```yaml
permissions:
  contents: read
```

This allows reading repository content if needed (such as when loading scripts) but prevents accidental modification. If artifact upload or summary writing required explicit permission adjustments, we'd make exceptions, but in practice the artifact upload action does not require additional write permission.

**Implementation:**
- Add the following block after the workflow `name:` section, above `on:` in `.github/workflows/setup-certificates.yml`:

```yaml
permissions:
  contents: read
```

No imports or complex changes are needed; this is a YAML file edit only.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
