### PR TITLE
migrate escrow deposits to uact denomination and CLI v2 command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,7 @@ AKASH_KEY_NAME=default
 RPC_ENDPOINT=https://rpc.akashnet.net:443
 GRPC_ENDPOINT=https://akash-grpc.publicnode.com:443
 AKASH_CHAIN_ID=akashnet-2
-AKT_USD_PRICE=0.33
+AKT_USD_PRICE=0.50
 AKASH_SSL_PROXY_PROVIDER=akash1zlsep362zz46qlwzttm06t8lv9qtg8gtaya97u
 AKASH_SSL_PROXY_PROVIDER_NAME=america.computer
 

--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,12 @@ STRIPE_WEBHOOK_SECRET=
 INTERNAL_AUTH_TOKEN=
 
 # =============================================================================
+# Discord Feedback Webhook
+# =============================================================================
+# Webhook URL for bug reports / feedback submitted through the app UI
+DISCORD_FEEDBACK_WEBHOOK_URL=
+
+# =============================================================================
 # Ops 
 # =============================================================================
 ADMIN_EMAIL=

--- a/src/config/billing.ts
+++ b/src/config/billing.ts
@@ -15,8 +15,8 @@ export const BILLING_CONFIG = {
     // Escrow: 0 = no upfront hold (pure pay-as-you-go).
     // Set > 0 to pre-fund N days (e.g. for budget-cap or auto-stop features later).
     escrowDays: 0,
-    billingIntervalHours: 24,
-    minBillingIntervalHours: 20,
+    billingIntervalHours: 1,
+    minBillingIntervalHours: 1,
     minBalanceCentsToLaunch: 100,
   },
   phala: {
@@ -24,7 +24,7 @@ export const BILLING_CONFIG = {
     minBalanceCentsToLaunch: 100,
   },
   scheduler: {
-    cronExpression: '0 3 * * *',
+    cronExpression: '0 * * * *',
   },
   thresholds: {
     /** Suspend when balance cannot cover this many hours of total burn. */

--- a/src/config/pricing.ts
+++ b/src/config/pricing.ts
@@ -87,8 +87,8 @@ export const PHALA_RATES: Record<string, number> = {
 // AKASH — CONVERSION HELPERS
 // ============================================
 
-/** Fallback AKT/USD price used when the live CoinGecko feed is unavailable. */
-export const AKT_USD_PRICE_FALLBACK = parseFloat(process.env.AKT_USD_PRICE || '0.33')
+/** Last-resort fallback — only used when ALL live sources fail. */
+export const AKT_USD_PRICE_FALLBACK = parseFloat(process.env.AKT_USD_PRICE || '0.50')
 
 /** @deprecated Use getAktUsdPrice() for live price. Kept for non-async call sites. */
 export const AKT_USD_PRICE = AKT_USD_PRICE_FALLBACK
@@ -96,37 +96,65 @@ export const AKT_USD_PRICE = AKT_USD_PRICE_FALLBACK
 /** Akash blocks per day (~6s/block) */
 export const AKASH_BLOCKS_PER_DAY = 14400
 
-// ---- Live AKT price via CoinGecko (10-min cache) ----
+// ---- Live AKT price (Akash API → CoinGecko → env fallback) ----
 
 let _aktCache: { price: number; ts: number } | null = null
-const AKT_CACHE_TTL_MS = 10 * 60_000
+const AKT_CACHE_TTL_MS = 5 * 60_000
+
+async function fetchAkashMarketPrice(signal: AbortSignal): Promise<number | null> {
+  const res = await fetch('https://console-api.akash.network/v1/market-data', { signal })
+  if (!res.ok) throw new Error(`Akash API HTTP ${res.status}`)
+  const data = (await res.json()) as { price?: number }
+  return data.price && data.price > 0 ? data.price : null
+}
+
+async function fetchCoinGeckoPrice(signal: AbortSignal): Promise<number | null> {
+  const res = await fetch(
+    'https://api.coingecko.com/api/v3/simple/price?ids=akash-network&vs_currencies=usd',
+    { signal },
+  )
+  if (!res.ok) throw new Error(`CoinGecko HTTP ${res.status}`)
+  const data = (await res.json()) as { 'akash-network'?: { usd?: number } }
+  const price = data['akash-network']?.usd
+  return price && price > 0 ? price : null
+}
 
 /**
- * Fetch the current AKT/USD price from CoinGecko with a 10-minute in-memory cache.
- * Falls back to AKT_USD_PRICE env var if the API is unreachable.
+ * Fetch the current AKT/USD price with a 5-minute in-memory cache.
+ * Sources tried in order: Akash Console API → CoinGecko → last cached → env fallback.
  */
 export async function getAktUsdPrice(): Promise<number> {
   if (_aktCache && Date.now() - _aktCache.ts < AKT_CACHE_TTL_MS) {
     return _aktCache.price
   }
 
-  try {
-    const res = await fetch(
-      'https://api.coingecko.com/api/v3/simple/price?ids=akash-network&vs_currencies=usd',
-      { signal: AbortSignal.timeout(5_000) },
-    )
-    if (!res.ok) throw new Error(`CoinGecko HTTP ${res.status}`)
-    const data = (await res.json()) as { 'akash-network'?: { usd?: number } }
-    const price = data['akash-network']?.usd
-    if (price && price > 0) {
-      _aktCache = { price, ts: Date.now() }
-      return price
+  const signal = AbortSignal.timeout(5_000)
+
+  const sources: Array<[string, () => Promise<number | null>]> = [
+    ['akash-api', () => fetchAkashMarketPrice(signal)],
+    ['coingecko', () => fetchCoinGeckoPrice(signal)],
+  ]
+
+  for (const [name, fetcher] of sources) {
+    try {
+      const price = await fetcher()
+      if (price) {
+        _aktCache = { price, ts: Date.now() }
+        log.info({ source: name, price }, 'AKT/USD price updated')
+        return price
+      }
+    } catch (err) {
+      log.warn({ source: name, err: (err as Error).message }, 'AKT price source failed')
     }
-  } catch (err) {
-    log.warn({ err: (err as Error).message }, 'CoinGecko AKT price fetch failed, using fallback')
   }
 
-  return _aktCache?.price ?? AKT_USD_PRICE_FALLBACK
+  if (_aktCache?.price) {
+    log.warn({ stalePrice: _aktCache.price, ageMs: Date.now() - _aktCache.ts }, 'All AKT price sources failed, using stale cache')
+    return _aktCache.price
+  }
+
+  log.error({ fallback: AKT_USD_PRICE_FALLBACK }, 'All AKT price sources failed and no cache — using env fallback')
+  return AKT_USD_PRICE_FALLBACK
 }
 
 // ============================================
@@ -238,20 +266,33 @@ export function calculateStorageCostWithMargin(
 }
 
 /**
- * Convert Akash pricePerBlock (uAKT) to USD per day.
- * @param pricePerBlock - Price in uAKT per block (from bid)
- * @param aktUsdPrice   - Current AKT/USD rate. Pass the result of getAktUsdPrice()
- *                        for live pricing; omit only in sync contexts where the fallback is acceptable.
+ * Convert Akash pricePerBlock to USD per day.
+ *
+ * Since the BME upgrade (March 2026), all Akash leases are denominated in
+ * uact (micro-ACT), where ACT is a USD-pegged compute credit (1 ACT = $1).
+ * For uact: daily USD = (pricePerBlock × blocksPerDay) / 1,000,000.
+ * For legacy uakt: daily USD = (pricePerBlock × blocksPerDay) / 1,000,000 × aktUsdPrice.
+ *
+ * @param pricePerBlock - Price per block from the bid/lease
+ * @param denom         - Token denomination ('uact' or 'uakt'). Defaults to 'uact' (post-BME).
+ * @param aktUsdPrice   - Current AKT/USD rate. Only used when denom is 'uakt'.
  * @returns Daily cost in USD (raw, before margin)
  */
 export function akashPricePerBlockToUsdPerDay(
   pricePerBlock: string | number,
+  denom: string = 'uact',
   aktUsdPrice: number = AKT_USD_PRICE_FALLBACK,
 ): number {
-  const priceUakt = typeof pricePerBlock === 'string' ? parseFloat(pricePerBlock) : pricePerBlock
-  const dailyUakt = priceUakt * AKASH_BLOCKS_PER_DAY
-  const dailyAkt = dailyUakt / 1_000_000
-  return dailyAkt * aktUsdPrice
+  const price = typeof pricePerBlock === 'string' ? parseFloat(pricePerBlock) : pricePerBlock
+  const dailyMicro = price * AKASH_BLOCKS_PER_DAY
+  const dailyUnits = dailyMicro / 1_000_000
+
+  if (denom === 'uakt') {
+    return dailyUnits * aktUsdPrice
+  }
+
+  // uact (ACT) is USD-pegged: 1 ACT = $1
+  return dailyUnits
 }
 
 /**

--- a/src/resolvers/akash.ts
+++ b/src/resolvers/akash.ts
@@ -143,15 +143,14 @@ async function estimateGpuDailyCost(
 
     if (providers.length === 0) return 1800 * gpuUnits
 
-    const { getAktUsdPrice, akashPricePerBlockToUsdPerDay, applyMargin, DEFAULT_MONTHLY_MARGIN } =
+    const { akashPricePerBlockToUsdPerDay, applyMargin, DEFAULT_MONTHLY_MARGIN } =
       await import('../config/pricing.js')
-    const aktPrice = await getAktUsdPrice()
 
     const minUact = providers.reduce(
       (min, p) => (p.minPriceUact! < min ? p.minPriceUact! : min),
       providers[0].minPriceUact!
     )
-    const dailyUsd = akashPricePerBlockToUsdPerDay(Number(minUact), aktPrice)
+    const dailyUsd = akashPricePerBlockToUsdPerDay(Number(minUact), 'uact')
     const withMargin = applyMargin(dailyUsd, DEFAULT_MONTHLY_MARGIN)
     return Math.ceil(withMargin * 100) * gpuUnits
   } catch (error) {
@@ -673,9 +672,8 @@ export const akashFieldResolvers = {
     },
     costPerDay: async (parent: any) => {
       if (parent.pricePerBlock) {
-        const { akashPricePerBlockToUsdPerDay, getAktUsdPrice, applyMargin, DEFAULT_MONTHLY_MARGIN } = await import('../config/pricing.js')
-        const aktPrice = await getAktUsdPrice()
-        const raw = akashPricePerBlockToUsdPerDay(parent.pricePerBlock, aktPrice)
+        const { akashPricePerBlockToUsdPerDay, applyMargin, DEFAULT_MONTHLY_MARGIN } = await import('../config/pricing.js')
+        const raw = akashPricePerBlockToUsdPerDay(parent.pricePerBlock, 'uact')
         return applyMargin(raw, DEFAULT_MONTHLY_MARGIN)
       }
       if (parent.dailyRateCentsCharged != null) return parent.dailyRateCentsCharged / 100
@@ -683,9 +681,8 @@ export const akashFieldResolvers = {
     },
     costPerHour: async (parent: any) => {
       if (parent.pricePerBlock) {
-        const { akashPricePerBlockToUsdPerDay, getAktUsdPrice, applyMargin, DEFAULT_MONTHLY_MARGIN } = await import('../config/pricing.js')
-        const aktPrice = await getAktUsdPrice()
-        const raw = akashPricePerBlockToUsdPerDay(parent.pricePerBlock, aktPrice)
+        const { akashPricePerBlockToUsdPerDay, applyMargin, DEFAULT_MONTHLY_MARGIN } = await import('../config/pricing.js')
+        const raw = akashPricePerBlockToUsdPerDay(parent.pricePerBlock, 'uact')
         return applyMargin(raw, DEFAULT_MONTHLY_MARGIN) / 24
       }
       if (parent.dailyRateCentsCharged != null) return parent.dailyRateCentsCharged / 100 / 24
@@ -693,9 +690,8 @@ export const akashFieldResolvers = {
     },
     costPerMonth: async (parent: any) => {
       if (parent.pricePerBlock) {
-        const { akashPricePerBlockToUsdPerDay, getAktUsdPrice, applyMargin, DEFAULT_MONTHLY_MARGIN } = await import('../config/pricing.js')
-        const aktPrice = await getAktUsdPrice()
-        const raw = akashPricePerBlockToUsdPerDay(parent.pricePerBlock, aktPrice)
+        const { akashPricePerBlockToUsdPerDay, applyMargin, DEFAULT_MONTHLY_MARGIN } = await import('../config/pricing.js')
+        const raw = akashPricePerBlockToUsdPerDay(parent.pricePerBlock, 'uact')
         return applyMargin(raw, DEFAULT_MONTHLY_MARGIN) * 30
       }
       if (parent.dailyRateCentsCharged != null) return (parent.dailyRateCentsCharged / 100) * 30

--- a/src/services/akash/orchestrator.ts
+++ b/src/services/akash/orchestrator.ts
@@ -363,8 +363,9 @@ export class AkashOrchestrator {
     log.info({ dseq, amountUact }, 'Topping up deployment escrow')
     await runAkashAsync([
       'tx',
-      'deployment',
+      'escrow',
       'deposit',
+      'deployment',
       `${amountUact}uact`,
       '--dseq',
       String(dseq),

--- a/src/services/billing/computeBillingScheduler.ts
+++ b/src/services/billing/computeBillingScheduler.ts
@@ -115,7 +115,7 @@ export class ComputeBillingScheduler {
 
   private async runBillingCycle() {
     const startTime = Date.now()
-    log.info('Starting daily billing cycle')
+    log.info('Starting hourly billing cycle')
 
     const stats = {
       akashProcessed: 0,
@@ -237,16 +237,17 @@ export class ComputeBillingScheduler {
 
         if (escrow.depositCents === 0) {
           // Pay-as-you-go: debit wallet directly (same pattern as Phala)
-          const daysToBill = this.forceMode
-            ? Math.max(1, Math.floor(hoursSinceLastBill / 24))
-            : Math.max(1, Math.floor(hoursSinceLastBill / 24))
-          const amountCents = escrow.dailyRateCents * daysToBill
+          const hoursToBill = this.forceMode
+            ? Math.max(1, Math.floor(hoursSinceLastBill))
+            : Math.max(1, Math.floor(hoursSinceLastBill))
+          const hourlyRateCents = escrow.dailyRateCents / 24
+          const amountCents = Math.round(hourlyRateCents * hoursToBill)
 
           if (amountCents <= 0) continue
 
-          const dateKey = now.toISOString().slice(0, 10)
-          const runId = this.forceMode ? `force_${now.toISOString().slice(0, 13)}` : dateKey
-          const idempotencyKey = `akash_daily:${escrow.id}:${runId}`
+          const hourKey = now.toISOString().slice(0, 13)
+          const runId = this.forceMode ? `force_${hourKey}` : hourKey
+          const idempotencyKey = `akash_hourly:${escrow.id}:${runId}`
 
           const result = await billingApi.computeDebit({
             orgBillingId: escrow.orgBillingId,
@@ -254,7 +255,7 @@ export class ComputeBillingScheduler {
             serviceType: 'akash_compute',
             provider: 'akash',
             resource: escrow.akashDeployment.service?.slug || escrow.akashDeploymentId,
-            description: `Akash compute: ${daysToBill}d @ $${(escrow.dailyRateCents / 100).toFixed(2)}/day`,
+            description: `Akash compute: ${hoursToBill}h @ $${(hourlyRateCents / 100).toFixed(2)}/hr`,
             idempotencyKey,
             metadata: {
               deploymentId: escrow.akashDeploymentId,

--- a/src/services/billing/deploymentSettlement.test.ts
+++ b/src/services/billing/deploymentSettlement.test.ts
@@ -20,7 +20,6 @@ vi.mock('./billingApiClient.js', () => ({
 }))
 
 vi.mock('../../config/pricing.js', () => ({
-  getAktUsdPrice: vi.fn(async () => 1),
   akashPricePerBlockToUsdPerDay: vi.fn(() => 1.44),
   applyMargin: vi.fn((raw: number, margin: number) => raw * (1 + margin)),
 }))

--- a/src/services/billing/deploymentSettlement.ts
+++ b/src/services/billing/deploymentSettlement.ts
@@ -1,6 +1,6 @@
 import type { PrismaClient } from '@prisma/client'
 import { getBillingApiClient } from './billingApiClient.js'
-import { akashPricePerBlockToUsdPerDay, applyMargin, getAktUsdPrice } from '../../config/pricing.js'
+import { akashPricePerBlockToUsdPerDay, applyMargin } from '../../config/pricing.js'
 import { createLogger } from '../../lib/logger.js'
 
 const log = createLogger('deployment-settlement')
@@ -261,14 +261,11 @@ async function resolveAkashDailyRateCentsWithoutEscrow(
   if (!deployment.pricePerBlock) return 0
 
   try {
-    const [orgBilling, aktPrice] = await Promise.all([
-      billingApi.getOrgBilling(deployment.service.project.organizationId),
-      getAktUsdPrice(),
-    ])
+    const orgBilling = await billingApi.getOrgBilling(deployment.service.project.organizationId)
     const orgMarkup = await billingApi.getOrgMarkup(orgBilling.orgBillingId)
     const rawDailyUsd = akashPricePerBlockToUsdPerDay(
       deployment.pricePerBlock,
-      aktPrice
+      'uact'
     )
     return Math.ceil(applyMargin(rawDailyUsd, orgMarkup.marginRate) * 100)
   } catch {

--- a/src/services/billing/escrowHealthMonitor.ts
+++ b/src/services/billing/escrowHealthMonitor.ts
@@ -140,7 +140,7 @@ export class EscrowHealthMonitor {
         '-o', 'json',
       ])
       const data = JSON.parse(output)
-      const uactBal = data?.balances?.find((b: { denom: string }) => b.denom === 'uakt')
+      const uactBal = data?.balances?.find((b: { denom: string }) => b.denom === 'uact')
       const balance = parseInt(uactBal?.amount || '0', 10)
       if (balance < LOW_WALLET_THRESHOLD_UACT) {
         log.warn(
@@ -203,10 +203,12 @@ export class EscrowHealthMonitor {
     try {
       await runAkashCmd([
         'tx',
-        'deployment',
+        'escrow',
         'deposit',
+        'deployment',
         `${refillUact}uact`,
-        '--dseq', dseq,
+        '--dseq',
+        dseq,
         '-y',
       ])
 

--- a/src/services/billing/escrowService.test.ts
+++ b/src/services/billing/escrowService.test.ts
@@ -16,9 +16,9 @@ vi.mock('./billingApiClient.js', () => ({
 
 vi.mock('../../config/pricing.js', () => ({
   getAktUsdPrice: () => getAktUsdPriceMock(),
-  akashPricePerBlockToUsdPerDay: (ppb: string, aktPrice: number) => {
-    const priceUakt = parseFloat(ppb)
-    return (priceUakt * 14400) / 1_000_000 * aktPrice
+  akashPricePerBlockToUsdPerDay: (ppb: string, _denom: string = 'uact') => {
+    const price = parseFloat(ppb)
+    return (price * 14400) / 1_000_000
   },
   applyMargin: (raw: number, rate: number) => raw * (1 + rate),
 }))

--- a/src/services/billing/escrowService.ts
+++ b/src/services/billing/escrowService.ts
@@ -15,7 +15,7 @@
 import type { PrismaClient, DeploymentEscrow } from '@prisma/client'
 import { getBillingApiClient } from './billingApiClient.js'
 import { BILLING_CONFIG } from '../../config/billing.js'
-import { akashPricePerBlockToUsdPerDay, applyMargin, getAktUsdPrice } from '../../config/pricing.js'
+import { akashPricePerBlockToUsdPerDay, applyMargin } from '../../config/pricing.js'
 import { createLogger } from '../../lib/logger.js'
 
 const log = createLogger('escrow-service')
@@ -48,8 +48,7 @@ export class EscrowService {
   }): Promise<DeploymentEscrow> {
     const escrowDays = args.escrowDays ?? BILLING_CONFIG.akash.escrowDays
 
-    const aktPrice = await getAktUsdPrice()
-    const rawDailyUsd = akashPricePerBlockToUsdPerDay(args.pricePerBlock, aktPrice)
+    const rawDailyUsd = akashPricePerBlockToUsdPerDay(args.pricePerBlock, 'uact')
     const chargedDailyUsd = applyMargin(rawDailyUsd, args.marginRate)
     const dailyRateCents = Math.ceil(chargedDailyUsd * 100)
 

--- a/src/services/billing/escrowService.ts
+++ b/src/services/billing/escrowService.ts
@@ -128,8 +128,9 @@ export class EscrowService {
       return null
     }
 
-    const daysToBill = Math.max(1, Math.floor(hoursSinceLastBill / 24))
-    const consumptionCents = escrow.dailyRateCents * daysToBill
+    const hoursToBill = Math.max(1, Math.floor(hoursSinceLastBill))
+    const hourlyRateCents = escrow.dailyRateCents / 24
+    const consumptionCents = Math.round(hourlyRateCents * hoursToBill)
     const newConsumed = escrow.consumedCents + consumptionCents
     const remaining = escrow.depositCents - newConsumed
 

--- a/src/services/queue/akashSteps.ts
+++ b/src/services/queue/akashSteps.ts
@@ -818,14 +818,15 @@ export async function handleCreateLease(
 
     await new Promise(r => setTimeout(r, 6000))
 
-    // Top up on-chain escrow based on actual bid price so the deployment
-    // has at least 1 hour of runway. The initial deposit (1 ACT) may not
-    // be enough for expensive GPU leases.
+    // Top up on-chain escrow so the deployment has at least 1 full hour
+    // of runway PLUS the initial 1 ACT deposit as a safety buffer.
+    // Without this, expensive GPU leases would drain the initial deposit
+    // in minutes and the health monitor might not refill in time.
     if (payload.priceAmount) {
       const pricePerBlock = parseInt(payload.priceAmount, 10) || 0
       const BLOCKS_PER_HOUR = 600
       const hourlyUact = pricePerBlock * BLOCKS_PER_HOUR
-      const needed = hourlyUact - DEFAULT_DEPOSIT_UACT
+      const needed = hourlyUact
       if (needed > 0) {
         try {
           const orchestrator = getAkashOrchestrator(prisma)


### PR DESCRIPTION
Akash BME upgrade (March 2026) changed lease denominations from uakt
(market-priced AKT) to uact (USD-pegged ACT, 1 ACT = $1). All pricing
was incorrectly multiplying uact amounts by AKT/USD, showing ~50%
lower costs than Akash Console.

- Refactor akashPricePerBlockToUsdPerDay() to accept denom param;
  skip AKT/USD conversion for uact (USD-pegged)
- Add Akash Console API as primary AKT price source, CoinGecko fallback
- Fix escrow health monitor wallet balance check from uakt to uact
- Migrate deposit commands from `akash tx deployment deposit` to
  `akash tx escrow deposit deployment <amount> --dseq <dseq>`
  (CLI v2.0.0-rc18 breaking change)
- Fix post-lease top-up to deposit full hour on top of initial buffer
- Update AKT_USD_PRICE fallback to 0.50 across all env files
- Update tests to match new function signatures