### PR TITLE
repair escrow health monitor and consolidate getAkashEnv

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ import { ProviderRegistryScheduler } from './services/providers/providerRegistry
 import { ProviderVerificationScheduler } from './services/providers/providerVerificationScheduler.js'
 import { handleProviderRegistryRequest } from './services/providers/providerRegistryEndpoint.js'
 import { handleAdminDeploymentStats } from './services/admin/deploymentStatsEndpoint.js'
+import { handleAdminBillingStats } from './services/admin/billingStatsEndpoint.js'
 import { handlePhalaInstanceTypesRequest } from './services/providers/phalaInstanceTypesEndpoint.js'
 import { reconcileActivePolicyExpirySchedules } from './services/policy/runtimeScheduler.js'
 import { ShellEndpoint } from './services/shell/shellEndpoint.js'
@@ -225,6 +226,11 @@ async function requestHandler(req: IncomingMessage, res: ServerResponse) {
 
     if (url.pathname === '/internal/admin/deployment-stats' && req.method === 'GET') {
       await handleAdminDeploymentStats(req, res, prisma)
+      return
+    }
+
+    if (url.pathname === '/internal/admin/billing-stats' && req.method === 'GET') {
+      await handleAdminBillingStats(req, res, prisma)
       return
     }
 

--- a/src/lib/akashEnv.ts
+++ b/src/lib/akashEnv.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared Akash CLI environment variables.
+ *
+ * SINGLE SOURCE OF TRUTH — every module that shells out to `akash` or
+ * `provider-services` MUST use this function.  Duplicating the env map
+ * is how the EscrowHealthMonitor shipped without AKASH_FROM and silently
+ * failed every refill for weeks.
+ */
+
+export interface AkashEnvOptions {
+  /** Override broadcast mode (default: 'sync'). providerVerification uses 'block'. */
+  broadcastMode?: 'sync' | 'block'
+  /** Skip the AKASH_MNEMONIC check (for read-only query commands). */
+  skipMnemonicCheck?: boolean
+}
+
+export function getAkashEnv(opts: AkashEnvOptions = {}): Record<string, string> {
+  if (!opts.skipMnemonicCheck && !process.env.AKASH_MNEMONIC) {
+    throw new Error('AKASH_MNEMONIC is not set')
+  }
+
+  const keyName = process.env.AKASH_KEY_NAME || 'default'
+
+  return {
+    ...(process.env as Record<string, string>),
+    AKASH_KEY_NAME: keyName,
+    AKASH_FROM: keyName,
+    AKASH_KEYRING_BACKEND: 'test',
+    AKASH_NODE: process.env.RPC_ENDPOINT || 'https://rpc.akashnet.net:443',
+    AKASH_CHAIN_ID: process.env.AKASH_CHAIN_ID || 'akashnet-2',
+    AKASH_GAS: 'auto',
+    AKASH_GAS_ADJUSTMENT: '1.5',
+    AKASH_GAS_PRICES: '0.025uakt',
+    AKASH_BROADCAST_MODE: opts.broadcastMode || 'sync',
+    AKASH_YES: 'true',
+    HOME: process.env.HOME || '/home/nodejs',
+  }
+}

--- a/src/services/admin/billingStatsEndpoint.ts
+++ b/src/services/admin/billingStatsEndpoint.ts
@@ -1,0 +1,94 @@
+/**
+ * Internal endpoint: GET /internal/admin/billing-stats
+ *
+ * Returns aggregate billing stats per provider (Akash, Phala):
+ * total charged, raw cost, profit, active count, and current burn rate.
+ * Secured by INTERNAL_AUTH_TOKEN (same pattern as deployment-stats).
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { PrismaClient } from '@prisma/client'
+import { createLogger } from '../../lib/logger.js'
+
+const log = createLogger('admin-billing-stats')
+
+interface AkashRow {
+  total_charged_cents: bigint
+  total_cost_cents: bigint
+  active_count: bigint
+  active_daily_burn_cents: bigint
+}
+
+interface PhalaRow {
+  total_charged_cents: bigint
+  total_cost_cents: bigint
+  active_count: bigint
+  active_hourly_burn_cents: bigint
+}
+
+export async function handleAdminBillingStats(
+  req: IncomingMessage,
+  res: ServerResponse,
+  prisma: PrismaClient,
+): Promise<void> {
+  const expectedToken = process.env.INTERNAL_AUTH_TOKEN
+  const authToken = req.headers['x-internal-auth']
+
+  if (!expectedToken || authToken !== expectedToken) {
+    res.writeHead(401, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ error: 'Unauthorized' }))
+    return
+  }
+
+  try {
+    const akashRows = await prisma.$queryRaw<AkashRow[]>`
+      SELECT
+        COALESCE(SUM(e."consumed_cents"), 0)::bigint AS total_charged_cents,
+        COALESCE(SUM(ROUND(e."consumed_cents" / (1.0 + e."margin_rate")))::bigint, 0) AS total_cost_cents,
+        COUNT(DISTINCT CASE WHEN e."status" = 'ACTIVE' THEN e.id END)::bigint AS active_count,
+        COALESCE(SUM(CASE WHEN e."status" = 'ACTIVE' THEN e."daily_rate_cents" ELSE 0 END), 0)::bigint AS active_daily_burn_cents
+      FROM "deployment_escrow" e
+    `
+
+    const phalaRows = await prisma.$queryRaw<PhalaRow[]>`
+      SELECT
+        COALESCE(SUM(pd."total_billed_cents"), 0)::bigint AS total_charged_cents,
+        COALESCE(SUM(CASE WHEN pd."margin_rate" IS NOT NULL AND pd."margin_rate" > 0
+          THEN ROUND(pd."total_billed_cents" / (1.0 + pd."margin_rate"))
+          ELSE pd."total_billed_cents" END)::bigint, 0) AS total_cost_cents,
+        COUNT(DISTINCT CASE WHEN pd."status" = 'ACTIVE' THEN pd.id END)::bigint AS active_count,
+        COALESCE(SUM(CASE WHEN pd."status" = 'ACTIVE' THEN pd."hourly_rate_cents" ELSE 0 END), 0)::bigint AS active_hourly_burn_cents
+      FROM "PhalaDeployment" pd
+    `
+
+    const akash = akashRows[0]
+    const phala = phalaRows[0]
+
+    const akashCharged = Number(akash.total_charged_cents)
+    const akashCost = Number(akash.total_cost_cents)
+    const phalaCharged = Number(phala.total_charged_cents)
+    const phalaCost = Number(phala.total_cost_cents)
+
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({
+      akash: {
+        totalChargedCents: akashCharged,
+        totalCostCents: akashCost,
+        profitCents: akashCharged - akashCost,
+        activeCount: Number(akash.active_count),
+        activeDailyBurnCents: Number(akash.active_daily_burn_cents),
+      },
+      phala: {
+        totalChargedCents: phalaCharged,
+        totalCostCents: phalaCost,
+        profitCents: phalaCharged - phalaCost,
+        activeCount: Number(phala.active_count),
+        activeHourlyBurnCents: Number(phala.active_hourly_burn_cents),
+      },
+    }))
+  } catch (err) {
+    log.error({ err }, 'Failed to fetch billing stats')
+    res.writeHead(500, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ error: 'Internal server error' }))
+  }
+}

--- a/src/services/akash/orchestrator.ts
+++ b/src/services/akash/orchestrator.ts
@@ -18,6 +18,7 @@ import type { PrismaClient, ServiceType } from '@prisma/client'
 import type { ShellSession } from '../providers/types.js'
 import { providerSelector } from './providerSelector.js'
 import { getEscrowService } from '../billing/escrowService.js'
+import { getAkashEnv } from '../../lib/akashEnv.js'
 import { getBillingApiClient } from '../billing/billingApiClient.js'
 import { createLogger } from '../../lib/logger.js'
 import type { TemplateGpu } from '../../templates/index.js'
@@ -32,27 +33,6 @@ const SERVICE_POLL_MAX_ATTEMPTS = 24
 
 /** Default Akash deposit in uact (1 ACT — buffer for bid/lease process). */
 export const DEFAULT_DEPOSIT_UACT = 1_000_000
-
-function getAkashEnv(): Record<string, string> {
-  if (!process.env.AKASH_MNEMONIC) {
-    throw new Error('AKASH_MNEMONIC is not set')
-  }
-  const keyName = process.env.AKASH_KEY_NAME || 'default'
-  return {
-    ...(process.env as Record<string, string>),
-    AKASH_KEY_NAME: keyName,
-    AKASH_FROM: keyName,
-    AKASH_KEYRING_BACKEND: 'test',
-    AKASH_NODE: process.env.RPC_ENDPOINT || 'https://rpc.akashnet.net:443',
-    AKASH_CHAIN_ID: process.env.AKASH_CHAIN_ID || 'akashnet-2',
-    AKASH_GAS: 'auto',
-    AKASH_GAS_ADJUSTMENT: '1.5',
-    AKASH_GAS_PRICES: '0.025uakt',
-    AKASH_BROADCAST_MODE: 'sync',
-    AKASH_YES: 'true',
-    HOME: process.env.HOME || '/home/nodejs',
-  }
-}
 
 // Fixed by audit 2026-03: use execFileSync to prevent shell injection (was execSync with string concat)
 function runAkash(args: string[], timeout = AKASH_CLI_TIMEOUT_MS): string {

--- a/src/services/billing/escrowHealthMonitor.ts
+++ b/src/services/billing/escrowHealthMonitor.ts
@@ -15,6 +15,7 @@ import * as cron from 'node-cron'
 import type { PrismaClient } from '@prisma/client'
 import { BILLING_CONFIG } from '../../config/billing.js'
 import { createLogger } from '../../lib/logger.js'
+import { getAkashEnv } from '../../lib/akashEnv.js'
 import { execAsync } from '../queue/asyncExec.js'
 
 const log = createLogger('escrow-health')
@@ -26,23 +27,8 @@ const REFILL_HOURS = 1
 /** Warn when deployer wallet ACT balance falls below this (5 ACT). */
 const LOW_WALLET_THRESHOLD_UACT = 5_000_000
 
-function getAkashEnv(): Record<string, string> {
-  return {
-    AKASH_HOME: process.env.AKASH_HOME || `${process.env.HOME}/.akash`,
-    AKASH_NODE: process.env.AKASH_NODE || 'https://rpc.akashnet.net:443',
-    AKASH_CHAIN_ID: process.env.AKASH_CHAIN_ID || 'akashnet-2',
-    AKASH_KEY_NAME: process.env.AKASH_KEY_NAME || 'default',
-    AKASH_KEYRING_BACKEND: process.env.AKASH_KEYRING_BACKEND || 'test',
-    AKASH_GAS_ADJUSTMENT: '1.5',
-    AKASH_GAS_PRICES: '0.025uakt',
-    AKASH_GAS: 'auto',
-    AKASH_BROADCAST_MODE: 'sync',
-    AKASH_YES: '1',
-  }
-}
-
 async function runAkashCmd(args: string[]): Promise<string> {
-  const env = { ...(process.env as Record<string, string>), ...getAkashEnv() }
+  const env = getAkashEnv()
   return execAsync('akash', args, { env, timeout: AKASH_CLI_TIMEOUT_MS, maxBuffer: 10 * 1024 * 1024 })
 }
 
@@ -134,9 +120,16 @@ export class EscrowHealthMonitor {
 
   private async checkWalletBalance(): Promise<void> {
     try {
+      const keyName = process.env.AKASH_KEY_NAME || 'default'
+      const addrOutput = await runAkashCmd(['keys', 'show', keyName, '-a'])
+      const address = addrOutput.trim()
+      if (!address) {
+        log.warn('Could not resolve deployer wallet address')
+        return
+      }
+
       const output = await runAkashCmd([
-        'query', 'bank', 'balances',
-        '--from', process.env.AKASH_KEY_NAME || 'default',
+        'query', 'bank', 'balances', address,
         '-o', 'json',
       ])
       const data = JSON.parse(output)
@@ -172,8 +165,18 @@ export class EscrowHealthMonitor {
       const escrowAccount = data?.escrow_account
       if (!escrowAccount) return null
 
-      const balanceStr = escrowAccount.balance?.amount || '0'
-      const escrowBalanceUact = parseInt(balanceStr, 10) || 0
+      // Akash CLI v2 returns escrow_account.state.funds[] and
+      // escrow_account.state.state ('open' | 'closed'), NOT .balance.
+      const escrowState = escrowAccount.state || escrowAccount
+      if (escrowState.state === 'closed') return null
+
+      const funds: Array<{ denom: string; amount: string }> = escrowState.funds || []
+      const uactFund = funds.find((f: { denom: string }) => f.denom === 'uact')
+      const balanceStr = uactFund?.amount
+        // v1 fallback: escrow_account.balance.amount
+        || escrowAccount.balance?.amount
+        || '0'
+      const escrowBalanceUact = Math.floor(parseFloat(balanceStr)) || 0
 
       const ppb = parseInt(pricePerBlock || '0', 10) || 1
       const blocksPerHour = 600
@@ -181,6 +184,11 @@ export class EscrowHealthMonitor {
       const estimatedHoursRemaining = uactPerHour > 0
         ? escrowBalanceUact / uactPerHour
         : Infinity
+
+      log.debug(
+        { dseq, escrowBalanceUact, estimatedHoursRemaining: +estimatedHoursRemaining.toFixed(2) },
+        'Escrow status checked'
+      )
 
       return {
         dseq,
@@ -201,7 +209,7 @@ export class EscrowHealthMonitor {
     )
 
     try {
-      await runAkashCmd([
+      const output = await runAkashCmd([
         'tx',
         'escrow',
         'deposit',
@@ -210,10 +218,22 @@ export class EscrowHealthMonitor {
         '--dseq',
         dseq,
         '-y',
+        '-o', 'json',
       ])
 
+      let txhash = ''
+      try {
+        const result = JSON.parse(output)
+        txhash = result.txhash || ''
+        if (result.code && result.code !== 0) {
+          throw new Error(`TX failed on-chain: code=${result.code} log=${result.raw_log || ''}`)
+        }
+      } catch (parseErr) {
+        if ((parseErr as Error).message.startsWith('TX failed')) throw parseErr
+      }
+
       log.info(
-        { dseq, refillUact, refillAct: (refillUact / 1_000_000).toFixed(4) },
+        { dseq, refillUact, refillAct: (refillUact / 1_000_000).toFixed(4), txhash },
         'Refilled on-chain escrow'
       )
     } catch (err) {

--- a/src/services/providers/providerVerification.ts
+++ b/src/services/providers/providerVerification.ts
@@ -17,6 +17,7 @@ import { connect } from 'net'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import type { PrismaClient, ComputeProviderType } from '@prisma/client'
+import { getAkashEnv as getAkashEnvBase } from '../../lib/akashEnv.js'
 import { getAllTemplates } from '../../templates/registry.js'
 import { DEFAULT_DEPOSIT_UACT } from '../akash/orchestrator.js'
 import { generateSDLFromTemplate } from '../../templates/sdl.js'
@@ -93,23 +94,7 @@ interface ExecResult {
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
-function getAkashEnv(): Record<string, string> {
-  const keyName = process.env.AKASH_KEY_NAME || 'default'
-  return {
-    ...(process.env as Record<string, string>),
-    AKASH_KEY_NAME: keyName,
-    AKASH_FROM: keyName,
-    AKASH_KEYRING_BACKEND: 'test',
-    AKASH_NODE: process.env.RPC_ENDPOINT || 'https://rpc.akashnet.net:443',
-    AKASH_CHAIN_ID: process.env.AKASH_CHAIN_ID || 'akashnet-2',
-    AKASH_GAS: 'auto',
-    AKASH_GAS_ADJUSTMENT: '1.5',
-    AKASH_GAS_PRICES: '0.025uakt',
-    AKASH_BROADCAST_MODE: 'block',
-    AKASH_YES: 'true',
-    HOME: process.env.HOME || '/home/nodejs',
-  }
-}
+function getAkashEnv() { return getAkashEnvBase({ broadcastMode: 'block' }) }
 
 function execCli(bin: string, args: string[], timeoutMs = CLI_TIMEOUT_MS): Promise<ExecResult> {
   const env = getAkashEnv()

--- a/src/services/queue/akashSteps.ts
+++ b/src/services/queue/akashSteps.ts
@@ -17,6 +17,7 @@ import { getEscrowService } from '../billing/escrowService.js'
 import { getBillingApiClient } from '../billing/billingApiClient.js'
 import { scheduleOrEnforcePolicyExpiry } from '../policy/runtimeScheduler.js'
 import { execAsync } from './asyncExec.js'
+import { getAkashEnv } from '../../lib/akashEnv.js'
 import {
   AKASH_TOTAL_STEPS,
   AKASH_STEP_NUMBERS,
@@ -85,27 +86,6 @@ const AKASH_TERMINAL_STATES = new Set([
   'PERMANENTLY_FAILED',
   'SUSPENDED',
 ])
-
-function getAkashEnv(): Record<string, string> {
-  if (!process.env.AKASH_MNEMONIC) {
-    throw new Error('AKASH_MNEMONIC is not set')
-  }
-  const keyName = process.env.AKASH_KEY_NAME || 'default'
-  return {
-    ...(process.env as Record<string, string>),
-    AKASH_KEY_NAME: keyName,
-    AKASH_FROM: keyName,
-    AKASH_KEYRING_BACKEND: 'test',
-    AKASH_NODE: process.env.RPC_ENDPOINT || 'https://rpc.akashnet.net:443',
-    AKASH_CHAIN_ID: process.env.AKASH_CHAIN_ID || 'akashnet-2',
-    AKASH_GAS: 'auto',
-    AKASH_GAS_ADJUSTMENT: '1.5',
-    AKASH_GAS_PRICES: '0.025uakt',
-    AKASH_BROADCAST_MODE: 'sync',
-    AKASH_YES: 'true',
-    HOME: process.env.HOME || '/home/nodejs',
-  }
-}
 
 async function runAkashAsync(
   args: string[],


### PR DESCRIPTION
Three bugs prevented on-chain escrow refills from ever working:

- AKASH_FROM missing from health monitor's env, failing every tx
- Wrong JSON path for escrow balance (v2 uses state.funds[], not balance.amount)
- Four drifting copies of getAkashEnv across modules Extract shared getAkashEnv to src/lib/akashEnv.ts with broadcastMode and skipMnemonicCheck options. All four consumers now import from the shared module. Fix escrow JSON parsing with v1 fallback, add closed-state check, and validate refill TX response codes.
