### PR TITLE
couple escrow top-up with hourly billing cycle

### DIFF
--- a/src/config/akash.ts
+++ b/src/config/akash.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared Akash constants.
+ *
+ * Single source of truth for chain-geometry numbers (block time, sequence
+ * settle delay, post-lease buffer) that were previously duplicated across
+ * the billing scheduler, escrow health monitor, and deployment step worker.
+ */
+
+/**
+ * Akash averages ~6s per block. 600 blocks ≈ 1 hour — close enough that
+ * we use it as the hourly unit when converting pricePerBlock (uact/block)
+ * into hourly burn. If Akash changes block time, update this constant.
+ */
+export const BLOCKS_PER_HOUR = 600
+
+/**
+ * How long to hold the wallet mutex AFTER a `akash tx ...` CLI invocation
+ * returns, so the chain has time to commit the TX before the next caller
+ * reads the account sequence number.
+ *
+ * Required because our default broadcast mode is `sync` (returns on
+ * mempool acceptance, not block inclusion). Block time is ~6s; 3s is the
+ * empirically-tuned minimum that works reliably in production.
+ *
+ * This value is the mutex's internal delay — callers should NOT add
+ * their own `setTimeout` after a TX. If a caller uses broadcast mode
+ * `block`, pass `{ settleMs: 0 }` to `withWalletLock` to skip this delay.
+ */
+export const TX_SETTLE_DELAY_MS = 3_000
+
+/**
+ * How many hours of on-chain escrow runway to fund after a lease is
+ * accepted (on top of the initial 1 ACT deposit from deployment create).
+ *
+ * Why 2 (not 1): deployments created mid-hour can miss the billing cron
+ * at :00 (the scheduler skips runs that happened "too soon" after the
+ * previous cycle). With only 1 hour of post-lease runway, a lease created
+ * at e.g. :45 can burn its buffer before the first billing-cron top-up at
+ * the next :00. 2 hours guarantees the billing scheduler gets at least
+ * one successful top-up before the escrow enters the danger zone.
+ */
+export const POST_LEASE_HOURS = 2

--- a/src/lib/opsAlert.test.ts
+++ b/src/lib/opsAlert.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { __resetOpsAlertDedupeForTesting, opsAlert } from './opsAlert.js'
+
+const originalFetch = global.fetch
+const originalWebhook = process.env.OPS_ALERT_WEBHOOK_URL
+
+describe('opsAlert', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    __resetOpsAlertDedupeForTesting()
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 204 })
+    global.fetch = fetchMock as unknown as typeof fetch
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    if (originalWebhook === undefined) {
+      delete process.env.OPS_ALERT_WEBHOOK_URL
+    } else {
+      process.env.OPS_ALERT_WEBHOOK_URL = originalWebhook
+    }
+  })
+
+  it('does not call fetch when OPS_ALERT_WEBHOOK_URL is unset', async () => {
+    delete process.env.OPS_ALERT_WEBHOOK_URL
+    await opsAlert({
+      key: 'test-no-webhook',
+      title: 'test',
+      message: 'test body',
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('posts a discord embed when OPS_ALERT_WEBHOOK_URL is set', async () => {
+    process.env.OPS_ALERT_WEBHOOK_URL = 'https://discord.example.test/hook'
+    await opsAlert({
+      key: 'test-webhook',
+      title: 'Wallet low',
+      message: 'Deployer wallet under threshold',
+      context: { balanceAct: '4.20', thresholdUact: '5000000' },
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('https://discord.example.test/hook')
+    expect(init.method).toBe('POST')
+    const body = JSON.parse(init.body)
+    expect(body.embeds[0].title).toContain('Wallet low')
+    expect(body.embeds[0].description).toContain(
+      'Deployer wallet under threshold'
+    )
+    const fields = body.embeds[0].fields as Array<{
+      name: string
+      value: string
+    }>
+    expect(fields.find(f => f.name === 'balanceAct')?.value).toBe('4.20')
+  })
+
+  it('suppresses repeat alerts for the same key within the window', async () => {
+    process.env.OPS_ALERT_WEBHOOK_URL = 'https://discord.example.test/hook'
+    await opsAlert({
+      key: 'dedupe-test',
+      title: 't',
+      message: 'm',
+    })
+    await opsAlert({
+      key: 'dedupe-test',
+      title: 't',
+      message: 'm',
+    })
+    await opsAlert({
+      key: 'dedupe-test',
+      title: 't',
+      message: 'm',
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not suppress different keys', async () => {
+    process.env.OPS_ALERT_WEBHOOK_URL = 'https://discord.example.test/hook'
+    await opsAlert({ key: 'k1', title: 't', message: 'm' })
+    await opsAlert({ key: 'k2', title: 't', message: 'm' })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not throw when the webhook fetch fails', async () => {
+    process.env.OPS_ALERT_WEBHOOK_URL = 'https://discord.example.test/hook'
+    fetchMock.mockRejectedValueOnce(new Error('network down'))
+    await expect(
+      opsAlert({ key: 'fetch-fail', title: 't', message: 'm' })
+    ).resolves.toBeUndefined()
+  })
+
+  it('does not throw when the webhook returns non-2xx', async () => {
+    process.env.OPS_ALERT_WEBHOOK_URL = 'https://discord.example.test/hook'
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 429 })
+    await expect(
+      opsAlert({ key: 'fetch-429', title: 't', message: 'm' })
+    ).resolves.toBeUndefined()
+  })
+})

--- a/src/lib/opsAlert.ts
+++ b/src/lib/opsAlert.ts
@@ -1,0 +1,135 @@
+/**
+ * Ops alert helper — emits a structured, log-level=error message that downstream
+ * log aggregation (Discord/Sentry/Datadog) can ingest, and optionally POSTs to a
+ * Discord webhook if OPS_ALERT_WEBHOOK_URL is configured.
+ *
+ * Uses per-process in-memory dedupe: the same `key` only fires once per
+ * `suppressMs` window (default 10 minutes) so a cron that hits the same
+ * failure every cycle doesn't spam the channel.
+ *
+ * Every call is fire-and-forget — we never throw from inside the alert path
+ * (the caller is already handling a failure; making it worse is not useful).
+ */
+
+import { createLogger } from './logger.js'
+
+const log = createLogger('ops-alert')
+
+const DISCORD_COLOR_CRITICAL = 0xdc2626 // red-600
+const DISCORD_COLOR_WARNING = 0xf59e0b // amber-500
+
+const DEFAULT_SUPPRESS_MS = 10 * 60 * 1000
+
+type Severity = 'critical' | 'warning'
+
+export interface OpsAlertInput {
+  /** Stable identifier used for dedupe. Same key within suppressMs only fires once. */
+  key: string
+  severity?: Severity
+  title: string
+  message: string
+  context?: Record<string, unknown>
+  /** Override dedupe window (ms). */
+  suppressMs?: number
+}
+
+const lastFiredAt = new Map<string, number>()
+
+export async function opsAlert(input: OpsAlertInput): Promise<void> {
+  const now = Date.now()
+  const suppressMs = input.suppressMs ?? DEFAULT_SUPPRESS_MS
+  const last = lastFiredAt.get(input.key)
+  if (last !== undefined && now - last < suppressMs) {
+    // Still suppressed — emit a debug log so we can see that dedupe is working
+    // without spamming the webhook.
+    log.debug(
+      { alertKey: input.key, suppressedForMs: suppressMs - (now - last) },
+      'ops alert suppressed (dedupe window)'
+    )
+    return
+  }
+  lastFiredAt.set(input.key, now)
+
+  const severity: Severity = input.severity ?? 'critical'
+
+  // Structured log first — this is the primary signal. Includes `alert: true`
+  // so downstream log processors can key off it even without the webhook.
+  log.error(
+    {
+      alert: true,
+      alertKey: input.key,
+      severity,
+      title: input.title,
+      ...input.context,
+    },
+    `OPS ALERT: ${input.title} — ${input.message}`
+  )
+
+  // Optional: post to Discord webhook if configured.
+  const webhookUrl = process.env.OPS_ALERT_WEBHOOK_URL
+  if (!webhookUrl) return
+
+  try {
+    const color =
+      severity === 'critical' ? DISCORD_COLOR_CRITICAL : DISCORD_COLOR_WARNING
+    const emoji = severity === 'critical' ? '🚨' : '⚠️'
+    const fields = input.context
+      ? Object.entries(input.context)
+          .slice(0, 10)
+          .map(([name, value]) => ({
+            name,
+            value:
+              typeof value === 'string'
+                ? value.slice(0, 500)
+                : String(JSON.stringify(value)).slice(0, 500),
+            inline: false,
+          }))
+      : []
+
+    const embed = {
+      title: `${emoji} ${input.title}`,
+      description:
+        input.message.length > 2000
+          ? input.message.slice(0, 1997) + '...'
+          : input.message,
+      color,
+      fields,
+      timestamp: new Date(now).toISOString(),
+      footer: {
+        text: `service-cloud-api · ${process.env.NODE_ENV ?? 'unknown'} · ${input.key}`,
+      },
+    }
+
+    // 5s timeout — we never want the alert path to stall the caller.
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), 5000)
+    try {
+      const res = await fetch(webhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ embeds: [embed] }),
+        signal: controller.signal,
+      })
+      if (!res.ok) {
+        log.warn(
+          { status: res.status, alertKey: input.key },
+          'ops alert webhook returned non-2xx'
+        )
+      }
+    } finally {
+      clearTimeout(timer)
+    }
+  } catch (err) {
+    // Never let the alert path itself fail loudly — the original error is
+    // already surfaced via the structured log above.
+    log.warn(
+      { alertKey: input.key, err: (err as Error).message },
+      'ops alert webhook failed'
+    )
+  }
+}
+
+/** Test helper — clears the dedupe cache. Not for production use. */
+export function __resetOpsAlertDedupeForTesting(): void {
+  lastFiredAt.clear()
+}

--- a/src/services/akash/orchestrator.ts
+++ b/src/services/akash/orchestrator.ts
@@ -21,6 +21,7 @@ import { getEscrowService } from '../billing/escrowService.js'
 import { getAkashEnv } from '../../lib/akashEnv.js'
 import { getBillingApiClient } from '../billing/billingApiClient.js'
 import { createLogger } from '../../lib/logger.js'
+import { withWalletLock, isWalletTx } from './walletMutex.js'
 import type { TemplateGpu } from '../../templates/index.js'
 
 const log = createLogger('akash-orchestrator')
@@ -49,12 +50,19 @@ function runAkash(args: string[], timeout = AKASH_CLI_TIMEOUT_MS): string {
 /**
  * Non-blocking version of runAkash for use in request handlers.
  * Uses execAsync to avoid freezing the Node.js event loop.
+ *
+ * If args[0] === 'tx' the call is serialized on the process-wide wallet
+ * mutex to keep the Cosmos account sequence number monotonic. Read-only
+ * commands (query, keys show, status) run without lock contention.
  */
 async function runAkashAsync(args: string[], timeout = AKASH_CLI_TIMEOUT_MS): Promise<string> {
   const { execAsync } = await import('../queue/asyncExec.js')
   const env = getAkashEnv()
   log.info(`Running (async): akash ${args.join(' ')}`)
-  return execAsync('akash', args, { env, timeout, maxBuffer: 10 * 1024 * 1024 })
+  const invoke = () =>
+    execAsync('akash', args, { env, timeout, maxBuffer: 10 * 1024 * 1024 })
+  if (isWalletTx(args)) return withWalletLock(invoke)
+  return invoke()
 }
 
 /**
@@ -196,7 +204,7 @@ export class AkashOrchestrator {
     deposit: number
   ): Promise<{ dseq: number; owner: string }> {
     log.info('Creating deployment...')
-    const output = runAkash([
+    const output = await runAkashAsync([
       'tx',
       'deployment',
       'create',
@@ -457,7 +465,7 @@ export class AkashOrchestrator {
     oseq: number,
     provider: string
   ): Promise<void> {
-    runAkash([
+    await runAkashAsync([
       'tx',
       'market',
       'lease',

--- a/src/services/akash/orchestrator.ts
+++ b/src/services/akash/orchestrator.ts
@@ -353,19 +353,34 @@ export class AkashOrchestrator {
       '-o', 'json',
     ])
 
+    // A non-zero code here means the chain accepted the tx envelope but the
+    // state transition was rejected (e.g. insufficient wallet funds, unknown
+    // dseq, deployment already closed). We MUST throw so callers treat this as
+    // a failure — a silent return previously caused chain-escrow depletion to
+    // go unnoticed until the provider closed the lease.
+    let result: Record<string, unknown>
     try {
-      const result = extractJson(output) as Record<string, unknown>
-      const code = typeof result.code === 'number' ? result.code
-        : typeof result.code === 'string' ? parseInt(result.code, 10) : 0
-      if (code !== 0) {
-        const rawLog = (result.raw_log || '') as string
-        log.error({ dseq, amountUact, code, rawLog: rawLog.slice(0, 200) }, 'Escrow top-up TX rejected on-chain')
-        return
-      }
-      log.info({ dseq, amountUact, txhash: result.txhash }, 'Deployment escrow topped up')
+      result = extractJson(output) as Record<string, unknown>
     } catch {
+      // Parse failure after a successful CLI invocation usually means the
+      // broadcast went through but stdout had trailing noise. Keep as warn.
       log.warn({ dseq, amountUact }, 'Escrow top-up completed but could not parse TX response')
+      return
     }
+
+    const code =
+      typeof result.code === 'number'
+        ? result.code
+        : typeof result.code === 'string'
+          ? parseInt(result.code, 10)
+          : 0
+    if (code !== 0) {
+      const rawLog = (result.raw_log || result.rawLog || '') as string
+      const msg = `Escrow top-up TX rejected on-chain (code ${code}): ${rawLog.slice(0, 300)}`
+      log.error({ dseq, amountUact, code, rawLog: rawLog.slice(0, 200) }, msg)
+      throw new Error(msg)
+    }
+    log.info({ dseq, amountUact, txhash: result.txhash }, 'Deployment escrow topped up')
   }
 
   /**
@@ -759,10 +774,15 @@ export class AkashOrchestrator {
   }
 
   /**
-   * Close a deployment
+   * Close a deployment.
+   *
+   * Throws if the chain rejects the tx (e.g. deployment already closed,
+   * deployment not found). Callers that tolerate benign "already gone" states
+   * match on the thrown message (which includes the chain's raw_log) using
+   * patterns like /deployment not found|deployment closed|not active|does not exist/.
    */
   async closeDeployment(dseq: number): Promise<void> {
-    await runAkashAsync([
+    const output = await runAkashAsync([
       'tx',
       'deployment',
       'close',
@@ -772,6 +792,31 @@ export class AkashOrchestrator {
       'json',
       '-y',
     ])
+
+    let result: Record<string, unknown>
+    try {
+      result = extractJson(output) as Record<string, unknown>
+    } catch {
+      // CLI exited 0 but output was unparseable — treat as provisional success
+      // rather than block close paths. Downstream liveness reconciliation will
+      // catch any stuck-open deployment.
+      log.warn({ dseq }, 'Close TX completed but response could not be parsed')
+      return
+    }
+
+    const code =
+      typeof result.code === 'number'
+        ? result.code
+        : typeof result.code === 'string'
+          ? parseInt(result.code, 10)
+          : 0
+    if (code !== 0) {
+      const rawLog = (result.raw_log || result.rawLog || '') as string
+      const msg = `Close TX rejected on-chain (code ${code}): ${rawLog.slice(0, 300)}`
+      log.error({ dseq, code, rawLog: rawLog.slice(0, 200) }, msg)
+      throw new Error(msg)
+    }
+    log.info({ dseq, txhash: result.txhash }, 'Deployment close TX accepted')
   }
 
   /**

--- a/src/services/akash/walletMutex.test.ts
+++ b/src/services/akash/walletMutex.test.ts
@@ -17,17 +17,23 @@ describe('walletMutex', () => {
   })
 
   describe('withWalletLock', () => {
+    // Tests pass settleMs: 0 to avoid the production 3s hold-after-TX delay.
+    // The settle-delay behavior is tested separately below.
+
     it('serializes concurrent callers in FIFO order', async () => {
       const order: number[] = []
       const sleep = (ms: number) =>
         new Promise<void>(resolve => setTimeout(resolve, ms))
 
       const makeTask = (id: number, durationMs: number) =>
-        withWalletLock(async () => {
-          order.push(id)
-          await sleep(durationMs)
-          order.push(id + 100) // "finish" marker
-        })
+        withWalletLock(
+          async () => {
+            order.push(id)
+            await sleep(durationMs)
+            order.push(id + 100) // "finish" marker
+          },
+          { settleMs: 0 },
+        )
 
       // Start three concurrent tasks with different durations. Without the
       // mutex their start/finish markers would interleave; with the mutex
@@ -40,15 +46,21 @@ describe('walletMutex', () => {
     it('does not poison the queue when a task rejects', async () => {
       const order: string[] = []
 
-      const failing = withWalletLock(async () => {
-        order.push('A-start')
-        throw new Error('boom')
-      })
+      const failing = withWalletLock(
+        async () => {
+          order.push('A-start')
+          throw new Error('boom')
+        },
+        { settleMs: 0 },
+      )
 
-      const succeeding = withWalletLock(async () => {
-        order.push('B-start')
-        return 'B-result'
-      })
+      const succeeding = withWalletLock(
+        async () => {
+          order.push('B-start')
+          return 'B-result'
+        },
+        { settleMs: 0 },
+      )
 
       await expect(failing).rejects.toThrow('boom')
       await expect(succeeding).resolves.toBe('B-result')
@@ -56,8 +68,76 @@ describe('walletMutex', () => {
     })
 
     it('returns the inner function result', async () => {
-      const result = await withWalletLock(async () => 42)
+      const result = await withWalletLock(async () => 42, { settleMs: 0 })
       expect(result).toBe(42)
+    })
+
+    it('holds the lock for settleMs after fn() resolves', async () => {
+      // The next caller must NOT start running until the previous caller's
+      // settle window elapses. This is what prevents account-sequence
+      // collisions under broadcast-mode=sync.
+      const timings: Array<{ id: string; at: number }> = []
+      const t0 = Date.now()
+      const mark = (id: string) => timings.push({ id, at: Date.now() - t0 })
+
+      const first = withWalletLock(
+        async () => {
+          mark('A-start')
+          // Simulate a fast CLI return (mempool acceptance).
+          mark('A-fn-resolve')
+        },
+        { settleMs: 80 },
+      )
+
+      const second = withWalletLock(
+        async () => {
+          mark('B-start')
+        },
+        { settleMs: 0 },
+      )
+
+      await Promise.all([first, second])
+
+      const aStart = timings.find(t => t.id === 'A-start')!.at
+      const aResolve = timings.find(t => t.id === 'A-fn-resolve')!.at
+      const bStart = timings.find(t => t.id === 'B-start')!.at
+
+      expect(aStart).toBeGreaterThanOrEqual(0)
+      expect(aResolve).toBeGreaterThanOrEqual(aStart)
+      // B must start >= 80ms after A's fn resolved (the settle window).
+      expect(bStart - aResolve).toBeGreaterThanOrEqual(70) // small tolerance
+    })
+
+    it('holds the lock for settleMs even when fn() rejects', async () => {
+      // Sequence collisions care about the CLI call having returned, not
+      // about whether the JS promise resolved or rejected. The chain may
+      // still commit a TX even if our CLI errored out on parse/post-check.
+      const timings: Array<{ id: string; at: number }> = []
+      const t0 = Date.now()
+      const mark = (id: string) => timings.push({ id, at: Date.now() - t0 })
+
+      const first = withWalletLock(
+        async () => {
+          mark('A-start')
+          throw new Error('chain-rejected')
+        },
+        { settleMs: 80 },
+      ).catch(() => {
+        /* swallow */
+      })
+
+      const second = withWalletLock(
+        async () => {
+          mark('B-start')
+        },
+        { settleMs: 0 },
+      )
+
+      await Promise.all([first, second])
+
+      const aStart = timings.find(t => t.id === 'A-start')!.at
+      const bStart = timings.find(t => t.id === 'B-start')!.at
+      expect(bStart - aStart).toBeGreaterThanOrEqual(70)
     })
   })
 })

--- a/src/services/akash/walletMutex.test.ts
+++ b/src/services/akash/walletMutex.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { isWalletTx, withWalletLock } from './walletMutex.js'
+
+describe('walletMutex', () => {
+  describe('isWalletTx', () => {
+    it('returns true for tx commands', () => {
+      expect(isWalletTx(['tx', 'deployment', 'create'])).toBe(true)
+      expect(isWalletTx(['tx', 'escrow', 'deposit', 'deployment'])).toBe(true)
+    })
+
+    it('returns false for read-only commands', () => {
+      expect(isWalletTx(['query', 'deployment', 'get'])).toBe(false)
+      expect(isWalletTx(['keys', 'show', 'default', '-a'])).toBe(false)
+      expect(isWalletTx(['status'])).toBe(false)
+      expect(isWalletTx([])).toBe(false)
+    })
+  })
+
+  describe('withWalletLock', () => {
+    it('serializes concurrent callers in FIFO order', async () => {
+      const order: number[] = []
+      const sleep = (ms: number) =>
+        new Promise<void>(resolve => setTimeout(resolve, ms))
+
+      const makeTask = (id: number, durationMs: number) =>
+        withWalletLock(async () => {
+          order.push(id)
+          await sleep(durationMs)
+          order.push(id + 100) // "finish" marker
+        })
+
+      // Start three concurrent tasks with different durations. Without the
+      // mutex their start/finish markers would interleave; with the mutex
+      // we expect [1, 101, 2, 102, 3, 103].
+      await Promise.all([makeTask(1, 20), makeTask(2, 5), makeTask(3, 10)])
+
+      expect(order).toEqual([1, 101, 2, 102, 3, 103])
+    })
+
+    it('does not poison the queue when a task rejects', async () => {
+      const order: string[] = []
+
+      const failing = withWalletLock(async () => {
+        order.push('A-start')
+        throw new Error('boom')
+      })
+
+      const succeeding = withWalletLock(async () => {
+        order.push('B-start')
+        return 'B-result'
+      })
+
+      await expect(failing).rejects.toThrow('boom')
+      await expect(succeeding).resolves.toBe('B-result')
+      expect(order).toEqual(['A-start', 'B-start'])
+    })
+
+    it('returns the inner function result', async () => {
+      const result = await withWalletLock(async () => 42)
+      expect(result).toBe(42)
+    })
+  })
+})

--- a/src/services/akash/walletMutex.ts
+++ b/src/services/akash/walletMutex.ts
@@ -8,30 +8,78 @@
  * `account sequence mismatch` — and with our previous silent-return behavior
  * on top-ups, that rejection could drain on-chain escrow unnoticed.
  *
- * The in-loop TX_NONCE_DELAY_MS only serialized within ONE caller; this
- * process-wide mutex serializes across ALL callers using the same wallet.
+ * Important: by default we run the CLI with `AKASH_BROADCAST_MODE=sync`,
+ * which returns as soon as the TX is accepted into the mempool — NOT when
+ * it is committed to a block. The account sequence on-chain only advances
+ * after block inclusion (~6s on Akash). If the mutex released the moment
+ * `fn()` resolved, the next caller would query the chain for the latest
+ * sequence, see the pre-TX value, and collide. We therefore hold the lock
+ * for a short "settle" window after `fn()` resolves, giving the chain time
+ * to commit the previous TX before the next one reads the sequence.
  *
- * Only chain TX submissions must go through this lock. Read-only queries
- * (query, keys show, status) and provider-services calls do NOT need it.
+ * Query commands (query, keys show, status) and provider-services calls
+ * do NOT need this — they don't touch the account sequence. Use
+ * `withWalletLock(fn, { settleMs: 0 })` if a caller wants mutex ordering
+ * without the post-settle delay (e.g. a TX already broadcast in `block`
+ * mode, where block inclusion is guaranteed before `fn()` resolves).
  *
  * This is a simple FIFO chain-of-promises; callers are served in the order
  * they call `withWalletLock()`. Timeouts on individual TXs (enforced by
  * execAsync) prevent a single hung call from permanently blocking the queue.
  */
 
+import { TX_SETTLE_DELAY_MS } from '../../config/akash.js'
+
 let chain: Promise<unknown> = Promise.resolve()
 
-export function withWalletLock<T>(fn: () => Promise<T>): Promise<T> {
+export interface WalletLockOptions {
+  /**
+   * Milliseconds to hold the lock AFTER fn() resolves, so the chain can
+   * commit the TX before the next caller reads the account sequence.
+   * Defaults to TX_SETTLE_DELAY_MS. Pass 0 for non-TX work or for TXs
+   * broadcast in `block` mode (already block-waited by the CLI).
+   */
+  settleMs?: number
+}
+
+export function withWalletLock<T>(
+  fn: () => Promise<T>,
+  opts: WalletLockOptions = {},
+): Promise<T> {
+  const settleMs = opts.settleMs ?? TX_SETTLE_DELAY_MS
   const prev = chain
   let release!: () => void
   const next = new Promise<void>(resolve => {
     release = resolve
   })
   chain = next
+
+  let result: T
+  let caught: unknown
+  let rejected = false
+
   return prev
     .catch(() => undefined) // never let a prior failure poison the queue
     .then(() => fn())
+    .then(
+      v => {
+        result = v
+      },
+      e => {
+        caught = e
+        rejected = true
+      },
+    )
+    .then(() => (settleMs > 0 ? sleep(settleMs) : undefined))
     .finally(() => release())
+    .then(() => {
+      if (rejected) throw caught
+      return result
+    })
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
 }
 
 /**

--- a/src/services/akash/walletMutex.ts
+++ b/src/services/akash/walletMutex.ts
@@ -1,0 +1,43 @@
+/**
+ * Wallet-scoped async mutex for Akash chain transactions.
+ *
+ * Why: every `akash tx ...` submission from AKASH_FROM consumes a Cosmos
+ * account sequence number. When the billing cron, escrow health monitor,
+ * pause handler, user-initiated close resolver, and deployment step workers
+ * all submit TXs concurrently, the chain can reject them with
+ * `account sequence mismatch` — and with our previous silent-return behavior
+ * on top-ups, that rejection could drain on-chain escrow unnoticed.
+ *
+ * The in-loop TX_NONCE_DELAY_MS only serialized within ONE caller; this
+ * process-wide mutex serializes across ALL callers using the same wallet.
+ *
+ * Only chain TX submissions must go through this lock. Read-only queries
+ * (query, keys show, status) and provider-services calls do NOT need it.
+ *
+ * This is a simple FIFO chain-of-promises; callers are served in the order
+ * they call `withWalletLock()`. Timeouts on individual TXs (enforced by
+ * execAsync) prevent a single hung call from permanently blocking the queue.
+ */
+
+let chain: Promise<unknown> = Promise.resolve()
+
+export function withWalletLock<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = chain
+  let release!: () => void
+  const next = new Promise<void>(resolve => {
+    release = resolve
+  })
+  chain = next
+  return prev
+    .catch(() => undefined) // never let a prior failure poison the queue
+    .then(() => fn())
+    .finally(() => release())
+}
+
+/**
+ * Returns true if the first CLI arg is `tx` — i.e. this call mutates chain
+ * state and needs to be serialized on the wallet's sequence number.
+ */
+export function isWalletTx(args: readonly string[]): boolean {
+  return args[0] === 'tx'
+}

--- a/src/services/billing/computeBillingScheduler.test.ts
+++ b/src/services/billing/computeBillingScheduler.test.ts
@@ -1,0 +1,279 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const computeDebitMock = vi.fn()
+const getOrgBalanceMock = vi.fn()
+const getOrgMarkupMock = vi.fn()
+const getOrgBillingMock = vi.fn()
+
+vi.mock('./billingApiClient.js', () => ({
+  getBillingApiClient: vi.fn(() => ({
+    computeDebit: computeDebitMock,
+    getOrgBalance: getOrgBalanceMock,
+    getOrgMarkup: getOrgMarkupMock,
+    getOrgBilling: getOrgBillingMock,
+  })),
+}))
+
+const topUpDeploymentDepositMock = vi.fn().mockResolvedValue(undefined)
+
+vi.mock('../akash/orchestrator.js', () => ({
+  getAkashOrchestrator: vi.fn(() => ({
+    topUpDeploymentDeposit: topUpDeploymentDepositMock,
+    closeDeployment: vi.fn().mockResolvedValue(undefined),
+  })),
+}))
+
+vi.mock('./escrowService.js', () => ({
+  getEscrowService: vi.fn(() => ({
+    processDailyConsumption: vi.fn(),
+    pauseEscrow: vi.fn(),
+    refundEscrow: vi.fn(),
+  })),
+}))
+
+vi.mock('./deploymentSettlement.js', () => ({
+  processFinalPhalaBilling: vi.fn().mockResolvedValue(undefined),
+  settleAkashEscrowToTime: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../policy/enforcer.js', () => ({
+  checkPolicyLimits: vi.fn().mockResolvedValue({ budgetStopped: 0, runtimeExpired: 0 }),
+}))
+
+vi.mock('../../config/billing.js', () => ({
+  BILLING_CONFIG: {
+    akash: {
+      escrowDays: 0,
+      billingIntervalHours: 1,
+      minBillingIntervalHours: 1,
+      minBalanceCentsToLaunch: 100,
+    },
+    phala: {
+      billingIntervalHours: 1,
+      minBalanceCentsToLaunch: 100,
+    },
+    scheduler: { cronExpression: '0 * * * *' },
+    thresholds: {
+      lowBalanceHours: 1,
+      checkIntervalCron: '*/10 * * * *',
+    },
+  },
+}))
+
+import { ComputeBillingScheduler } from './computeBillingScheduler.js'
+
+interface FakeEscrow {
+  id: string
+  orgBillingId: string
+  akashDeploymentId: string
+  depositCents: number
+  consumedCents: number
+  dailyRateCents: number
+  lastBilledAt: Date
+  status: string
+  akashDeployment: {
+    id: string
+    dseq: bigint
+    pricePerBlock: string | null
+    service: { slug: string } | null
+    status: string
+  }
+}
+
+function buildEscrow(overrides: Partial<FakeEscrow> = {}): FakeEscrow {
+  const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000)
+  return {
+    id: 'escrow-1',
+    orgBillingId: 'org-1',
+    akashDeploymentId: 'akash-1',
+    depositCents: 0,
+    consumedCents: 0,
+    dailyRateCents: 2400, // $24/day → $1/hr
+    lastBilledAt: twoHoursAgo,
+    status: 'ACTIVE',
+    akashDeployment: {
+      id: 'akash-1',
+      dseq: 123n,
+      pricePerBlock: '0',
+      service: { slug: 'test-svc' },
+      status: 'ACTIVE',
+    },
+    ...overrides,
+  }
+}
+
+function buildPrisma(initialEscrows: FakeEscrow[]) {
+  const escrows = [...initialEscrows]
+  const updates: Array<{ where: any; data: any }> = []
+
+  const prisma = {
+    deploymentEscrow: {
+      findMany: vi.fn().mockImplementation(() => Promise.resolve(escrows)),
+      update: vi.fn().mockImplementation(({ where, data }) => {
+        updates.push({ where, data })
+        const target = escrows.find(e => e.id === where.id)
+        if (target) {
+          if (data.consumedCents !== undefined) target.consumedCents = data.consumedCents
+          if (data.lastBilledAt !== undefined) target.lastBilledAt = data.lastBilledAt
+          if (data.status !== undefined) target.status = data.status
+        }
+        return Promise.resolve(target)
+      }),
+      updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+    },
+    phalaDeployment: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    organization: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    deploymentPolicy: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    akashDeployment: {
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+  } as any
+
+  return { prisma, updates, escrows }
+}
+
+describe('ComputeBillingScheduler.processAkashEscrows — idempotency drift', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getOrgBalanceMock.mockResolvedValue({ balanceCents: 100_000 })
+    getOrgMarkupMock.mockResolvedValue({ marginRate: 0 })
+  })
+
+  it('advances lastBilledAt and consumedCents even when auth returns alreadyProcessed=true', async () => {
+    // Regression test for M1: previously, if billingApi.computeDebit returned
+    // { alreadyProcessed: true } (which happens when auth's ledger already has
+    // the idempotency key), the scheduler skipped updating lastBilledAt and
+    // consumedCents. Next cycle computed a larger hoursToBill under a fresh
+    // idempotency key and double-charged the user.
+    const { prisma, escrows } = buildPrisma([buildEscrow()])
+
+    computeDebitMock.mockResolvedValue({
+      success: true,
+      balanceCents: 99_900,
+      alreadyProcessed: true, // auth says: already charged under this key
+    })
+
+    const scheduler = new ComputeBillingScheduler(prisma)
+    await scheduler.runNow({ noPause: true })
+
+    // Debit was attempted (with an idempotency key)
+    expect(computeDebitMock).toHaveBeenCalledTimes(1)
+    const debitCall = computeDebitMock.mock.calls[0][0]
+    expect(debitCall.idempotencyKey).toMatch(/^akash_hourly:escrow-1:/)
+
+    // Critical assertion: even on idempotency hit, the local DB was advanced
+    expect(prisma.deploymentEscrow.update).toHaveBeenCalledTimes(1)
+    const updateArg = prisma.deploymentEscrow.update.mock.calls[0][0]
+    expect(updateArg.where.id).toBe('escrow-1')
+    expect(updateArg.data.consumedCents).toBe(escrows[0].consumedCents) // already mutated in place
+    expect(updateArg.data.lastBilledAt).toBeInstanceOf(Date)
+    expect(updateArg.data.lastBilledAt.getTime()).toBeGreaterThan(
+      Date.now() - 60_000
+    )
+
+    // On idempotency hit, we must NOT re-attempt the on-chain top-up
+    // (we cannot tell whether the prior attempt already did it; the :30
+    // health monitor is the safety net)
+    expect(topUpDeploymentDepositMock).not.toHaveBeenCalled()
+  })
+
+  it('advances lastBilledAt and consumedCents on normal (non-idempotent) debit', async () => {
+    const { prisma, escrows } = buildPrisma([
+      buildEscrow({
+        akashDeployment: {
+          id: 'akash-1',
+          dseq: 123n,
+          pricePerBlock: '100', // non-zero so top-up path runs
+          service: { slug: 'test-svc' },
+          status: 'ACTIVE',
+        },
+      }),
+    ])
+
+    computeDebitMock.mockResolvedValue({
+      success: true,
+      balanceCents: 99_900,
+      alreadyProcessed: false,
+    })
+
+    const scheduler = new ComputeBillingScheduler(prisma)
+    await scheduler.runNow({ noPause: true })
+
+    expect(prisma.deploymentEscrow.update).toHaveBeenCalledTimes(1)
+    const updateArg = prisma.deploymentEscrow.update.mock.calls[0][0]
+    expect(updateArg.data.lastBilledAt).toBeInstanceOf(Date)
+    expect(escrows[0].consumedCents).toBeGreaterThan(0)
+
+    // Normal path DOES do the on-chain top-up
+    expect(topUpDeploymentDepositMock).toHaveBeenCalledTimes(1)
+    expect(topUpDeploymentDepositMock).toHaveBeenCalledWith(123, 60_000) // ppb=100 * 600 blocks
+  })
+
+  it('does not double-bill after a simulated prior-run crash (sequential runs)', async () => {
+    // Simulate: hour H had a prior crash (auth billed, DB not updated).
+    // This run is hour H+1. Auth will alreadyProcess key for H-old? No —
+    // key is per UTC hour. But the auth side will accept a *new* key for H+1.
+    // The danger is that if we hadn't advanced lastBilledAt after the H
+    // idempotency hit, at H+1 we'd compute hoursToBill=2 and OVERCHARGE.
+    // With the fix, H mirrored → at H+1 hoursToBill=1. This test confirms
+    // the mirror occurs so the bug cannot arise.
+    const { prisma, escrows } = buildPrisma([buildEscrow()])
+
+    // First run: idempotency hit
+    computeDebitMock.mockResolvedValueOnce({
+      success: true,
+      balanceCents: 99_900,
+      alreadyProcessed: true,
+    })
+
+    const scheduler = new ComputeBillingScheduler(prisma)
+    await scheduler.runNow({ noPause: true })
+
+    const lastBilledAfterFirst = escrows[0].lastBilledAt
+    expect(Date.now() - lastBilledAfterFirst.getTime()).toBeLessThan(60_000)
+
+    // Advance clock ~1 hour, second run
+    const originalNow = Date.now
+    try {
+      const future = originalNow() + 60 * 60 * 1000
+      Date.now = () => future
+      const originalDate = Date
+      // @ts-expect-error override
+      globalThis.Date = class extends originalDate {
+        constructor(...args: any[]) {
+          if (args.length === 0) super(future)
+          else super(...(args as []))
+        }
+        static now() {
+          return future
+        }
+      }
+
+      computeDebitMock.mockResolvedValueOnce({
+        success: true,
+        balanceCents: 99_800,
+        alreadyProcessed: false,
+      })
+
+      await scheduler.runNow({ noPause: true })
+
+      // Second debit amount should be for 1 hour only (not 2), because we
+      // advanced lastBilledAt on the first run.
+      const secondCall = computeDebitMock.mock.calls[1][0]
+      // dailyRateCents=2400 → $1/hr → 100 cents
+      expect(secondCall.amountCents).toBe(100)
+      expect(secondCall.description).toMatch(/1h/)
+
+      // @ts-expect-error restore
+      globalThis.Date = originalDate
+    } finally {
+      Date.now = originalNow
+    }
+  })
+})

--- a/src/services/billing/computeBillingScheduler.ts
+++ b/src/services/billing/computeBillingScheduler.ts
@@ -21,6 +21,7 @@ import {
 import { createLogger } from '../../lib/logger.js'
 import { checkPolicyLimits } from '../policy/enforcer.js'
 import { getAkashOrchestrator } from '../akash/orchestrator.js'
+import { opsAlert } from '../../lib/opsAlert.js'
 
 const log = createLogger('compute-billing')
 
@@ -134,6 +135,7 @@ export class ComputeBillingScheduler {
     const stats = {
       akashProcessed: 0,
       akashErrors: 0,
+      akashIdempotencyHits: 0,
       phalaProcessed: 0,
       phalaErrors: 0,
       orgsPaused: 0,
@@ -167,6 +169,7 @@ export class ComputeBillingScheduler {
         {
           akashProcessed: stats.akashProcessed,
           akashErrors: stats.akashErrors,
+          akashIdempotencyHits: stats.akashIdempotencyHits,
           phalaProcessed: stats.phalaProcessed,
           phalaErrors: stats.phalaErrors,
           orgsPaused: stats.orgsPaused,
@@ -191,6 +194,7 @@ export class ComputeBillingScheduler {
   private async processAkashEscrows(stats: {
     akashProcessed: number
     akashErrors: number
+    akashIdempotencyHits: number
     totalDebitedCents: number
   }) {
     const escrowService = getEscrowService(this.prisma)
@@ -281,15 +285,30 @@ export class ComputeBillingScheduler {
             },
           })
 
-          if (!result.alreadyProcessed) {
-            await this.prisma.deploymentEscrow.update({
-              where: { id: escrow.id },
-              data: {
-                consumedCents: escrow.consumedCents + amountCents,
-                lastBilledAt: now,
-              },
-            })
+          // Always mirror the auth-side charge into our DB — even on
+          // idempotency hits. An `alreadyProcessed=true` response means auth
+          // has already debited this key on a prior attempt; if we don't
+          // advance lastBilledAt/consumedCents locally, the next cron cycle
+          // will compute a larger hoursToBill with a FRESH idempotency key
+          // and double-charge the user. This is the core of the M1 bug.
+          await this.prisma.deploymentEscrow.update({
+            where: { id: escrow.id },
+            data: {
+              consumedCents: escrow.consumedCents + amountCents,
+              lastBilledAt: now,
+            },
+          })
 
+          if (result.alreadyProcessed) {
+            stats.akashIdempotencyHits = (stats.akashIdempotencyHits || 0) + 1
+            log.info(
+              { escrowId: escrow.id, amountCents, idempotencyKey },
+              'Akash billing already processed (idempotency hit) — mirrored to local DB'
+            )
+            // Skip on-chain top-up on idempotency hits: we cannot tell whether
+            // the prior attempt's top-up succeeded without extra chain queries,
+            // and the :30 health monitor covers any shortfall safely.
+          } else {
             stats.akashProcessed++
             stats.totalDebitedCents += amountCents
             log.info(
@@ -312,22 +331,36 @@ export class ComputeBillingScheduler {
                   'Post-billing escrow top-up succeeded'
                 )
               } catch (topUpErr) {
+                const errMsg =
+                  topUpErr instanceof Error ? topUpErr.message : String(topUpErr)
                 log.warn(
                   {
                     dseq: String(escrow.akashDeployment.dseq),
                     hourlyUact,
-                    err: topUpErr instanceof Error ? topUpErr.message : topUpErr,
+                    err: errMsg,
                   },
                   'Post-billing escrow top-up failed — health monitor will catch up'
                 )
+                await opsAlert({
+                  key: `billing-topup-failed:${escrow.akashDeploymentId}`,
+                  severity: 'warning',
+                  title: 'Billing-cycle top-up failed',
+                  message:
+                    `Hourly top-up for dseq=${escrow.akashDeployment.dseq} failed after a successful user charge. ` +
+                    `The :30 escrow health monitor should recover, but repeated failures will drain on-chain escrow ` +
+                    `and the provider will close the lease. Investigate wallet balance, RPC health, or dseq state.`,
+                  context: {
+                    deploymentId: escrow.akashDeploymentId,
+                    dseq: String(escrow.akashDeployment.dseq),
+                    hourlyUact: String(hourlyUact),
+                    error: errMsg.slice(0, 400),
+                  },
+                  // Once per cycle is enough — no need to spam between runs.
+                  suppressMs: 55 * 60 * 1000,
+                })
               }
               await new Promise(r => setTimeout(r, TX_NONCE_DELAY_MS))
             }
-          } else {
-            log.info(
-              { escrowId: escrow.id },
-              'Akash billing already processed (idempotency hit)'
-            )
           }
         } else {
           // Pre-funded mode: consume from escrow pool
@@ -357,6 +390,22 @@ export class ComputeBillingScheduler {
           )
         } else {
           log.error({ escrowId: escrow.id, err: error }, 'Akash escrow error')
+          await opsAlert({
+            key: `billing-cycle-escrow-error:${escrow.id}`,
+            severity: 'warning',
+            title: 'Akash billing cycle error',
+            message:
+              `Failed to bill escrow ${escrow.id} (deployment ${escrow.akashDeploymentId}) during the hourly cycle. ` +
+              `If this persists across cycles the user will stop being charged for a live deployment.`,
+            context: {
+              escrowId: escrow.id,
+              deploymentId: escrow.akashDeploymentId,
+              dseq: String(escrow.akashDeployment.dseq ?? ''),
+              orgBillingId: escrow.orgBillingId,
+              error: errMsg.slice(0, 400),
+            },
+            suppressMs: 55 * 60 * 1000,
+          })
         }
       }
     }

--- a/src/services/billing/computeBillingScheduler.ts
+++ b/src/services/billing/computeBillingScheduler.ts
@@ -26,9 +26,13 @@ const log = createLogger('compute-billing')
 
 const BLOCKS_PER_HOUR = 600
 
+/** Delay between sequential chain TXs to avoid Cosmos SDK account-sequence-mismatch errors. */
+const TX_NONCE_DELAY_MS = 3_000
+
 export class ComputeBillingScheduler {
   private cronJob: cron.ScheduledTask | null = null
   private thresholdCronJob: cron.ScheduledTask | null = null
+  private running = false
   private forceMode = false
   private noPauseMode = false
   private readonly prisma: PrismaClient
@@ -118,6 +122,12 @@ export class ComputeBillingScheduler {
   // ========================================
 
   private async runBillingCycle() {
+    if (this.running) {
+      log.warn('Skipping billing cycle — previous cycle still running')
+      return
+    }
+    this.running = true
+
     const startTime = Date.now()
     log.info('Starting hourly billing cycle')
 
@@ -169,6 +179,8 @@ export class ComputeBillingScheduler {
       )
     } catch (error) {
       log.error(error, 'Fatal error in billing cycle')
+    } finally {
+      this.running = false
     }
   }
 
@@ -309,7 +321,7 @@ export class ComputeBillingScheduler {
                   'Post-billing escrow top-up failed — health monitor will catch up'
                 )
               }
-              await new Promise(r => setTimeout(r, 8000))
+              await new Promise(r => setTimeout(r, TX_NONCE_DELAY_MS))
             }
           } else {
             log.info(

--- a/src/services/billing/computeBillingScheduler.ts
+++ b/src/services/billing/computeBillingScheduler.ts
@@ -22,13 +22,9 @@ import { createLogger } from '../../lib/logger.js'
 import { checkPolicyLimits } from '../policy/enforcer.js'
 import { getAkashOrchestrator } from '../akash/orchestrator.js'
 import { opsAlert } from '../../lib/opsAlert.js'
+import { BLOCKS_PER_HOUR } from '../../config/akash.js'
 
 const log = createLogger('compute-billing')
-
-const BLOCKS_PER_HOUR = 600
-
-/** Delay between sequential chain TXs to avoid Cosmos SDK account-sequence-mismatch errors. */
-const TX_NONCE_DELAY_MS = 3_000
 
 export class ComputeBillingScheduler {
   private cronJob: cron.ScheduledTask | null = null
@@ -359,7 +355,11 @@ export class ComputeBillingScheduler {
                   suppressMs: 55 * 60 * 1000,
                 })
               }
-              await new Promise(r => setTimeout(r, TX_NONCE_DELAY_MS))
+              // Sequence-settle delay is now held INSIDE withWalletLock
+              // (see config/akash.ts TX_SETTLE_DELAY_MS). Do NOT add a
+              // setTimeout here — it would be outside the mutex and would
+              // not actually prevent the next caller from colliding on
+              // the account sequence.
             }
           }
         } else {
@@ -702,7 +702,8 @@ export class ComputeBillingScheduler {
           await orchestrator.closeDeployment(Number(deployment.dseq))
           onChainClosed = true
           log.info({ dseq: deployment.dseq }, 'On-chain close TX submitted')
-          await new Promise(r => setTimeout(r, 8000))
+          // Sequence-settle delay is held inside withWalletLock
+          // (see services/akash/walletMutex.ts). No manual sleep needed.
         } catch (err) {
           const errMsg = err instanceof Error ? err.message : String(err)
           const alreadyGone = /deployment not found|deployment closed|not active|does not exist|order not found|lease not found|unknown deployment|invalid deployment/i.test(errMsg)

--- a/src/services/billing/computeBillingScheduler.ts
+++ b/src/services/billing/computeBillingScheduler.ts
@@ -1,8 +1,9 @@
 /**
  * Compute Billing Scheduler
  *
- * Daily cron job that processes:
+ * Hourly cron that processes:
  *   1. Akash deployments — direct wallet debit (pay-as-you-go) or escrow consumption (pre-funded)
+ *      After each successful charge, tops up on-chain escrow for the next hour.
  *   2. Phala per-hour debits
  *   3. Balance threshold checks → pause if < 1 day burn
  *   4. Policy spend tracking and enforcement
@@ -19,8 +20,11 @@ import {
 } from './deploymentSettlement.js'
 import { createLogger } from '../../lib/logger.js'
 import { checkPolicyLimits } from '../policy/enforcer.js'
+import { getAkashOrchestrator } from '../akash/orchestrator.js'
 
 const log = createLogger('compute-billing')
+
+const BLOCKS_PER_HOUR = 600
 
 export class ComputeBillingScheduler {
   private cronJob: cron.ScheduledTask | null = null
@@ -188,6 +192,7 @@ export class ComputeBillingScheduler {
             id: true,
             status: true,
             dseq: true,
+            pricePerBlock: true,
             service: {
               select: {
                 slug: true,
@@ -279,6 +284,33 @@ export class ComputeBillingScheduler {
               { escrowId: escrow.id, debitedCents: amountCents },
               'Akash pay-as-you-go billing complete'
             )
+
+            // Top up on-chain escrow for the next hour so the lease stays alive.
+            // Failures are non-fatal — the :30 health monitor will catch up.
+            const ppb = parseInt(escrow.akashDeployment.pricePerBlock || '0', 10)
+            if (ppb > 0 && escrow.akashDeployment.dseq) {
+              const hourlyUact = ppb * BLOCKS_PER_HOUR
+              try {
+                const orchestrator = getAkashOrchestrator(this.prisma)
+                await orchestrator.topUpDeploymentDeposit(
+                  Number(escrow.akashDeployment.dseq), hourlyUact
+                )
+                log.info(
+                  { dseq: String(escrow.akashDeployment.dseq), hourlyUact },
+                  'Post-billing escrow top-up succeeded'
+                )
+              } catch (topUpErr) {
+                log.warn(
+                  {
+                    dseq: String(escrow.akashDeployment.dseq),
+                    hourlyUact,
+                    err: topUpErr instanceof Error ? topUpErr.message : topUpErr,
+                  },
+                  'Post-billing escrow top-up failed — health monitor will catch up'
+                )
+              }
+              await new Promise(r => setTimeout(r, 8000))
+            }
           } else {
             log.info(
               { escrowId: escrow.id },

--- a/src/services/billing/escrowHealthMonitor.test.ts
+++ b/src/services/billing/escrowHealthMonitor.test.ts
@@ -1,0 +1,430 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Hoisted so the mock factories can reference them (vi.mock is hoisted to
+// the top of the file, above non-hoisted `const` declarations).
+const {
+  execAsyncMock,
+  closeDeploymentMock,
+  refundEscrowMock,
+  settleAkashEscrowToTimeMock,
+  opsAlertMock,
+} = vi.hoisted(() => ({
+  execAsyncMock: vi.fn(),
+  closeDeploymentMock: vi.fn().mockResolvedValue(undefined),
+  refundEscrowMock: vi.fn().mockResolvedValue(undefined),
+  settleAkashEscrowToTimeMock: vi.fn().mockResolvedValue(undefined),
+  opsAlertMock: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../queue/asyncExec.js', () => ({
+  execAsync: execAsyncMock,
+}))
+
+vi.mock('../../lib/akashEnv.js', () => ({
+  getAkashEnv: vi.fn(() => ({
+    AKASH_FROM: 'test-key',
+    AKASH_KEY_NAME: 'test-key',
+    AKASH_NODE: 'https://rpc.test',
+    AKASH_CHAIN_ID: 'akashnet-2',
+  })),
+}))
+
+vi.mock('../akash/orchestrator.js', () => ({
+  getAkashOrchestrator: vi.fn(() => ({
+    closeDeployment: closeDeploymentMock,
+  })),
+}))
+
+vi.mock('./escrowService.js', () => ({
+  getEscrowService: vi.fn(() => ({
+    refundEscrow: refundEscrowMock,
+  })),
+}))
+
+vi.mock('./deploymentSettlement.js', () => ({
+  settleAkashEscrowToTime: settleAkashEscrowToTimeMock,
+}))
+
+vi.mock('../../lib/opsAlert.js', () => ({
+  opsAlert: opsAlertMock,
+}))
+
+vi.mock('../../config/akash.js', () => ({
+  BLOCKS_PER_HOUR: 600,
+  TX_SETTLE_DELAY_MS: 0,
+  POST_LEASE_HOURS: 2,
+}))
+
+import { EscrowHealthMonitor } from './escrowHealthMonitor.js'
+
+interface FakeAkashDeployment {
+  id: string
+  dseq: bigint
+  pricePerBlock: string | null
+  owner: string
+}
+
+function buildPrisma(deployments: FakeAkashDeployment[]) {
+  return {
+    akashDeployment: {
+      findMany: vi.fn().mockResolvedValue(deployments),
+      findUnique: vi.fn().mockImplementation(({ where }) => {
+        const d = deployments.find(x => x.id === where.id)
+        return Promise.resolve(d ? { status: 'ACTIVE' } : null)
+      }),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+    },
+  } as any
+}
+
+/**
+ * Mock `execAsync` by inspecting its args. Each arg-pattern returns a
+ * fixed JSON string, the way the real `akash` CLI would.
+ */
+function installAkashCli(overrides: {
+  blockHeight?: number
+  walletAddress?: string
+  walletUactBalance?: number
+  listDeployments?: Array<{
+    dseq: string
+    fundsUact: number
+    transferredUact: number
+    settledAt: number
+    closed?: boolean
+  }>
+  depositShouldFail?: string
+}) {
+  execAsyncMock.mockReset()
+  execAsyncMock.mockImplementation((_cmd: string, args: string[]) => {
+    // status → latest_block_height
+    if (args[0] === 'status') {
+      return Promise.resolve(
+        JSON.stringify({
+          sync_info: { latest_block_height: String(overrides.blockHeight ?? 1_000_000) },
+        }),
+      )
+    }
+
+    // keys show <name> -a → wallet address
+    if (args[0] === 'keys' && args[1] === 'show') {
+      return Promise.resolve(`${overrides.walletAddress ?? 'akash1mock'}\n`)
+    }
+
+    // query bank balances → wallet ACT balance
+    if (args[0] === 'query' && args[1] === 'bank' && args[2] === 'balances') {
+      return Promise.resolve(
+        JSON.stringify({
+          balances: [
+            { denom: 'uact', amount: String(overrides.walletUactBalance ?? 100_000_000) },
+          ],
+        }),
+      )
+    }
+
+    // query deployment list → escrow account listing
+    if (args[0] === 'query' && args[1] === 'deployment' && args[2] === 'list') {
+      return Promise.resolve(
+        JSON.stringify({
+          deployments: (overrides.listDeployments ?? []).map(d => ({
+            deployment: { deployment_id: { dseq: d.dseq } },
+            escrow_account: {
+              state: {
+                state: d.closed ? 'closed' : 'open',
+                funds: [{ denom: 'uact', amount: String(d.fundsUact) }],
+                transferred: [{ denom: 'uact', amount: String(d.transferredUact) }],
+                settled_at: String(d.settledAt),
+              },
+            },
+          })),
+        }),
+      )
+    }
+
+    // tx escrow deposit → refill
+    if (args[0] === 'tx' && args[1] === 'escrow' && args[2] === 'deposit') {
+      if (overrides.depositShouldFail) {
+        return Promise.reject(new Error(overrides.depositShouldFail))
+      }
+      return Promise.resolve(JSON.stringify({ code: 0, txhash: 'abc123' }))
+    }
+
+    return Promise.resolve('{}')
+  })
+}
+
+describe('EscrowHealthMonitor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    closeDeploymentMock.mockResolvedValue(undefined)
+    refundEscrowMock.mockResolvedValue(undefined)
+    settleAkashEscrowToTimeMock.mockResolvedValue(undefined)
+    opsAlertMock.mockResolvedValue(undefined)
+  })
+
+  it('refills when estimated runway < MIN_ESCROW_HOURS (1h)', async () => {
+    // ppb = 1000 uact/block → hourly burn = 600_000 uact
+    // funds = 1_000_000, transferred = 0, blocks elapsed = 700 → unsettled = 700_000
+    // real balance = 300_000 → 0.5h remaining → should refill.
+    const prisma = buildPrisma([
+      { id: 'a1', dseq: 100n, pricePerBlock: '1000', owner: 'akash1owner' },
+    ])
+    installAkashCli({
+      blockHeight: 1_000_700,
+      listDeployments: [
+        { dseq: '100', fundsUact: 1_000_000, transferredUact: 0, settledAt: 1_000_000 },
+      ],
+    })
+
+    const monitor = new EscrowHealthMonitor(prisma)
+    await monitor.checkAndRefill()
+
+    // Find the tx escrow deposit call
+    const depositCall = execAsyncMock.mock.calls.find(
+      c => c[1][0] === 'tx' && c[1][1] === 'escrow' && c[1][2] === 'deposit',
+    )
+    expect(depositCall).toBeDefined()
+    // Refill amount: ppb * BLOCKS_PER_HOUR * REFILL_HOURS = 1000 * 600 * 1 = 600_000
+    expect(depositCall![1]).toContain('600000uact')
+    expect(depositCall![1]).toContain('--dseq')
+    expect(depositCall![1]).toContain('100')
+  })
+
+  it('does NOT refill when estimated runway >= 1h', async () => {
+    // funds = 10_000_000, transferred = 0, blocks elapsed = 100 → unsettled = 100_000
+    // real balance = 9_900_000 → ~16.5h → plenty of runway.
+    const prisma = buildPrisma([
+      { id: 'a1', dseq: 100n, pricePerBlock: '1000', owner: 'akash1owner' },
+    ])
+    installAkashCli({
+      blockHeight: 1_000_100,
+      listDeployments: [
+        { dseq: '100', fundsUact: 10_000_000, transferredUact: 0, settledAt: 1_000_000 },
+      ],
+    })
+
+    const monitor = new EscrowHealthMonitor(prisma)
+    await monitor.checkAndRefill()
+
+    const depositCall = execAsyncMock.mock.calls.find(
+      c => c[1][0] === 'tx' && c[1][1] === 'escrow' && c[1][2] === 'deposit',
+    )
+    expect(depositCall).toBeUndefined()
+  })
+
+  it('computes real balance accounting for unsettled consumption (lazy settlement)', async () => {
+    // This test proves we subtract (currentBlock - settledAt) * ppb from
+    // (funds - transferred). Without that subtraction, a deployment with
+    // settled funds=10m and transferred=0 would look like ~16h of runway,
+    // but in reality 9_999 blocks have passed at ppb=1000 → 9.99m unsettled →
+    // real balance = 10_000 → < 1h → refill required.
+    const prisma = buildPrisma([
+      { id: 'a1', dseq: 100n, pricePerBlock: '1000', owner: 'akash1owner' },
+    ])
+    installAkashCli({
+      blockHeight: 1_009_999,
+      listDeployments: [
+        { dseq: '100', fundsUact: 10_000_000, transferredUact: 0, settledAt: 1_000_000 },
+      ],
+    })
+
+    const monitor = new EscrowHealthMonitor(prisma)
+    await monitor.checkAndRefill()
+
+    const depositCall = execAsyncMock.mock.calls.find(
+      c => c[1][0] === 'tx' && c[1][1] === 'escrow' && c[1][2] === 'deposit',
+    )
+    expect(depositCall).toBeDefined()
+  })
+
+  it('closes and settles deployments missing from chain', async () => {
+    // DB says ACTIVE but chain has no record → auto-close and settle.
+    const prisma = buildPrisma([
+      { id: 'a1', dseq: 999n, pricePerBlock: '1000', owner: 'akash1owner' },
+    ])
+    installAkashCli({
+      blockHeight: 1_000_000,
+      listDeployments: [], // chain returns no deployments
+    })
+
+    const monitor = new EscrowHealthMonitor(prisma)
+    await monitor.checkAndRefill()
+
+    expect(closeDeploymentMock).toHaveBeenCalledWith(999)
+    expect(settleAkashEscrowToTimeMock).toHaveBeenCalledWith(
+      prisma,
+      'a1',
+      expect.any(Date),
+    )
+    expect(refundEscrowMock).toHaveBeenCalledWith('a1')
+    expect(prisma.akashDeployment.updateMany).toHaveBeenCalledWith({
+      where: { id: 'a1', status: 'ACTIVE' },
+      data: { status: 'CLOSED', closedAt: expect.any(Date) },
+    })
+  })
+
+  it('closes and settles deployments explicitly closed on chain', async () => {
+    const prisma = buildPrisma([
+      { id: 'a1', dseq: 100n, pricePerBlock: '1000', owner: 'akash1owner' },
+    ])
+    installAkashCli({
+      blockHeight: 1_000_000,
+      listDeployments: [
+        {
+          dseq: '100',
+          fundsUact: 5_000_000,
+          transferredUact: 0,
+          settledAt: 1_000_000,
+          closed: true,
+        },
+      ],
+    })
+
+    const monitor = new EscrowHealthMonitor(prisma)
+    await monitor.checkAndRefill()
+
+    expect(closeDeploymentMock).toHaveBeenCalledWith(100)
+    expect(refundEscrowMock).toHaveBeenCalledWith('a1')
+  })
+
+  it('prevents concurrent runs with the reentrancy guard', async () => {
+    const prisma = buildPrisma([
+      { id: 'a1', dseq: 100n, pricePerBlock: '1000', owner: 'akash1owner' },
+    ])
+
+    // Make fetchAllEscrowBalances hang, forcing the first call to stay running.
+    let resolveFirstList: (v: string) => void = () => {}
+    const firstListPromise = new Promise<string>(resolve => {
+      resolveFirstList = resolve
+    })
+
+    let listCallCount = 0
+    execAsyncMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === 'query' && args[1] === 'deployment' && args[2] === 'list') {
+        listCallCount++
+        if (listCallCount === 1) return firstListPromise
+        return Promise.resolve(JSON.stringify({ deployments: [] }))
+      }
+      if (args[0] === 'status') {
+        return Promise.resolve(
+          JSON.stringify({ sync_info: { latest_block_height: '1000000' } }),
+        )
+      }
+      if (args[0] === 'keys') return Promise.resolve('akash1mock\n')
+      if (args[0] === 'query' && args[1] === 'bank') {
+        return Promise.resolve(
+          JSON.stringify({ balances: [{ denom: 'uact', amount: '100000000' }] }),
+        )
+      }
+      return Promise.resolve('{}')
+    })
+
+    const monitor = new EscrowHealthMonitor(prisma)
+    const run1 = monitor.checkAndRefill()
+
+    // Second call while the first is in flight → should bail out immediately.
+    // findMany should only be called once.
+    await monitor.checkAndRefill()
+    expect(prisma.akashDeployment.findMany).toHaveBeenCalledTimes(1)
+
+    // Now release the first run.
+    resolveFirstList(JSON.stringify({ deployments: [] }))
+    await run1
+  })
+
+  it('alerts when deployer wallet balance is below threshold', async () => {
+    const prisma = buildPrisma([
+      { id: 'a1', dseq: 100n, pricePerBlock: '1000', owner: 'akash1owner' },
+    ])
+    installAkashCli({
+      blockHeight: 1_000_000,
+      walletUactBalance: 1_000_000, // 1 ACT, below 5 ACT threshold
+      listDeployments: [
+        { dseq: '100', fundsUact: 10_000_000, transferredUact: 0, settledAt: 1_000_000 },
+      ],
+    })
+
+    const monitor = new EscrowHealthMonitor(prisma)
+    await monitor.checkAndRefill()
+
+    const lowWalletAlert = opsAlertMock.mock.calls.find(
+      c => c[0]?.key === 'deployer-wallet-low-balance',
+    )
+    expect(lowWalletAlert).toBeDefined()
+    expect(lowWalletAlert![0].severity).toBe('critical')
+  })
+
+  it('does NOT alert when deployer wallet balance is healthy', async () => {
+    const prisma = buildPrisma([
+      { id: 'a1', dseq: 100n, pricePerBlock: '1000', owner: 'akash1owner' },
+    ])
+    installAkashCli({
+      blockHeight: 1_000_000,
+      walletUactBalance: 50_000_000, // 50 ACT
+      listDeployments: [
+        { dseq: '100', fundsUact: 10_000_000, transferredUact: 0, settledAt: 1_000_000 },
+      ],
+    })
+
+    const monitor = new EscrowHealthMonitor(prisma)
+    await monitor.checkAndRefill()
+
+    const lowWalletAlert = opsAlertMock.mock.calls.find(
+      c => c[0]?.key === 'deployer-wallet-low-balance',
+    )
+    expect(lowWalletAlert).toBeUndefined()
+  })
+
+  it('alerts when a refill TX fails', async () => {
+    const prisma = buildPrisma([
+      { id: 'a1', dseq: 100n, pricePerBlock: '1000', owner: 'akash1owner' },
+    ])
+    installAkashCli({
+      blockHeight: 1_000_700,
+      listDeployments: [
+        { dseq: '100', fundsUact: 1_000_000, transferredUact: 0, settledAt: 1_000_000 },
+      ],
+      depositShouldFail: 'insufficient funds',
+    })
+
+    const monitor = new EscrowHealthMonitor(prisma)
+    await monitor.checkAndRefill()
+
+    const refillAlert = opsAlertMock.mock.calls.find(c =>
+      (c[0]?.key ?? '').startsWith('escrow-refill-failed:'),
+    )
+    expect(refillAlert).toBeDefined()
+    expect(refillAlert![0].severity).toBe('critical')
+    expect(refillAlert![0].context?.dseq).toBe('100')
+  })
+
+  it('handles batch query failure gracefully (no crash, no refills)', async () => {
+    const prisma = buildPrisma([
+      { id: 'a1', dseq: 100n, pricePerBlock: '1000', owner: 'akash1owner' },
+    ])
+    execAsyncMock.mockReset()
+    execAsyncMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === 'status') {
+        return Promise.resolve(
+          JSON.stringify({ sync_info: { latest_block_height: '1000000' } }),
+        )
+      }
+      if (args[0] === 'keys') return Promise.resolve('akash1mock\n')
+      if (args[0] === 'query' && args[1] === 'bank') {
+        return Promise.resolve(
+          JSON.stringify({ balances: [{ denom: 'uact', amount: '100000000' }] }),
+        )
+      }
+      if (args[0] === 'query' && args[1] === 'deployment' && args[2] === 'list') {
+        return Promise.reject(new Error('RPC unavailable'))
+      }
+      return Promise.resolve('{}')
+    })
+
+    const monitor = new EscrowHealthMonitor(prisma)
+
+    // Must not throw; the empty chain map means all deployments look
+    // "missing" → auto-close fires. That's a separate branch we cover
+    // elsewhere; here we just care that the method completes cleanly.
+    await expect(monitor.checkAndRefill()).resolves.not.toThrow()
+  })
+})

--- a/src/services/billing/escrowHealthMonitor.ts
+++ b/src/services/billing/escrowHealthMonitor.ts
@@ -24,6 +24,7 @@ import { getEscrowService } from './escrowService.js'
 import { getAkashOrchestrator } from '../akash/orchestrator.js'
 import { withWalletLock, isWalletTx } from '../akash/walletMutex.js'
 import { opsAlert } from '../../lib/opsAlert.js'
+import { BLOCKS_PER_HOUR } from '../../config/akash.js'
 
 const log = createLogger('escrow-health')
 
@@ -39,8 +40,6 @@ const ESCROW_CHECK_CRON = '30 * * * *'
 
 /** Warn when deployer wallet ACT balance falls below this (5 ACT). */
 const LOW_WALLET_THRESHOLD_UACT = 5_000_000
-
-const BLOCKS_PER_HOUR = 600
 
 async function runAkashCmd(args: string[], timeout = AKASH_CLI_TIMEOUT_MS): Promise<string> {
   const env = getAkashEnv()
@@ -179,9 +178,11 @@ export class EscrowHealthMonitor {
 
           if (estimatedHoursRemaining < MIN_ESCROW_HOURS) {
             log.warn(logFields, 'Low on-chain escrow — attempting safety-net refill')
-            await this.refillEscrow(dseq, dep.owner, ppb)
+            await this.refillEscrow(dseq, ppb)
             refillCount++
-            await new Promise(r => setTimeout(r, 8000))
+            // No post-refill sleep here — withWalletLock holds for
+            // TX_SETTLE_DELAY_MS internally so the next refill's sequence
+            // number lookup sees the previous TX committed.
           } else {
             log.info(logFields, 'Escrow OK — no refill needed')
           }
@@ -360,11 +361,10 @@ export class EscrowHealthMonitor {
     }
   }
 
-  private async refillEscrow(dseq: string, _owner: string, pricePerBlockUact: number): Promise<void> {
-    const blocksPerHour = 600
+  private async refillEscrow(dseq: string, pricePerBlockUact: number): Promise<void> {
     const refillUact = Math.max(
       100_000,
-      pricePerBlockUact * blocksPerHour * REFILL_HOURS
+      pricePerBlockUact * BLOCKS_PER_HOUR * REFILL_HOURS
     )
 
     try {

--- a/src/services/billing/escrowHealthMonitor.ts
+++ b/src/services/billing/escrowHealthMonitor.ts
@@ -22,6 +22,8 @@ import { execAsync } from '../queue/asyncExec.js'
 import { settleAkashEscrowToTime } from './deploymentSettlement.js'
 import { getEscrowService } from './escrowService.js'
 import { getAkashOrchestrator } from '../akash/orchestrator.js'
+import { withWalletLock, isWalletTx } from '../akash/walletMutex.js'
+import { opsAlert } from '../../lib/opsAlert.js'
 
 const log = createLogger('escrow-health')
 
@@ -42,7 +44,13 @@ const BLOCKS_PER_HOUR = 600
 
 async function runAkashCmd(args: string[], timeout = AKASH_CLI_TIMEOUT_MS): Promise<string> {
   const env = getAkashEnv()
-  return execAsync('akash', args, { env, timeout, maxBuffer: 10 * 1024 * 1024 })
+  const invoke = () =>
+    execAsync('akash', args, { env, timeout, maxBuffer: 10 * 1024 * 1024 })
+  // Serialize chain TX submissions (escrow refills) on the shared wallet
+  // mutex so they don't race with the billing scheduler, deployment steps,
+  // or any resolver-initiated close.
+  if (isWalletTx(args)) return withWalletLock(invoke)
+  return invoke()
 }
 
 interface ChainEscrowEntry {
@@ -212,10 +220,27 @@ export class EscrowHealthMonitor {
       const uactBal = data?.balances?.find((b: { denom: string }) => b.denom === 'uact')
       const balance = parseInt(uactBal?.amount || '0', 10)
       if (balance < LOW_WALLET_THRESHOLD_UACT) {
+        const balanceAct = (balance / 1_000_000).toFixed(4)
         log.warn(
-          { balanceUact: balance, balanceAct: (balance / 1_000_000).toFixed(4) },
+          { balanceUact: balance, balanceAct },
           'CRITICAL: Deployer wallet ACT balance is low — escrow refills will fail soon'
         )
+        await opsAlert({
+          key: 'deployer-wallet-low-balance',
+          severity: 'critical',
+          title: 'Deployer wallet ACT balance low',
+          message:
+            `Deployer wallet is below the ${(LOW_WALLET_THRESHOLD_UACT / 1_000_000).toFixed(0)} ACT threshold. ` +
+            `On-chain escrow top-ups will start failing; deployments will be closed by providers and the platform will eat the uncovered time.`,
+          context: {
+            address,
+            balanceAct,
+            balanceUact: String(balance),
+            thresholdUact: String(LOW_WALLET_THRESHOLD_UACT),
+          },
+          // Alert hourly (matches the health-monitor cadence), not every 10 min.
+          suppressMs: 55 * 60 * 1000,
+        })
       }
     } catch {
       log.warn('Could not check deployer wallet balance')
@@ -371,7 +396,22 @@ export class EscrowHealthMonitor {
         'Refilled on-chain escrow'
       )
     } catch (err) {
-      log.error({ dseq, error: (err as Error).message }, 'Failed to refill escrow via CLI')
+      const errMsg = (err as Error).message
+      log.error({ dseq, error: errMsg }, 'Failed to refill escrow via CLI')
+      await opsAlert({
+        key: `escrow-refill-failed:${dseq}`,
+        severity: 'critical',
+        title: 'Escrow refill failed',
+        message:
+          `Health-monitor escrow refill for dseq=${dseq} failed. If this keeps failing the provider will close ` +
+          `the lease and the platform will eat any time between the last user billing and chain-death.`,
+        context: {
+          dseq,
+          refillUact: String(refillUact),
+          refillAct: (refillUact / 1_000_000).toFixed(4),
+          error: errMsg.slice(0, 400),
+        },
+      })
       throw err
     }
   }

--- a/src/services/billing/escrowHealthMonitor.ts
+++ b/src/services/billing/escrowHealthMonitor.ts
@@ -1,16 +1,17 @@
 /**
- * Akash On-Chain Escrow Health Monitor
+ * Akash On-Chain Escrow Health Monitor — Safety Net
  *
- * Monitors the on-chain escrow balance for active Akash deployments and
- * auto-refills from the deployer wallet's ACT balance before the escrow
- * depletes (which would cause Akash to close the lease).
+ * Runs at :30 each hour (30 min after the billing cycle at :00). The billing
+ * scheduler is the primary mechanism for on-chain escrow top-ups — it deposits
+ * 1 hour of runway after each successful user charge. This monitor is the
+ * safety net that catches any billing-cycle top-up failures.
  *
- * This operates at the infrastructure level (platform's deployer wallet),
- * separate from the user-facing org wallet billing.
+ * Also detects deployments that died on-chain (escrow depleted or provider
+ * closed the lease) and triggers close + pro-rated billing settlement so users
+ * are never charged for a non-existent lease.
  *
- * Schedule: hourly at :15 (offset from billing cycle). Refills 3 hours
- * of runway when balance drops below 2 hours, so one missed cycle can't
- * kill a lease.
+ * Operates at the infrastructure level (platform's deployer wallet), separate
+ * from user-facing org wallet billing.
  */
 
 import * as cron from 'node-cron'
@@ -18,6 +19,9 @@ import type { PrismaClient } from '@prisma/client'
 import { createLogger } from '../../lib/logger.js'
 import { getAkashEnv } from '../../lib/akashEnv.js'
 import { execAsync } from '../queue/asyncExec.js'
+import { settleAkashEscrowToTime } from './deploymentSettlement.js'
+import { getEscrowService } from './escrowService.js'
+import { getAkashOrchestrator } from '../akash/orchestrator.js'
 
 const log = createLogger('escrow-health')
 
@@ -25,11 +29,11 @@ const AKASH_CLI_TIMEOUT_MS = 30_000
 /** Longer timeout for the batch deployment list query (may return large JSON). */
 const BATCH_QUERY_TIMEOUT_MS = 60_000
 /** Refill when escrow drops below this many hours of runway. */
-const MIN_ESCROW_HOURS = 2
+const MIN_ESCROW_HOURS = 1
 /** Top up this many hours of runway per refill. */
-const REFILL_HOURS = 3
-/** Own cron schedule — hourly at :15 (offset from billing cycle at :00). */
-const ESCROW_CHECK_CRON = '15 * * * *'
+const REFILL_HOURS = 1
+/** Safety-net cron — hourly at :30 (30 min after billing cycle at :00). */
+const ESCROW_CHECK_CRON = '30 * * * *'
 
 /** Warn when deployer wallet ACT balance falls below this (5 ACT). */
 const LOW_WALLET_THRESHOLD_UACT = 5_000_000
@@ -103,6 +107,7 @@ export class EscrowHealthMonitor {
       const chainEscrows = await this.fetchAllEscrowBalances(owner)
 
       let refillCount = 0
+      let closedCount = 0
       let errorCount = 0
 
       for (const dep of activeDeployments) {
@@ -111,11 +116,17 @@ export class EscrowHealthMonitor {
 
         try {
           const chain = chainEscrows.get(dseq)
-          if (!chain) {
-            log.warn({ dseq }, 'Deployment not found in chain query — may be closed on-chain')
+
+          // Deployment missing from chain or explicitly closed — settle billing
+          if (!chain || chain.closed) {
+            log.warn(
+              { dseq, deploymentId: dep.id, reason: chain ? 'closed' : 'missing' },
+              'Deployment gone on-chain — closing and settling billing'
+            )
+            await this.closeAndSettleDeployment(dep.id, dseq)
+            closedCount++
             continue
           }
-          if (chain.closed) continue
 
           const ppb = parseInt(dep.pricePerBlock || '0', 10) || 1
           const uactPerHour = ppb * BLOCKS_PER_HOUR
@@ -126,7 +137,7 @@ export class EscrowHealthMonitor {
           if (estimatedHoursRemaining < MIN_ESCROW_HOURS) {
             log.warn(
               { dseq, hoursRemaining: +estimatedHoursRemaining.toFixed(2), balanceUact: chain.balanceUact },
-              'Low on-chain escrow — attempting refill'
+              'Low on-chain escrow — attempting safety-net refill'
             )
             await this.refillEscrow(dseq, dep.owner, ppb)
             refillCount++
@@ -144,7 +155,7 @@ export class EscrowHealthMonitor {
       }
 
       log.info(
-        { checked: activeDeployments.length, refilled: refillCount, errors: errorCount },
+        { checked: activeDeployments.length, refilled: refillCount, closed: closedCount, errors: errorCount },
         'Escrow health check complete'
       )
     } catch (err) {
@@ -223,11 +234,46 @@ export class EscrowHealthMonitor {
       log.info({ count: map.size }, 'Fetched escrow balances from chain (single query)')
     } catch (err) {
       log.error({ error: (err as Error).message }, 'Failed to batch-fetch escrow balances — falling back to per-deployment')
-      // Fallback removed: if the list query fails, we skip this cycle.
-      // The 2-hour threshold + 3-hour refill gives enough buffer to survive
-      // one missed cycle without any deployment dying.
+      // If the list query fails, we skip this cycle.
+      // The billing-cycle top-up at :00 is the primary mechanism; this is the safety net.
     }
     return map
+  }
+
+  /**
+   * Close a deployment that the chain reports as gone/closed, settle billing
+   * pro-rata, and refund any pre-funded escrow balance.
+   */
+  private async closeAndSettleDeployment(deploymentId: string, dseq: string): Promise<void> {
+    const current = await this.prisma.akashDeployment.findUnique({
+      where: { id: deploymentId },
+      select: { status: true },
+    })
+    if (!current || current.status !== 'ACTIVE') return
+
+    const closedAt = new Date()
+
+    try {
+      const orchestrator = getAkashOrchestrator(this.prisma)
+      await orchestrator.closeDeployment(Number(dseq))
+    } catch (closeErr) {
+      const msg = (closeErr as Error).message ?? ''
+      const alreadyGone = /deployment not found|deployment closed|not active|does not exist/i.test(msg)
+      if (!alreadyGone) {
+        log.error({ deploymentId, dseq, err: msg }, 'On-chain close failed during escrow-monitor auto-close')
+      }
+    }
+
+    const result = await this.prisma.akashDeployment.updateMany({
+      where: { id: deploymentId, status: 'ACTIVE' },
+      data: { status: 'CLOSED', closedAt },
+    })
+
+    if (result.count > 0) {
+      await settleAkashEscrowToTime(this.prisma, deploymentId, closedAt)
+      await getEscrowService(this.prisma).refundEscrow(deploymentId)
+      log.info({ deploymentId, dseq }, 'Chain-dead deployment closed and billing settled')
+    }
   }
 
   private async refillEscrow(dseq: string, _owner: string, pricePerBlockUact: number): Promise<void> {

--- a/src/services/billing/escrowHealthMonitor.ts
+++ b/src/services/billing/escrowHealthMonitor.ts
@@ -47,7 +47,12 @@ async function runAkashCmd(args: string[], timeout = AKASH_CLI_TIMEOUT_MS): Prom
 
 interface ChainEscrowEntry {
   dseq: string
-  balanceUact: number
+  /** Raw `funds[uact].amount` from chain — total ever deposited, only changes on deposit/withdraw tx. */
+  fundsUact: number
+  /** Raw `transferred[uact].amount` — only updates on settlement txs (deposit/withdraw/close). */
+  transferredUact: number
+  /** Block height of last on-chain settlement. Used to compute unsettled consumption. */
+  settledAtBlock: number
   closed: boolean
 }
 
@@ -104,7 +109,15 @@ export class EscrowHealthMonitor {
       // Single RPC call to fetch all deployment escrow accounts for our owner,
       // instead of one query per dseq. O(1) RPC calls regardless of deployment count.
       const owner = activeDeployments[0].owner
-      const chainEscrows = await this.fetchAllEscrowBalances(owner)
+      const [chainEscrows, currentBlockHeight] = await Promise.all([
+        this.fetchAllEscrowBalances(owner),
+        this.fetchCurrentBlockHeight(),
+      ])
+
+      if (currentBlockHeight === 0) {
+        log.error('Could not fetch current block height — aborting escrow check this cycle')
+        return
+      }
 
       let refillCount = 0
       let closedCount = 0
@@ -130,23 +143,39 @@ export class EscrowHealthMonitor {
 
           const ppb = parseInt(dep.pricePerBlock || '0', 10) || 1
           const uactPerHour = ppb * BLOCKS_PER_HOUR
+
+          // Akash chain lazy-settles: `funds` / `transferred` only update on settlement
+          // txs (deposit, withdraw, close). Between settlements the escrow drains
+          // invisibly at `pricePerBlock` per block. Real balance must be computed as:
+          //   real = funds - transferred - (currentBlock - settledAt) * pricePerBlock
+          const blocksSinceSettlement = Math.max(0, currentBlockHeight - chain.settledAtBlock)
+          const unsettledConsumption = blocksSinceSettlement * ppb
+          const settledBalance = chain.fundsUact - chain.transferredUact
+          const realBalanceUact = Math.max(0, settledBalance - unsettledConsumption)
+
           const estimatedHoursRemaining = uactPerHour > 0
-            ? chain.balanceUact / uactPerHour
+            ? realBalanceUact / uactPerHour
             : Infinity
 
+          const logFields = {
+            dseq,
+            hoursRemaining: +estimatedHoursRemaining.toFixed(2),
+            realBalanceUact,
+            fundsUact: chain.fundsUact,
+            transferredUact: chain.transferredUact,
+            settledAtBlock: chain.settledAtBlock,
+            currentBlockHeight,
+            blocksSinceSettlement,
+            pricePerBlock: ppb,
+          }
+
           if (estimatedHoursRemaining < MIN_ESCROW_HOURS) {
-            log.warn(
-              { dseq, hoursRemaining: +estimatedHoursRemaining.toFixed(2), balanceUact: chain.balanceUact },
-              'Low on-chain escrow — attempting safety-net refill'
-            )
+            log.warn(logFields, 'Low on-chain escrow — attempting safety-net refill')
             await this.refillEscrow(dseq, dep.owner, ppb)
             refillCount++
             await new Promise(r => setTimeout(r, 8000))
           } else {
-            log.info(
-              { dseq, hoursRemaining: +estimatedHoursRemaining.toFixed(2), balanceUact: chain.balanceUact },
-              'Escrow OK — no refill needed'
-            )
+            log.info(logFields, 'Escrow OK — no refill needed')
           }
         } catch (err) {
           errorCount++
@@ -194,8 +223,29 @@ export class EscrowHealthMonitor {
   }
 
   /**
+   * Fetch the current chain block height via `akash status`. Needed to compute
+   * real escrow balance because Akash lazy-settles — the on-chain `transferred`
+   * value only updates on settlement txs, not as blocks pass.
+   */
+  private async fetchCurrentBlockHeight(): Promise<number> {
+    try {
+      const output = await runAkashCmd(['status'])
+      const data = JSON.parse(output)
+      const heightStr = data?.sync_info?.latest_block_height
+        || data?.SyncInfo?.latest_block_height
+        || '0'
+      const height = parseInt(String(heightStr), 10) || 0
+      return height
+    } catch (err) {
+      log.error({ error: (err as Error).message }, 'Failed to fetch current block height')
+      return 0
+    }
+  }
+
+  /**
    * Single RPC call: `akash query deployment list --owner <addr> --state active -o json`
-   * Returns a Map of dseq → escrow balance, replacing N per-deployment queries.
+   * Returns a Map of dseq → chain escrow state. Real balance must be derived
+   * by combining these fields with the current block height in the caller.
    */
   private async fetchAllEscrowBalances(owner: string): Promise<Map<string, ChainEscrowEntry>> {
     const map = new Map<string, ChainEscrowEntry>()
@@ -222,13 +272,22 @@ export class EscrowHealthMonitor {
         const closed = escrowState.state === 'closed'
 
         const funds: Array<{ denom: string; amount: string }> = escrowState.funds || []
-        const uactFund = funds.find((f: { denom: string }) => f.denom === 'uact')
-        const balanceStr = uactFund?.amount
-          || escrowAccount.balance?.amount
-          || '0'
-        const balanceUact = Math.floor(parseFloat(balanceStr)) || 0
+        const transferred: Array<{ denom: string; amount: string }> = escrowState.transferred || []
+        const fundsUact = Math.floor(
+          parseFloat(funds.find((f) => f.denom === 'uact')?.amount || '0')
+        ) || 0
+        const transferredUact = Math.floor(
+          parseFloat(transferred.find((f) => f.denom === 'uact')?.amount || '0')
+        ) || 0
+        const settledAtBlock = parseInt(String(escrowState.settled_at || '0'), 10) || 0
 
-        map.set(String(dseq), { dseq: String(dseq), balanceUact, closed })
+        map.set(String(dseq), {
+          dseq: String(dseq),
+          fundsUact,
+          transferredUact,
+          settledAtBlock,
+          closed,
+        })
       }
 
       log.info({ count: map.size }, 'Fetched escrow balances from chain (single query)')

--- a/src/services/billing/suspendOrgHandler.ts
+++ b/src/services/billing/suspendOrgHandler.ts
@@ -101,8 +101,8 @@ export async function handleSuspendOrg(
           await orchestrator.closeDeployment(Number(deployment.dseq))
           onChainClosed = true
           log.info({ dseq: deployment.dseq }, 'On-chain close TX submitted')
-          // Wait for TX to settle before closing the next one — avoids sequence number collisions
-          await new Promise(r => setTimeout(r, 8000))
+          // Sequence-settle delay is held inside withWalletLock
+          // (see services/akash/walletMutex.ts). No manual sleep needed.
         } catch (err) {
           const errMsg = err instanceof Error ? err.message : String(err)
           const alreadyGone = /deployment not found|deployment closed|not active|does not exist|order not found|lease not found|unknown deployment|invalid deployment/i.test(errMsg)

--- a/src/services/providers/providerVerification.ts
+++ b/src/services/providers/providerVerification.ts
@@ -20,6 +20,7 @@ import type { PrismaClient, ComputeProviderType } from '@prisma/client'
 import { getAkashEnv as getAkashEnvBase } from '../../lib/akashEnv.js'
 import { getAllTemplates } from '../../templates/registry.js'
 import { DEFAULT_DEPOSIT_UACT } from '../akash/orchestrator.js'
+import { withWalletLock } from '../akash/walletMutex.js'
 import { generateSDLFromTemplate } from '../../templates/sdl.js'
 import { createLogger } from '../../lib/logger.js'
 
@@ -226,14 +227,18 @@ async function testSingleTemplate(
     if (addrResult.exitCode !== 0) return mkFail(`Cannot get address: ${addrResult.stderr.trim()}`)
     owner = addrResult.stdout.trim()
 
-    // Step 2: Submit deployment tx (with sequence mismatch retry)
+    // Step 2: Submit deployment tx (with sequence mismatch retry).
+    // Serialized on the shared wallet mutex so the verifier doesn't race
+    // the billing scheduler / health monitor / deployment workers.
     const TX_RETRIES = 3
     let txJson: any = {}
     for (let attempt = 1; attempt <= TX_RETRIES; attempt++) {
-      const txResult = await execCli('akash', [
-        'tx', 'deployment', 'create', sdlPath,
-        '--deposit', `${DEFAULT_DEPOSIT_UACT}uact`, '-o', 'json', '-y',
-      ])
+      const txResult = await withWalletLock(() =>
+        execCli('akash', [
+          'tx', 'deployment', 'create', sdlPath,
+          '--deposit', `${DEFAULT_DEPOSIT_UACT}uact`, '-o', 'json', '-y',
+        ])
+      )
       if (txResult.exitCode !== 0) return mkFail(txResult.stderr.trim().slice(0, 300))
       try { txJson = extractJson(txResult.stdout) as any } catch { txJson = {} }
       const code = typeof txJson.code === 'number' ? txJson.code : parseInt(txJson.code ?? '0', 10)
@@ -327,11 +332,13 @@ async function testSingleTemplate(
     // Step 4: Create lease (with sequence mismatch retry)
     let leaseOk = false
     for (let attempt = 1; attempt <= TX_RETRIES; attempt++) {
-      const leaseResult = await execCli('akash', [
-        'tx', 'market', 'lease', 'create',
-        '--dseq', String(dseq), '--gseq', String(selectedBid.gseq), '--oseq', String(selectedBid.oseq),
-        '--provider', provider!, '-o', 'json', '-y',
-      ])
+      const leaseResult = await withWalletLock(() =>
+        execCli('akash', [
+          'tx', 'market', 'lease', 'create',
+          '--dseq', String(dseq), '--gseq', String(selectedBid.gseq), '--oseq', String(selectedBid.oseq),
+          '--provider', provider!, '-o', 'json', '-y',
+        ])
+      )
       if (leaseResult.exitCode !== 0) return mkFail(`Lease creation failed: ${leaseResult.stderr.trim().slice(0, 200)}`)
       let leaseCode = 0
       try { leaseCode = (extractJson(leaseResult.stdout) as any)?.code ?? 0 } catch { /* ok */ }
@@ -416,7 +423,9 @@ async function testSingleTemplate(
   } finally {
     if (dseq) {
       try {
-        await execCli('akash', ['tx', 'deployment', 'close', '--dseq', String(dseq), '-o', 'json', '-y'])
+        await withWalletLock(() =>
+          execCli('akash', ['tx', 'deployment', 'close', '--dseq', String(dseq), '-o', 'json', '-y'])
+        )
         log.info({ dseq, templateId }, 'Test deployment closed')
       } catch { /* best-effort */ }
     }

--- a/src/services/queue/akashSteps.ts
+++ b/src/services/queue/akashSteps.ts
@@ -798,15 +798,22 @@ export async function handleCreateLease(
 
     await new Promise(r => setTimeout(r, 6000))
 
-    // Top up on-chain escrow so the deployment has at least 1 full hour
-    // of runway PLUS the initial 1 ACT deposit as a safety buffer.
-    // Without this, expensive GPU leases would drain the initial deposit
-    // in minutes and the health monitor might not refill in time.
+    // Top up on-chain escrow so the deployment has at least 2 full hours of
+    // runway PLUS the initial 1 ACT safety buffer.
+    //
+    // Why 2 hours (not 1):
+    // Deployments created mid-hour can miss the billing cron at :00 (the
+    // scheduler skips runs that happened "too soon" after the previous cycle).
+    // With only 1 hour of post-lease runway, a lease created at e.g. :45 can
+    // burn its buffer before the first billing-cron top-up at the next :00.
+    // 2 hours guarantees the billing scheduler gets at least one successful
+    // top-up before the escrow enters the danger zone, regardless of when
+    // the deployment was created.
     if (payload.priceAmount) {
       const pricePerBlock = parseInt(payload.priceAmount, 10) || 0
       const BLOCKS_PER_HOUR = 600
-      const hourlyUact = pricePerBlock * BLOCKS_PER_HOUR
-      const needed = hourlyUact
+      const POST_LEASE_HOURS = 2
+      const needed = pricePerBlock * BLOCKS_PER_HOUR * POST_LEASE_HOURS
       if (needed > 0) {
         try {
           const orchestrator = getAkashOrchestrator(prisma)

--- a/src/services/queue/akashSteps.ts
+++ b/src/services/queue/akashSteps.ts
@@ -19,6 +19,7 @@ import { scheduleOrEnforcePolicyExpiry } from '../policy/runtimeScheduler.js'
 import { execAsync } from './asyncExec.js'
 import { getAkashEnv } from '../../lib/akashEnv.js'
 import { withWalletLock, isWalletTx } from '../akash/walletMutex.js'
+import { BLOCKS_PER_HOUR, POST_LEASE_HOURS } from '../../config/akash.js'
 import {
   AKASH_TOTAL_STEPS,
   AKASH_STEP_NUMBERS,
@@ -817,8 +818,6 @@ export async function handleCreateLease(
     // the deployment was created.
     if (payload.priceAmount) {
       const pricePerBlock = parseInt(payload.priceAmount, 10) || 0
-      const BLOCKS_PER_HOUR = 600
-      const POST_LEASE_HOURS = 2
       const needed = pricePerBlock * BLOCKS_PER_HOUR * POST_LEASE_HOURS
       if (needed > 0) {
         try {

--- a/src/services/queue/akashSteps.ts
+++ b/src/services/queue/akashSteps.ts
@@ -18,6 +18,7 @@ import { getBillingApiClient } from '../billing/billingApiClient.js'
 import { scheduleOrEnforcePolicyExpiry } from '../policy/runtimeScheduler.js'
 import { execAsync } from './asyncExec.js'
 import { getAkashEnv } from '../../lib/akashEnv.js'
+import { withWalletLock, isWalletTx } from '../akash/walletMutex.js'
 import {
   AKASH_TOTAL_STEPS,
   AKASH_STEP_NUMBERS,
@@ -93,7 +94,12 @@ async function runAkashAsync(
 ): Promise<string> {
   const env = getAkashEnv()
   log.info(`Running: akash ${args.join(' ')}`)
-  return execAsync('akash', args, { env, timeout })
+  const invoke = () => execAsync('akash', args, { env, timeout })
+  // Serialize tx submissions on the wallet mutex to avoid Cosmos account
+  // sequence collisions with other TX-emitting call sites (orchestrator,
+  // billing scheduler, health monitor, etc.).
+  if (isWalletTx(args)) return withWalletLock(invoke)
+  return invoke()
 }
 
 async function runProviderServicesAsync(


### PR DESCRIPTION
After each successful hourly user charge, the billing scheduler now
deposits 1 hour of on-chain escrow for the next period. The escrow
health monitor is demoted to a safety net at :30 (1hr threshold, 1hr
refill) and now also detects chain-dead deployments, triggering
close + pro-rated settlement to prevent ghost billing.

Two related fixes for on-chain escrow drift.

1. Health monitor was reading escrow `funds` as the live balance, but
   Akash lazy-settles — `funds` / `transferred` only update on deposit,
   withdraw, or close txs. Between settlements the escrow drains
   invisibly at `pricePerBlock` per block. Result: monitor saw every
   escrow as perpetually healthy and never fired a refill, while real
   leases drained to zero and providers closed them on-chain.

   Now computes:
     real = funds - transferred - (currentBlock - settledAt) * ppb

   - fetchAllEscrowBalances returns fundsUact, transferredUact, settledAtBlock
   - new fetchCurrentBlockHeight via `akash status`
   - log fields expanded to surface all raw inputs for future debugging

2. Post-lease deposit bumped from 1h to 2h. Deployments created mid-hour
   can miss the first billing cron at :00 (scheduler skips runs that
   happen "too soon" after the previous cycle), so 1h of runway can
   drain before the first billing-cycle top-up. 2h guarantees the
   billing scheduler gets at least one tick before the escrow enters
   the danger zone.


---------------------

fix(akash): throw on chain-rejected close/top-up tx instead of silent return

orchestrator.closeDeployment and topUpDeploymentDeposit previously
ignored non-zero result.code from the broadcast response, logging an
error and returning as if successful. This allowed two silent failure
paths:

- Top-up rejections (insufficient wallet funds, unknown dseq, etc.)
  would return OK to the billing scheduler; the on-chain escrow would
  deplete and the provider would close the lease, with the platform
  eating the uncovered time — exactly the staging incident pattern.
- Close rejections would leave deployments burning on-chain while the
  DB transitioned to CLOSED/SUSPENDED, hiding the leak from both the
  health monitor (which skips non-ACTIVE rows) and the user.

Now both parse the TX JSON and throw on code !== 0 with raw_log in the
message. All existing callers already wrap these calls in try/catch
and match chain rejection phrases ("deployment not found", "deployment
closed", "does not exist", etc.) via their alreadyGone regexes, so
benign races still short-circuit cleanly while real failures surface.

Parse failures (CLI exited 0 with unparseable stdout) still warn
without throwing — that path previously worked and changing it would
risk false positives on trailing CLI noise.

Refs audit: M2, M3, M13, M17.


fix(billing): mirror auth-side debit on idempotency hit to prevent double-charge

On billingApi.computeDebit returning alreadyProcessed=true, still advance
lastBilledAt and consumedCents locally. Previously we skipped the DB update,
so the next cycle computed a larger hoursToBill under a fresh idempotency
key and double-charged the user. Skip the on-chain top-up on idempotency
hits (prior attempt's top-up state is ambiguous; :30 health monitor covers).
Adds akashIdempotencyHits stat and 3 regression tests. Refs audit M1.

---

fix(akash): serialize wallet TX submissions via process-wide mutex

Introduces src/services/akash/walletMutex.ts — a FIFO async mutex every
'akash tx ...' must acquire. Wired into orchestrator.runAkashAsync,
akashSteps.runAkashAsync, escrowHealthMonitor.runAkashCmd, and
providerVerification tx call sites. Converts orchestrator.createDeployment
and .createLease to async so they flow through the same queue. Queries and
keys commands bypass the lock. Eliminates Cosmos account-sequence-mismatch
races between billing cron, health monitor, resolvers, deploy workers, and
verifier. +5 tests. Refs audit M6.

---

feat(ops): add ops-alert utility and wire into billing failure paths

Adds src/lib/opsAlert.ts — fire-and-forget helper emitting structured
log.error with alert:true plus optional Discord webhook via
OPS_ALERT_WEBHOOK_URL. Per-process dedupe (default 10 min) prevents cron
spam. Wired into: low deployer wallet balance, escrow refill failures,
billing-cycle top-up failures, and generic per-escrow billing errors.
All with 55-min suppress windows. +6 tests. Refs audit M7, M14.


------


Addresses PR review of Phase 34 (wallet mutex). Reviewer correctly spotted
the stray 3s/8s setTimeouts around akash tx calls, but "just remove them
because the mutex handles it" would have regressed Phase 34.
Root cause (confirmed in src/lib/akashEnv.ts):
  AKASH_BROADCAST_MODE defaults to 'sync'. `akash tx` returns on mempool
  accept, NOT block inclusion. The Cosmos SDK account sequence only
  advances after a TX is in a block (~6s on Akash). The Phase 34 mutex
  released the lock the moment the CLI returned, so the next caller's
  sequence-number lookup would see pre-TX state and collide with
  `account sequence mismatch`.
Fix:
- withWalletLock now holds the lock for `settleMs` (default 3000ms, from
  new src/config/akash.ts TX_SETTLE_DELAY_MS) after fn() resolves or
  rejects. Chain TXs now get true serialization across ALL subsystems —
  not just within one loop.
- Removed every out-of-mutex setTimeout that existed to paper over this:
  computeBillingScheduler post-top-up and post-close, escrowHealthMonitor
  post-refill, suspendOrgHandler post-close.
- Callers using broadcastMode: 'block' (providerVerification) can opt out
  with { settleMs: 0 }.
Also in this commit (cleanup flagged by the same review):
- New src/config/akash.ts consolidates BLOCKS_PER_HOUR (was duplicated in
  4 places, one as lowercase shadow), TX_SETTLE_DELAY_MS, POST_LEASE_HOURS.
- refillEscrow: dropped unused _owner param.
Tests:
- walletMutex.test.ts: +2 tests proving the lock holds for settleMs on
  both success and rejection paths.
- escrowHealthMonitor.test.ts: NEW. 10 tests — previously 0 coverage on a
  428-line safety-net module. Covers: refill threshold, runway-healthy
  no-op, lazy-settlement real-balance math, chain-missing/closed auto-
  close, reentrancy guard, low-wallet alert, refill-fail alert, batch-
  query graceful failure.
- Full suite: 614/614 passing.
Not done (from review, with rationale):
- Inline retry-with-backoff on top-up failures: would extend mutex
  hold-time under degraded RPC and worsen cycle duration. Alerting +
  :30 health monitor already cover this.
- Unifying INTER_BIDDER_DELAY_MS with TX_SETTLE_DELAY_MS: different
  concept (bidder test spacing under broadcastMode=block), not a
  sequence delay.
