### PR TITLE
first-hour leak + launch guards for 150-user beta

### DIFF
--- a/deploy/pnpm-lock.yaml
+++ b/deploy/pnpm-lock.yaml
@@ -1,0 +1,1260 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+overrides:
+  axios: '>=1.15.0'
+  elliptic: ^6.6.1
+  secp256k1: ^5.0.1
+  parse-duration: ^2.1.3
+  ws: ^8.18.3
+  nanoid: ^5.0.9
+  fast-xml-parser: '>=5.5.7'
+  hono: '>=4.12.12'
+  preact: '>=10.28.2'
+  h3: '>=1.15.9'
+  qs: '>=6.14.2'
+  minimatch: '>=9.0.7'
+  jsrsasign: '>=11.1.1'
+  undici: '>=6.24.0'
+  node-forge: '>=1.4.0'
+  effect: '>=3.20.0'
+  socket.io-parser: '>=4.2.6'
+  defu: '>=6.1.5'
+  picomatch: '>=4.0.4'
+  lodash: '>=4.18.0'
+  bn.js: '>=5.2.3'
+  ajv: '>=8.18.0'
+  yaml: '>=2.8.3'
+  brace-expansion: '>=5.0.5'
+  '@smithy/config-resolver': '>=4.4.0'
+
+importers:
+
+  .:
+    dependencies:
+      '@graphql-tools/schema':
+        specifier: ^10.0.25
+        version: 10.0.32(graphql@16.13.2)
+      '@prisma/client':
+        specifier: ^5.22.0
+        version: 5.22.0(prisma@5.22.0)
+      bcrypt:
+        specifier: ^5.1.1
+        version: 5.1.1
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.6.1
+      graphql:
+        specifier: ^16.9.0
+        version: 16.13.2
+      graphql-yoga:
+        specifier: ^5.7.0
+        version: 5.21.0(graphql@16.13.2)
+      jsonwebtoken:
+        specifier: ^9.0.2
+        version: 9.0.3
+    devDependencies:
+      '@types/bcrypt':
+        specifier: ^5.0.2
+        version: 5.0.2
+      '@types/jsonwebtoken':
+        specifier: ^9.0.7
+        version: 9.0.10
+      '@types/node':
+        specifier: ^22.8.6
+        version: 22.19.17
+      prisma:
+        specifier: ^5.22.0
+        version: 5.22.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+packages:
+
+  '@envelop/core@5.5.1':
+    resolution: {integrity: sha512-3DQg8sFskDo386TkL5j12jyRAdip/8yzK3x7YGbZBgobZ4aKXrvDU0GppU0SnmrpQnNaiTUsxBs9LKkwQ/eyvw==}
+    engines: {node: '>=18.0.0'}
+
+  '@envelop/instrumentation@1.0.0':
+    resolution: {integrity: sha512-cxgkB66RQB95H3X27jlnxCRNTmPuSTgmBAq6/4n2Dtv4hsk4yz8FadA1ggmd0uZzvKqWD6CR+WFgTjhDqg7eyw==}
+    engines: {node: '>=18.0.0'}
+
+  '@envelop/types@5.2.1':
+    resolution: {integrity: sha512-CsFmA3u3c2QoLDTfEpGr4t25fjMU31nyvse7IzWTvb0ZycuPjMjb0fjlheh+PbhBYb9YLugnT2uY6Mwcg1o+Zg==}
+    engines: {node: '>=18.0.0'}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@fastify/busboy@3.2.0':
+    resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
+
+  '@graphql-tools/executor@1.5.2':
+    resolution: {integrity: sha512-V7QaW/59Dml7DK0MApMP/Z+qx2qkQ0inGJGi/n1JwBHRZehXTKDNKO7OFRA0h6V1w2afmcVso2GFwlDnPyusGA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/merge@9.1.8':
+    resolution: {integrity: sha512-25V7WDrODo1cPrmuUCrqf5qlMA4a/Ow4aHaqJ1MnTUaluwsV3UiqzCHWux3HSLb0H63mkoZiuOrU5xJhxRcoCg==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/schema@10.0.32':
+    resolution: {integrity: sha512-kJ1Qn20MPnlaEVH37639E6rzQ1tEtr6XTUhNdR4EKydl+FijtLhWX2WLZbGnvrYuG8XUcMxsZU9mRRYYNvK02w==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/utils@10.11.0':
+    resolution: {integrity: sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-tools/utils@11.0.1':
+    resolution: {integrity: sha512-pNyCOb95ab/z3zkkiPwIPYxigX7IcpyFVcgD1XACDEvg/7yGnKCESx3k/XHEeneKYx/aWKGzEh/uuf6M6Q8HOw==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-typed-document-node/core@3.2.0':
+    resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+
+  '@graphql-yoga/logger@2.0.1':
+    resolution: {integrity: sha512-Nv0BoDGLMg9QBKy9cIswQ3/6aKaKjlTh87x3GiBg2Z4RrjyrM48DvOOK0pJh1C1At+b0mUIM67cwZcFTDLN4sA==}
+    engines: {node: '>=18.0.0'}
+
+  '@graphql-yoga/subscription@5.0.5':
+    resolution: {integrity: sha512-oCMWOqFs6QV96/NZRt/ZhTQvzjkGB4YohBOpKM4jH/lDT4qb7Lex/aGCxpi/JD9njw3zBBtMqxbaC22+tFHVvw==}
+    engines: {node: '>=18.0.0'}
+
+  '@graphql-yoga/typed-event-target@3.0.2':
+    resolution: {integrity: sha512-ZpJxMqB+Qfe3rp6uszCQoag4nSw42icURnBRfFYSOmTgEeOe4rD0vYlbA8spvCu2TlCesNTlEN9BLWtQqLxabA==}
+    engines: {node: '>=18.0.0'}
+
+  '@mapbox/node-pre-gyp@1.0.11':
+    resolution: {integrity: sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==}
+    hasBin: true
+
+  '@prisma/client@5.22.0':
+    resolution: {integrity: sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==}
+    engines: {node: '>=16.13'}
+    peerDependencies:
+      prisma: '*'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
+
+  '@prisma/debug@5.22.0':
+    resolution: {integrity: sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==}
+
+  '@prisma/engines-version@5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2':
+    resolution: {integrity: sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==}
+
+  '@prisma/engines@5.22.0':
+    resolution: {integrity: sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==}
+
+  '@prisma/fetch-engine@5.22.0':
+    resolution: {integrity: sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==}
+
+  '@prisma/get-platform@5.22.0':
+    resolution: {integrity: sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==}
+
+  '@repeaterjs/repeater@3.0.6':
+    resolution: {integrity: sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==}
+
+  '@types/bcrypt@5.0.2':
+    resolution: {integrity: sha512-6atioO8Y75fNcbmj0G7UjI9lXN2pQ/IGJ2FWT4a/btd0Lk9lQalHLKhkgKVZ3r+spnmWUKfbMi1GEe9wyHQfNQ==}
+
+  '@types/jsonwebtoken@9.0.10':
+    resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
+  '@types/node@22.19.17':
+    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
+
+  '@whatwg-node/disposablestack@0.0.6':
+    resolution: {integrity: sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw==}
+    engines: {node: '>=18.0.0'}
+
+  '@whatwg-node/events@0.1.2':
+    resolution: {integrity: sha512-ApcWxkrs1WmEMS2CaLLFUEem/49erT3sxIVjpzU5f6zmVcnijtDSrhoK2zVobOIikZJdH63jdAXOrvjf6eOUNQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@whatwg-node/fetch@0.10.13':
+    resolution: {integrity: sha512-b4PhJ+zYj4357zwk4TTuF2nEe0vVtOrwdsrNo5hL+u1ojXNhh1FgJ6pg1jzDlwlT4oBdzfSwaBwMCtFCsIWg8Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@whatwg-node/node-fetch@0.8.5':
+    resolution: {integrity: sha512-4xzCl/zphPqlp9tASLVeUhB5+WJHbuWGYpfoC2q1qh5dw0AqZBW7L27V5roxYWijPxj4sspRAAoOH3d2ztaHUQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@whatwg-node/promise-helpers@1.3.2':
+    resolution: {integrity: sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==}
+    engines: {node: '>=16.0.0'}
+
+  '@whatwg-node/server@0.10.18':
+    resolution: {integrity: sha512-kMwLlxUbduttIgaPdSkmEarFpP+mSY8FEm+QWMBRJwxOHWkri+cxd8KZHO9EMrB9vgUuz+5WEaCawaL5wGVoXg==}
+    engines: {node: '>=18.0.0'}
+
+  abbrev@1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  aproba@2.1.0:
+    resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
+
+  are-we-there-yet@2.0.0:
+    resolution: {integrity: sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==}
+    engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  bcrypt@5.1.1:
+    resolution: {integrity: sha512-AGBHOG5hPYZ5Xl9KXzU5iKq9516yEmvCKDg3ecP5kX2aB6UqTeXZxk2ELnDgDm6BQSMlLt9rDB4LoSMx0rYwww==}
+    engines: {node: '>= 10.0.0'}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
+  chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
+
+  color-support@1.1.3:
+    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
+    hasBin: true
+
+  console-control-strings@1.1.0:
+    resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
+
+  cross-inspect@1.0.1:
+    resolution: {integrity: sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==}
+    engines: {node: '>=16.0.0'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  delegates@1.0.0:
+    resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fs-minipass@2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gauge@3.0.2:
+    resolution: {integrity: sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==}
+    engines: {node: '>=10'}
+    deprecated: This package is no longer supported.
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  graphql-yoga@5.21.0:
+    resolution: {integrity: sha512-PS37UoDihx8209RRl1ogttzWevNYDnGvP7beHkwHzUpUdfZTHsVRTVe1ysGXre1EjwUAePbpez302YSrq70Ngw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      graphql: ^15.2.0 || ^16.0.0
+
+  graphql@16.13.2:
+    resolution: {integrity: sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
+  has-unicode@2.0.1:
+    resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  jsonwebtoken@9.0.3:
+    resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
+    engines: {node: '>=12', npm: '>=6'}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  make-dir@3.1.0:
+    resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
+    engines: {node: '>=8'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
+
+  minizlib@2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  node-addon-api@5.1.0:
+    resolution: {integrity: sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  nopt@5.0.0:
+    resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  npmlog@5.0.1:
+    resolution: {integrity: sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==}
+    deprecated: This package is no longer supported.
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
+  prisma@5.22.0:
+    resolution: {integrity: sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==}
+    engines: {node: '>=16.13'}
+    hasBin: true
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  urlpattern-polyfill@10.1.0:
+    resolution: {integrity: sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  wide-align@1.1.5:
+    resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+snapshots:
+
+  '@envelop/core@5.5.1':
+    dependencies:
+      '@envelop/instrumentation': 1.0.0
+      '@envelop/types': 5.2.1
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
+
+  '@envelop/instrumentation@1.0.0':
+    dependencies:
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
+
+  '@envelop/types@5.2.1':
+    dependencies:
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@fastify/busboy@3.2.0': {}
+
+  '@graphql-tools/executor@1.5.2(graphql@16.13.2)':
+    dependencies:
+      '@graphql-tools/utils': 11.0.1(graphql@16.13.2)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.13.2)
+      '@repeaterjs/repeater': 3.0.6
+      '@whatwg-node/disposablestack': 0.0.6
+      '@whatwg-node/promise-helpers': 1.3.2
+      graphql: 16.13.2
+      tslib: 2.8.1
+
+  '@graphql-tools/merge@9.1.8(graphql@16.13.2)':
+    dependencies:
+      '@graphql-tools/utils': 11.0.1(graphql@16.13.2)
+      graphql: 16.13.2
+      tslib: 2.8.1
+
+  '@graphql-tools/schema@10.0.32(graphql@16.13.2)':
+    dependencies:
+      '@graphql-tools/merge': 9.1.8(graphql@16.13.2)
+      '@graphql-tools/utils': 11.0.1(graphql@16.13.2)
+      graphql: 16.13.2
+      tslib: 2.8.1
+
+  '@graphql-tools/utils@10.11.0(graphql@16.13.2)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.13.2)
+      '@whatwg-node/promise-helpers': 1.3.2
+      cross-inspect: 1.0.1
+      graphql: 16.13.2
+      tslib: 2.8.1
+
+  '@graphql-tools/utils@11.0.1(graphql@16.13.2)':
+    dependencies:
+      '@graphql-typed-document-node/core': 3.2.0(graphql@16.13.2)
+      '@whatwg-node/promise-helpers': 1.3.2
+      cross-inspect: 1.0.1
+      graphql: 16.13.2
+      tslib: 2.8.1
+
+  '@graphql-typed-document-node/core@3.2.0(graphql@16.13.2)':
+    dependencies:
+      graphql: 16.13.2
+
+  '@graphql-yoga/logger@2.0.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@graphql-yoga/subscription@5.0.5':
+    dependencies:
+      '@graphql-yoga/typed-event-target': 3.0.2
+      '@repeaterjs/repeater': 3.0.6
+      '@whatwg-node/events': 0.1.2
+      tslib: 2.8.1
+
+  '@graphql-yoga/typed-event-target@3.0.2':
+    dependencies:
+      '@repeaterjs/repeater': 3.0.6
+      tslib: 2.8.1
+
+  '@mapbox/node-pre-gyp@1.0.11':
+    dependencies:
+      detect-libc: 2.1.2
+      https-proxy-agent: 5.0.1
+      make-dir: 3.1.0
+      node-fetch: 2.7.0
+      nopt: 5.0.0
+      npmlog: 5.0.1
+      rimraf: 3.0.2
+      semver: 7.7.4
+      tar: 6.2.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@prisma/client@5.22.0(prisma@5.22.0)':
+    optionalDependencies:
+      prisma: 5.22.0
+
+  '@prisma/debug@5.22.0': {}
+
+  '@prisma/engines-version@5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2': {}
+
+  '@prisma/engines@5.22.0':
+    dependencies:
+      '@prisma/debug': 5.22.0
+      '@prisma/engines-version': 5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2
+      '@prisma/fetch-engine': 5.22.0
+      '@prisma/get-platform': 5.22.0
+
+  '@prisma/fetch-engine@5.22.0':
+    dependencies:
+      '@prisma/debug': 5.22.0
+      '@prisma/engines-version': 5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2
+      '@prisma/get-platform': 5.22.0
+
+  '@prisma/get-platform@5.22.0':
+    dependencies:
+      '@prisma/debug': 5.22.0
+
+  '@repeaterjs/repeater@3.0.6': {}
+
+  '@types/bcrypt@5.0.2':
+    dependencies:
+      '@types/node': 22.19.17
+
+  '@types/jsonwebtoken@9.0.10':
+    dependencies:
+      '@types/ms': 2.1.0
+      '@types/node': 22.19.17
+
+  '@types/ms@2.1.0': {}
+
+  '@types/node@22.19.17':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@whatwg-node/disposablestack@0.0.6':
+    dependencies:
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
+
+  '@whatwg-node/events@0.1.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@whatwg-node/fetch@0.10.13':
+    dependencies:
+      '@whatwg-node/node-fetch': 0.8.5
+      urlpattern-polyfill: 10.1.0
+
+  '@whatwg-node/node-fetch@0.8.5':
+    dependencies:
+      '@fastify/busboy': 3.2.0
+      '@whatwg-node/disposablestack': 0.0.6
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
+
+  '@whatwg-node/promise-helpers@1.3.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@whatwg-node/server@0.10.18':
+    dependencies:
+      '@envelop/instrumentation': 1.0.0
+      '@whatwg-node/disposablestack': 0.0.6
+      '@whatwg-node/fetch': 0.10.13
+      '@whatwg-node/promise-helpers': 1.3.2
+      tslib: 2.8.1
+
+  abbrev@1.1.1: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  ansi-regex@5.0.1: {}
+
+  aproba@2.1.0: {}
+
+  are-we-there-yet@2.0.0:
+    dependencies:
+      delegates: 1.0.0
+      readable-stream: 3.6.2
+
+  balanced-match@4.0.4: {}
+
+  bcrypt@5.1.1:
+    dependencies:
+      '@mapbox/node-pre-gyp': 1.0.11
+      node-addon-api: 5.1.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
+
+  buffer-equal-constant-time@1.0.1: {}
+
+  chownr@2.0.0: {}
+
+  color-support@1.1.3: {}
+
+  console-control-strings@1.1.0: {}
+
+  cross-inspect@1.0.1:
+    dependencies:
+      tslib: 2.8.1
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  delegates@1.0.0: {}
+
+  detect-libc@2.1.2: {}
+
+  dotenv@16.6.1: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  emoji-regex@8.0.0: {}
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
+
+  fs-minipass@2.1.0:
+    dependencies:
+      minipass: 3.3.6
+
+  fs.realpath@1.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  gauge@3.0.2:
+    dependencies:
+      aproba: 2.1.0
+      color-support: 1.1.3
+      console-control-strings: 1.1.0
+      has-unicode: 2.0.1
+      object-assign: 4.1.1
+      signal-exit: 3.0.7
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wide-align: 1.1.5
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 10.2.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
+  graphql-yoga@5.21.0(graphql@16.13.2):
+    dependencies:
+      '@envelop/core': 5.5.1
+      '@envelop/instrumentation': 1.0.0
+      '@graphql-tools/executor': 1.5.2(graphql@16.13.2)
+      '@graphql-tools/schema': 10.0.32(graphql@16.13.2)
+      '@graphql-tools/utils': 10.11.0(graphql@16.13.2)
+      '@graphql-yoga/logger': 2.0.1
+      '@graphql-yoga/subscription': 5.0.5
+      '@whatwg-node/fetch': 0.10.13
+      '@whatwg-node/promise-helpers': 1.3.2
+      '@whatwg-node/server': 0.10.18
+      graphql: 16.13.2
+      lru-cache: 10.4.3
+      tslib: 2.8.1
+
+  graphql@16.13.2: {}
+
+  has-unicode@2.0.1: {}
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  jsonwebtoken@9.0.3:
+    dependencies:
+      jws: 4.0.1
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.7.4
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
+
+  lodash.once@4.1.1: {}
+
+  lru-cache@10.4.3: {}
+
+  make-dir@3.1.0:
+    dependencies:
+      semver: 6.3.1
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
+
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
+  minipass@5.0.0: {}
+
+  minizlib@2.1.2:
+    dependencies:
+      minipass: 3.3.6
+      yallist: 4.0.0
+
+  mkdirp@1.0.4: {}
+
+  ms@2.1.3: {}
+
+  node-addon-api@5.1.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  nopt@5.0.0:
+    dependencies:
+      abbrev: 1.1.1
+
+  npmlog@5.0.1:
+    dependencies:
+      are-we-there-yet: 2.0.0
+      console-control-strings: 1.1.0
+      gauge: 3.0.2
+      set-blocking: 2.0.0
+
+  object-assign@4.1.1: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  path-is-absolute@1.0.1: {}
+
+  prisma@5.22.0:
+    dependencies:
+      '@prisma/engines': 5.22.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  resolve-pkg-maps@1.0.0: {}
+
+  rimraf@3.0.2:
+    dependencies:
+      glob: 7.2.3
+
+  safe-buffer@5.2.1: {}
+
+  semver@6.3.1: {}
+
+  semver@7.7.4: {}
+
+  set-blocking@2.0.0: {}
+
+  signal-exit@3.0.7: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  tar@6.2.1:
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
+
+  tr46@0.0.3: {}
+
+  tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  urlpattern-polyfill@10.1.0: {}
+
+  util-deprecate@1.0.2: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
+  wide-align@1.1.5:
+    dependencies:
+      string-width: 4.2.3
+
+  wrappy@1.0.2: {}
+
+  yallist@4.0.0: {}

--- a/prisma/migrations/20260416215437_phala_deployment_org_status_idx/migration.sql
+++ b/prisma/migrations/20260416215437_phala_deployment_org_status_idx/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "PhalaDeployment_organization_id_status_idx" ON "PhalaDeployment"("organization_id", "status");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1181,6 +1181,12 @@ model PhalaDeployment {
   @@index([status])
   @@index([appId])
   @@index([orgBillingId])
+  // Compound index for the per-org concurrency check in
+  // `resolvers/launchGuards.ts → assertOrgConcurrency`. PhalaDeployment carries
+  // organizationId directly (unlike AkashDeployment which joins through
+  // Service → Project), so this index covers the entire WHERE clause without
+  // needing the join optimizer to be clever. Becomes meaningful at >10K rows.
+  @@index([organizationId, status])
 }
 
 // ============================================

--- a/src/resolvers/akash.ts
+++ b/src/resolvers/akash.ts
@@ -294,7 +294,7 @@ export const akashMutations = {
       throw new GraphQLError('Not authenticated')
     }
 
-    await assertSubscriptionActive(context.organizationId)
+    const subscriptionStatus = await assertSubscriptionActive(context.organizationId)
 
     // Get the service from the registry
     const service = await context.prisma.service.findUnique({
@@ -386,13 +386,17 @@ export const akashMutations = {
       policyId = policyRecord.id
     }
 
-    // Kill-switch + hourly cap + per-org concurrency. Runs BEFORE
+    // Kill-switch + hourly cap + tier-aware concurrency cap. Runs BEFORE
     // assertDeployBalance so a disabled platform / disallowed rate / over-limit
-    // org fails cleanly with no balance lookup side effects.
+    // org fails cleanly with no balance lookup side effects. The subscription
+    // status was already fetched by assertSubscriptionActive above — we reuse
+    // it here so the concurrency cap can pick the trial vs paid tier without
+    // a second round-trip to service-auth.
     await assertLaunchAllowed(
       context.organizationId,
       context.prisma,
       estimatedDailyCostCents / 24,
+      subscriptionStatus,
     )
 
     await assertDeployBalance(context.organizationId, 'akash', context.prisma, {
@@ -445,7 +449,7 @@ export const akashMutations = {
       throw new GraphQLError('Not authenticated')
     }
 
-    await assertSubscriptionActive(context.organizationId)
+    const subscriptionStatus = await assertSubscriptionActive(context.organizationId)
 
     // Get the function with its service
     const func = await context.prisma.aFFunction.findUnique({
@@ -474,6 +478,7 @@ export const akashMutations = {
       context.organizationId,
       context.prisma,
       BILLING_CONFIG.akash.minBalanceCentsToLaunch / 24,
+      subscriptionStatus,
     )
 
     await assertDeployBalance(context.organizationId, 'akash', context.prisma, {

--- a/src/resolvers/akash.ts
+++ b/src/resolvers/akash.ts
@@ -11,6 +11,7 @@ import { getEscrowService } from '../services/billing/escrowService.js'
 import { settleAkashEscrowToTime } from '../services/billing/deploymentSettlement.js'
 import { assertSubscriptionActive } from './subscriptionCheck.js'
 import { assertDeployBalance, checkTimeLimitedDeployBalance } from './balanceCheck.js'
+import { assertLaunchAllowed } from './launchGuards.js'
 import type { Context } from './types.js'
 import { requireAuth, assertProjectAccess } from '../utils/authorization.js'
 import { createLogger } from '../lib/logger.js'
@@ -385,6 +386,15 @@ export const akashMutations = {
       policyId = policyRecord.id
     }
 
+    // Kill-switch + hourly cap + per-org concurrency. Runs BEFORE
+    // assertDeployBalance so a disabled platform / disallowed rate / over-limit
+    // org fails cleanly with no balance lookup side effects.
+    await assertLaunchAllowed(
+      context.organizationId,
+      context.prisma,
+      estimatedDailyCostCents / 24,
+    )
+
     await assertDeployBalance(context.organizationId, 'akash', context.prisma, {
       dailyCostCents: estimatedDailyCostCents,
     })
@@ -459,6 +469,12 @@ export const akashMutations = {
     if (!func.serviceId) {
       throw new GraphQLError('Function has no associated service in the registry')
     }
+
+    await assertLaunchAllowed(
+      context.organizationId,
+      context.prisma,
+      BILLING_CONFIG.akash.minBalanceCentsToLaunch / 24,
+    )
 
     await assertDeployBalance(context.organizationId, 'akash', context.prisma, {
       dailyCostCents: BILLING_CONFIG.akash.minBalanceCentsToLaunch,

--- a/src/resolvers/launchGuards.test.ts
+++ b/src/resolvers/launchGuards.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { GraphQLError } from 'graphql'
+
+const opsAlertMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+vi.mock('../lib/opsAlert.js', () => ({
+  opsAlert: opsAlertMock,
+}))
+
 import {
   assertDeploymentsEnabled,
   assertWithinHourlyCap,
@@ -48,6 +54,7 @@ describe('launchGuards', () => {
     delete process.env.MAX_ACTIVE_DEPLOYMENTS_PER_ORG
     delete process.env.MAX_ACTIVE_DEPLOYMENTS_TRIAL
     delete process.env.MAX_ACTIVE_DEPLOYMENTS_PAID
+    opsAlertMock.mockClear()
   })
 
   afterEach(() => {
@@ -290,6 +297,33 @@ describe('launchGuards', () => {
       const prisma = buildPrisma(100, 100)
       await expect(assertOrgConcurrency('org-1', prisma, TRIAL)).resolves.toBeUndefined()
       expect(prisma.akashDeployment.count).not.toHaveBeenCalled()
+    })
+
+    it('disabled guard fires a deduped opsAlert (warning, hourly suppress)', async () => {
+      process.env.MAX_ACTIVE_DEPLOYMENTS_PER_ORG = '0'
+      const prisma = buildPrisma(0, 0)
+
+      await assertOrgConcurrency('org-1', prisma, TRIAL)
+      await assertOrgConcurrency('org-2', prisma, PAID)
+
+      // Both calls hit the alert path — `opsAlert` itself dedupes (we just
+      // verify we ALWAYS call it with the same key + a long suppressMs so
+      // dedupe actually engages downstream).
+      expect(opsAlertMock).toHaveBeenCalledTimes(2)
+      const firstCall = opsAlertMock.mock.calls[0]?.[0]
+      const secondCall = opsAlertMock.mock.calls[1]?.[0]
+      expect(firstCall.key).toBe('launch-guards:concurrency-disabled')
+      expect(secondCall.key).toBe('launch-guards:concurrency-disabled')
+      expect(firstCall.severity).toBe('warning')
+      expect(firstCall.suppressMs).toBeGreaterThanOrEqual(60 * 60 * 1000)
+      expect(firstCall.context).toEqual({ organizationId: 'org-1', tier: 'trial' })
+      expect(secondCall.context).toEqual({ organizationId: 'org-2', tier: 'paid' })
+    })
+
+    it('does not fire the disabled-guard alert when the guard is enabled', async () => {
+      const prisma = buildPrisma(1, 0)
+      await assertOrgConcurrency('org-1', prisma, PAID)
+      expect(opsAlertMock).not.toHaveBeenCalled()
     })
 
     it('skips the check when organizationId is undefined', async () => {

--- a/src/resolvers/launchGuards.test.ts
+++ b/src/resolvers/launchGuards.test.ts
@@ -5,8 +5,11 @@ import {
   assertWithinHourlyCap,
   assertOrgConcurrency,
   assertLaunchAllowed,
+  classifyTier,
+  resolveConcurrencyCap,
   isHourlyCapAllowlisted,
 } from './launchGuards.js'
+import type { SubscriptionStatusInfo } from './subscriptionCheck.js'
 import type { PrismaClient } from '@prisma/client'
 
 function buildPrisma(akashActive = 0, phalaActive = 0): PrismaClient {
@@ -20,6 +23,20 @@ function buildPrisma(akashActive = 0, phalaActive = 0): PrismaClient {
   } as unknown as PrismaClient
 }
 
+function sub(status: string | null): SubscriptionStatusInfo {
+  return {
+    status,
+    trialEnd: null,
+    daysRemaining: null,
+    graceRemaining: null,
+    planName: null,
+  }
+}
+
+const TRIAL = sub('TRIALING')
+const PAID = sub('ACTIVE')
+const PAST_DUE = sub('PAST_DUE')
+
 describe('launchGuards', () => {
   const originalEnv = { ...process.env }
 
@@ -29,6 +46,8 @@ describe('launchGuards', () => {
     delete process.env.BETA_MAX_HOURLY_CENTS
     delete process.env.BETA_HOURLY_CAP_ALLOWLIST
     delete process.env.MAX_ACTIVE_DEPLOYMENTS_PER_ORG
+    delete process.env.MAX_ACTIVE_DEPLOYMENTS_TRIAL
+    delete process.env.MAX_ACTIVE_DEPLOYMENTS_PAID
   })
 
   afterEach(() => {
@@ -120,7 +139,7 @@ describe('launchGuards', () => {
     })
 
     it('allows rate at or below cap', () => {
-      process.env.BETA_MAX_HOURLY_CENTS = '2000' // $20/hr
+      process.env.BETA_MAX_HOURLY_CENTS = '2000'
       expect(() => assertWithinHourlyCap('org-1', 1999)).not.toThrow()
       expect(() => assertWithinHourlyCap('org-1', 2000)).not.toThrow()
     })
@@ -146,96 +165,189 @@ describe('launchGuards', () => {
     })
   })
 
-  describe('assertOrgConcurrency', () => {
-    it('allows when under the default cap (10)', async () => {
-      const prisma = buildPrisma(3, 2)
-      await expect(assertOrgConcurrency('org-1', prisma)).resolves.toBeUndefined()
+  describe('classifyTier', () => {
+    it('maps ACTIVE → paid', () => {
+      expect(classifyTier(PAID)).toBe('paid')
     })
 
-    it('rejects when at or above the default cap', async () => {
-      const prisma = buildPrisma(6, 4) // 10 total
-      await expect(assertOrgConcurrency('org-1', prisma)).rejects.toThrow(GraphQLError)
+    it('maps PAST_DUE → paid (grace period still trusted)', () => {
+      expect(classifyTier(PAST_DUE)).toBe('paid')
+    })
+
+    it('maps TRIALING → trial', () => {
+      expect(classifyTier(TRIAL)).toBe('trial')
+    })
+
+    it('maps null/unknown → trial (fail-safe)', () => {
+      expect(classifyTier(null)).toBe('trial')
+      expect(classifyTier(sub(null))).toBe('trial')
+      expect(classifyTier(sub('WEIRD_STATUS'))).toBe('trial')
+      expect(classifyTier(sub('SUSPENDED'))).toBe('trial')
+    })
+  })
+
+  describe('resolveConcurrencyCap', () => {
+    it('returns tier defaults when no env is set', () => {
+      expect(resolveConcurrencyCap('trial')).toBe(10)
+      expect(resolveConcurrencyCap('paid')).toBe(25)
+    })
+
+    it('honors per-tier env overrides', () => {
+      process.env.MAX_ACTIVE_DEPLOYMENTS_TRIAL = '5'
+      process.env.MAX_ACTIVE_DEPLOYMENTS_PAID = '100'
+      expect(resolveConcurrencyCap('trial')).toBe(5)
+      expect(resolveConcurrencyCap('paid')).toBe(100)
+    })
+
+    it('falls back to default when tier env is garbage', () => {
+      process.env.MAX_ACTIVE_DEPLOYMENTS_TRIAL = 'lol'
+      expect(resolveConcurrencyCap('trial')).toBe(10)
+    })
+
+    it('global override wins over per-tier envs', () => {
+      process.env.MAX_ACTIVE_DEPLOYMENTS_TRIAL = '5'
+      process.env.MAX_ACTIVE_DEPLOYMENTS_PAID = '100'
+      process.env.MAX_ACTIVE_DEPLOYMENTS_PER_ORG = '3'
+      expect(resolveConcurrencyCap('trial')).toBe(3)
+      expect(resolveConcurrencyCap('paid')).toBe(3)
+    })
+
+    it('global override "0" disables the guard (returns null)', () => {
+      process.env.MAX_ACTIVE_DEPLOYMENTS_TRIAL = '5'
+      process.env.MAX_ACTIVE_DEPLOYMENTS_PER_ORG = '0'
+      expect(resolveConcurrencyCap('trial')).toBeNull()
+      expect(resolveConcurrencyCap('paid')).toBeNull()
+    })
+
+    it('garbage global override falls through to tier defaults', () => {
+      process.env.MAX_ACTIVE_DEPLOYMENTS_PER_ORG = 'nope'
+      expect(resolveConcurrencyCap('trial')).toBe(10)
+      expect(resolveConcurrencyCap('paid')).toBe(25)
+    })
+  })
+
+  describe('assertOrgConcurrency', () => {
+    it('trial: allows when under default cap (10)', async () => {
+      const prisma = buildPrisma(3, 2)
+      await expect(assertOrgConcurrency('org-1', prisma, TRIAL)).resolves.toBeUndefined()
+    })
+
+    it('trial: rejects at default cap (10)', async () => {
+      const prisma = buildPrisma(6, 4)
+      await expect(assertOrgConcurrency('org-1', prisma, TRIAL)).rejects.toThrow(GraphQLError)
       try {
-        await assertOrgConcurrency('org-1', prisma)
+        await assertOrgConcurrency('org-1', prisma, TRIAL)
       } catch (e) {
         expect((e as GraphQLError).extensions?.code).toBe('CONCURRENCY_LIMIT_REACHED')
-        expect((e as GraphQLError).extensions?.activeDeployments).toBe(10)
+        expect((e as GraphQLError).extensions?.tier).toBe('trial')
         expect((e as GraphQLError).extensions?.maxActiveDeployments).toBe(10)
+        expect((e as GraphQLError).extensions?.upgradeable).toBe(true)
+        expect((e as GraphQLError).message).toMatch(/Subscribe to a paid plan/)
       }
     })
 
-    it('respects a raised cap via env', async () => {
-      process.env.MAX_ACTIVE_DEPLOYMENTS_PER_ORG = '50'
-      const prisma = buildPrisma(30, 15) // 45 total, under 50
-      await expect(assertOrgConcurrency('org-1', prisma)).resolves.toBeUndefined()
+    it('paid: allows more deployments than trial default', async () => {
+      const prisma = buildPrisma(15, 0)
+      await expect(assertOrgConcurrency('org-1', prisma, PAID)).resolves.toBeUndefined()
     })
 
-    it('respects a lowered cap via env', async () => {
+    it('paid: rejects at paid default cap (25)', async () => {
+      const prisma = buildPrisma(25, 0)
+      await expect(assertOrgConcurrency('org-1', prisma, PAID)).rejects.toThrow(GraphQLError)
+      try {
+        await assertOrgConcurrency('org-1', prisma, PAID)
+      } catch (e) {
+        expect((e as GraphQLError).extensions?.tier).toBe('paid')
+        expect((e as GraphQLError).extensions?.upgradeable).toBe(false)
+        expect((e as GraphQLError).message).toMatch(/contact support/)
+      }
+    })
+
+    it('PAST_DUE still gets paid cap (grace period)', async () => {
+      const prisma = buildPrisma(15, 0)
+      await expect(assertOrgConcurrency('org-1', prisma, PAST_DUE)).resolves.toBeUndefined()
+    })
+
+    it('unknown subscription status falls back to trial cap (fail-safe)', async () => {
+      const prisma = buildPrisma(10, 0)
+      await expect(assertOrgConcurrency('org-1', prisma, null)).rejects.toThrow(GraphQLError)
+    })
+
+    it('per-tier env overrides work', async () => {
+      process.env.MAX_ACTIVE_DEPLOYMENTS_PAID = '50'
+      const prisma = buildPrisma(30, 15)
+      await expect(assertOrgConcurrency('org-1', prisma, PAID)).resolves.toBeUndefined()
+    })
+
+    it('global MAX_ACTIVE_DEPLOYMENTS_PER_ORG still overrides all tiers (incident lever)', async () => {
       process.env.MAX_ACTIVE_DEPLOYMENTS_PER_ORG = '3'
-      const prisma = buildPrisma(2, 2) // 4 total, over 3
-      await expect(assertOrgConcurrency('org-1', prisma)).rejects.toThrow(GraphQLError)
+      const prisma = buildPrisma(2, 2)
+      await expect(assertOrgConcurrency('org-1', prisma, PAID)).rejects.toThrow(GraphQLError)
     })
 
-    it('disables the guard when env is exactly "0"', async () => {
+    it('global override "0" disables the guard entirely', async () => {
       process.env.MAX_ACTIVE_DEPLOYMENTS_PER_ORG = '0'
       const prisma = buildPrisma(100, 100)
-      await expect(assertOrgConcurrency('org-1', prisma)).resolves.toBeUndefined()
-    })
-
-    it('falls back to default 10 for garbage input', async () => {
-      process.env.MAX_ACTIVE_DEPLOYMENTS_PER_ORG = 'lots'
-      const prisma = buildPrisma(5, 5) // 10 total, at default cap
-      await expect(assertOrgConcurrency('org-1', prisma)).rejects.toThrow(GraphQLError)
+      await expect(assertOrgConcurrency('org-1', prisma, TRIAL)).resolves.toBeUndefined()
+      expect(prisma.akashDeployment.count).not.toHaveBeenCalled()
     })
 
     it('skips the check when organizationId is undefined', async () => {
       const prisma = buildPrisma(100, 100)
-      await expect(assertOrgConcurrency(undefined, prisma)).resolves.toBeUndefined()
+      await expect(assertOrgConcurrency(undefined, prisma, TRIAL)).resolves.toBeUndefined()
       expect(prisma.akashDeployment.count).not.toHaveBeenCalled()
-      expect(prisma.phalaDeployment.count).not.toHaveBeenCalled()
     })
   })
 
   describe('assertLaunchAllowed', () => {
-    it('passes when all guards pass', async () => {
+    it('passes when all guards pass (paid)', async () => {
       const prisma = buildPrisma(1, 0)
-      await expect(assertLaunchAllowed('org-1', prisma, 100)).resolves.toBeUndefined()
+      await expect(assertLaunchAllowed('org-1', prisma, 100, PAID)).resolves.toBeUndefined()
+    })
+
+    it('passes when all guards pass (trial)', async () => {
+      const prisma = buildPrisma(1, 0)
+      await expect(assertLaunchAllowed('org-1', prisma, 100, TRIAL)).resolves.toBeUndefined()
     })
 
     it('rejects when kill-switch is on (before concurrency check)', async () => {
       process.env.DEPLOYMENTS_DISABLED = 'true'
       const prisma = buildPrisma(0, 0)
-      await expect(assertLaunchAllowed('org-1', prisma, 100)).rejects.toThrow(GraphQLError)
+      await expect(assertLaunchAllowed('org-1', prisma, 100, PAID)).rejects.toThrow(GraphQLError)
       expect(prisma.akashDeployment.count).not.toHaveBeenCalled()
     })
 
     it('rejects when hourly cap is exceeded (before concurrency check)', async () => {
       process.env.BETA_MAX_HOURLY_CENTS = '100'
       const prisma = buildPrisma(0, 0)
-      await expect(assertLaunchAllowed('org-1', prisma, 150)).rejects.toThrow(GraphQLError)
+      await expect(assertLaunchAllowed('org-1', prisma, 150, PAID)).rejects.toThrow(GraphQLError)
       expect(prisma.akashDeployment.count).not.toHaveBeenCalled()
     })
 
-    it('rejects when org is at concurrency limit', async () => {
-      const prisma = buildPrisma(10, 0) // at default cap
-      await expect(assertLaunchAllowed('org-1', prisma, 100)).rejects.toThrow(GraphQLError)
+    it('trial org at 10 deployments is rejected even when paid org would succeed', async () => {
+      const prisma = buildPrisma(10, 0)
+      await expect(assertLaunchAllowed('org-1', prisma, 100, TRIAL)).rejects.toThrow(GraphQLError)
+    })
+
+    it('paid org at 10 deployments is still allowed (paid cap is higher)', async () => {
+      const prisma = buildPrisma(10, 0)
+      await expect(assertLaunchAllowed('org-1', prisma, 100, PAID)).resolves.toBeUndefined()
     })
 
     it('allowlisted org still gated by concurrency cap', async () => {
       process.env.BETA_MAX_HOURLY_CENTS = '100'
       process.env.BETA_HOURLY_CAP_ALLOWLIST = 'org-power'
-      const prisma = buildPrisma(10, 0)
-      // Hourly cap bypassed for org-power, but concurrency still applies
-      await expect(assertLaunchAllowed('org-power', prisma, 10_000)).rejects.toThrow(
+      const prisma = buildPrisma(25, 0)
+      await expect(assertLaunchAllowed('org-power', prisma, 10_000, PAID)).rejects.toThrow(
         /CONCURRENCY_LIMIT_REACHED|active deployments/i,
       )
     })
 
-    it('allowlisted org under concurrency cap succeeds at any rate', async () => {
+    it('allowlisted paid org under cap succeeds at any rate', async () => {
       process.env.BETA_MAX_HOURLY_CENTS = '100'
       process.env.BETA_HOURLY_CAP_ALLOWLIST = 'org-power'
       const prisma = buildPrisma(1, 0)
-      await expect(assertLaunchAllowed('org-power', prisma, 50_000)).resolves.toBeUndefined()
+      await expect(assertLaunchAllowed('org-power', prisma, 50_000, PAID)).resolves.toBeUndefined()
     })
   })
 })

--- a/src/resolvers/launchGuards.test.ts
+++ b/src/resolvers/launchGuards.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { GraphQLError } from 'graphql'
+import {
+  assertDeploymentsEnabled,
+  assertWithinHourlyCap,
+  assertOrgConcurrency,
+  assertLaunchAllowed,
+  isHourlyCapAllowlisted,
+} from './launchGuards.js'
+import type { PrismaClient } from '@prisma/client'
+
+function buildPrisma(akashActive = 0, phalaActive = 0): PrismaClient {
+  return {
+    akashDeployment: {
+      count: vi.fn().mockResolvedValue(akashActive),
+    },
+    phalaDeployment: {
+      count: vi.fn().mockResolvedValue(phalaActive),
+    },
+  } as unknown as PrismaClient
+}
+
+describe('launchGuards', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    delete process.env.DEPLOYMENTS_DISABLED
+    delete process.env.DEPLOYMENTS_DISABLED_REASON
+    delete process.env.BETA_MAX_HOURLY_CENTS
+    delete process.env.BETA_HOURLY_CAP_ALLOWLIST
+    delete process.env.MAX_ACTIVE_DEPLOYMENTS_PER_ORG
+  })
+
+  afterEach(() => {
+    process.env = { ...originalEnv }
+  })
+
+  describe('assertDeploymentsEnabled', () => {
+    it('allows deployments when env var is unset', () => {
+      expect(() => assertDeploymentsEnabled()).not.toThrow()
+    })
+
+    it('allows deployments when env var is false', () => {
+      process.env.DEPLOYMENTS_DISABLED = 'false'
+      expect(() => assertDeploymentsEnabled()).not.toThrow()
+    })
+
+    it('rejects when DEPLOYMENTS_DISABLED=true', () => {
+      process.env.DEPLOYMENTS_DISABLED = 'true'
+      expect(() => assertDeploymentsEnabled()).toThrow(GraphQLError)
+      try {
+        assertDeploymentsEnabled()
+      } catch (e) {
+        expect((e as GraphQLError).extensions?.code).toBe('DEPLOYMENTS_DISABLED')
+      }
+    })
+
+    it('accepts alternate truthy values', () => {
+      for (const v of ['1', 'yes', 'on', 'TRUE', 'Yes']) {
+        process.env.DEPLOYMENTS_DISABLED = v
+        expect(() => assertDeploymentsEnabled()).toThrow(GraphQLError)
+      }
+    })
+
+    it('uses custom reason when DEPLOYMENTS_DISABLED_REASON is set', () => {
+      process.env.DEPLOYMENTS_DISABLED = 'true'
+      process.env.DEPLOYMENTS_DISABLED_REASON = 'Scheduled maintenance until 2pm UTC'
+      try {
+        assertDeploymentsEnabled()
+      } catch (e) {
+        expect((e as GraphQLError).message).toContain('Scheduled maintenance')
+      }
+    })
+  })
+
+  describe('isHourlyCapAllowlisted', () => {
+    it('returns false when allowlist is unset', () => {
+      expect(isHourlyCapAllowlisted('org-1')).toBe(false)
+    })
+
+    it('returns true for orgs in the CSV', () => {
+      process.env.BETA_HOURLY_CAP_ALLOWLIST = 'org-1, org-2 ,org-3'
+      expect(isHourlyCapAllowlisted('org-1')).toBe(true)
+      expect(isHourlyCapAllowlisted('org-2')).toBe(true)
+      expect(isHourlyCapAllowlisted('org-3')).toBe(true)
+    })
+
+    it('returns false for orgs not in the CSV', () => {
+      process.env.BETA_HOURLY_CAP_ALLOWLIST = 'org-1,org-2'
+      expect(isHourlyCapAllowlisted('org-99')).toBe(false)
+    })
+
+    it('tolerates whitespace and empty entries', () => {
+      process.env.BETA_HOURLY_CAP_ALLOWLIST = '  org-1 , ,org-2, '
+      expect(isHourlyCapAllowlisted('org-1')).toBe(true)
+      expect(isHourlyCapAllowlisted('org-2')).toBe(true)
+      expect(isHourlyCapAllowlisted('')).toBe(false)
+    })
+
+    it('returns false for undefined/null orgId', () => {
+      process.env.BETA_HOURLY_CAP_ALLOWLIST = 'org-1'
+      expect(isHourlyCapAllowlisted(undefined)).toBe(false)
+      expect(isHourlyCapAllowlisted(null)).toBe(false)
+    })
+  })
+
+  describe('assertWithinHourlyCap', () => {
+    it('allows any rate when cap is unset', () => {
+      expect(() => assertWithinHourlyCap('org-1', 10_000)).not.toThrow()
+    })
+
+    it('allows any rate when cap is 0', () => {
+      process.env.BETA_MAX_HOURLY_CENTS = '0'
+      expect(() => assertWithinHourlyCap('org-1', 10_000)).not.toThrow()
+    })
+
+    it('allows any rate when cap is non-numeric', () => {
+      process.env.BETA_MAX_HOURLY_CENTS = 'abc'
+      expect(() => assertWithinHourlyCap('org-1', 10_000)).not.toThrow()
+    })
+
+    it('allows rate at or below cap', () => {
+      process.env.BETA_MAX_HOURLY_CENTS = '2000' // $20/hr
+      expect(() => assertWithinHourlyCap('org-1', 1999)).not.toThrow()
+      expect(() => assertWithinHourlyCap('org-1', 2000)).not.toThrow()
+    })
+
+    it('rejects rate above cap', () => {
+      process.env.BETA_MAX_HOURLY_CENTS = '2000'
+      expect(() => assertWithinHourlyCap('org-1', 2001)).toThrow(GraphQLError)
+      try {
+        assertWithinHourlyCap('org-1', 5000)
+      } catch (e) {
+        expect((e as GraphQLError).extensions?.code).toBe('HOURLY_CAP_EXCEEDED')
+        expect((e as GraphQLError).extensions?.maxHourlyCostCents).toBe(2000)
+        expect((e as GraphQLError).extensions?.projectedHourlyCostCents).toBe(5000)
+        expect((e as GraphQLError).extensions?.allowlistable).toBe(true)
+      }
+    })
+
+    it('bypasses cap for allowlisted orgs', () => {
+      process.env.BETA_MAX_HOURLY_CENTS = '2000'
+      process.env.BETA_HOURLY_CAP_ALLOWLIST = 'org-power-user'
+      expect(() => assertWithinHourlyCap('org-power-user', 10_000)).not.toThrow()
+      expect(() => assertWithinHourlyCap('org-normal', 10_000)).toThrow(GraphQLError)
+    })
+  })
+
+  describe('assertOrgConcurrency', () => {
+    it('allows when under the default cap (10)', async () => {
+      const prisma = buildPrisma(3, 2)
+      await expect(assertOrgConcurrency('org-1', prisma)).resolves.toBeUndefined()
+    })
+
+    it('rejects when at or above the default cap', async () => {
+      const prisma = buildPrisma(6, 4) // 10 total
+      await expect(assertOrgConcurrency('org-1', prisma)).rejects.toThrow(GraphQLError)
+      try {
+        await assertOrgConcurrency('org-1', prisma)
+      } catch (e) {
+        expect((e as GraphQLError).extensions?.code).toBe('CONCURRENCY_LIMIT_REACHED')
+        expect((e as GraphQLError).extensions?.activeDeployments).toBe(10)
+        expect((e as GraphQLError).extensions?.maxActiveDeployments).toBe(10)
+      }
+    })
+
+    it('respects a raised cap via env', async () => {
+      process.env.MAX_ACTIVE_DEPLOYMENTS_PER_ORG = '50'
+      const prisma = buildPrisma(30, 15) // 45 total, under 50
+      await expect(assertOrgConcurrency('org-1', prisma)).resolves.toBeUndefined()
+    })
+
+    it('respects a lowered cap via env', async () => {
+      process.env.MAX_ACTIVE_DEPLOYMENTS_PER_ORG = '3'
+      const prisma = buildPrisma(2, 2) // 4 total, over 3
+      await expect(assertOrgConcurrency('org-1', prisma)).rejects.toThrow(GraphQLError)
+    })
+
+    it('disables the guard when env is exactly "0"', async () => {
+      process.env.MAX_ACTIVE_DEPLOYMENTS_PER_ORG = '0'
+      const prisma = buildPrisma(100, 100)
+      await expect(assertOrgConcurrency('org-1', prisma)).resolves.toBeUndefined()
+    })
+
+    it('falls back to default 10 for garbage input', async () => {
+      process.env.MAX_ACTIVE_DEPLOYMENTS_PER_ORG = 'lots'
+      const prisma = buildPrisma(5, 5) // 10 total, at default cap
+      await expect(assertOrgConcurrency('org-1', prisma)).rejects.toThrow(GraphQLError)
+    })
+
+    it('skips the check when organizationId is undefined', async () => {
+      const prisma = buildPrisma(100, 100)
+      await expect(assertOrgConcurrency(undefined, prisma)).resolves.toBeUndefined()
+      expect(prisma.akashDeployment.count).not.toHaveBeenCalled()
+      expect(prisma.phalaDeployment.count).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('assertLaunchAllowed', () => {
+    it('passes when all guards pass', async () => {
+      const prisma = buildPrisma(1, 0)
+      await expect(assertLaunchAllowed('org-1', prisma, 100)).resolves.toBeUndefined()
+    })
+
+    it('rejects when kill-switch is on (before concurrency check)', async () => {
+      process.env.DEPLOYMENTS_DISABLED = 'true'
+      const prisma = buildPrisma(0, 0)
+      await expect(assertLaunchAllowed('org-1', prisma, 100)).rejects.toThrow(GraphQLError)
+      expect(prisma.akashDeployment.count).not.toHaveBeenCalled()
+    })
+
+    it('rejects when hourly cap is exceeded (before concurrency check)', async () => {
+      process.env.BETA_MAX_HOURLY_CENTS = '100'
+      const prisma = buildPrisma(0, 0)
+      await expect(assertLaunchAllowed('org-1', prisma, 150)).rejects.toThrow(GraphQLError)
+      expect(prisma.akashDeployment.count).not.toHaveBeenCalled()
+    })
+
+    it('rejects when org is at concurrency limit', async () => {
+      const prisma = buildPrisma(10, 0) // at default cap
+      await expect(assertLaunchAllowed('org-1', prisma, 100)).rejects.toThrow(GraphQLError)
+    })
+
+    it('allowlisted org still gated by concurrency cap', async () => {
+      process.env.BETA_MAX_HOURLY_CENTS = '100'
+      process.env.BETA_HOURLY_CAP_ALLOWLIST = 'org-power'
+      const prisma = buildPrisma(10, 0)
+      // Hourly cap bypassed for org-power, but concurrency still applies
+      await expect(assertLaunchAllowed('org-power', prisma, 10_000)).rejects.toThrow(
+        /CONCURRENCY_LIMIT_REACHED|active deployments/i,
+      )
+    })
+
+    it('allowlisted org under concurrency cap succeeds at any rate', async () => {
+      process.env.BETA_MAX_HOURLY_CENTS = '100'
+      process.env.BETA_HOURLY_CAP_ALLOWLIST = 'org-power'
+      const prisma = buildPrisma(1, 0)
+      await expect(assertLaunchAllowed('org-power', prisma, 50_000)).resolves.toBeUndefined()
+    })
+  })
+})

--- a/src/resolvers/launchGuards.ts
+++ b/src/resolvers/launchGuards.ts
@@ -1,5 +1,6 @@
 /**
- * Launch guards — operational kill-switch, hourly cost cap, concurrency cap.
+ * Launch guards — operational kill-switch, hourly cost cap, tier-aware
+ * concurrency cap.
  *
  * These are env-driven circuit breakers that reject new deployments before any
  * on-chain or provider-side work happens. Complementary to `assertDeployBalance`
@@ -9,10 +10,20 @@
  *      (`DEPLOYMENTS_DISABLED=true`).
  *   2. Mis-clicks and obvious abuse (a beta user accidentally launching a
  *      $50/hr H200, or a griefer firing 20 leases in a minute)
- *      (`BETA_MAX_HOURLY_CENTS`, `MAX_ACTIVE_DEPLOYMENTS_PER_ORG`).
+ *      (`BETA_MAX_HOURLY_CENTS`, tier-based concurrency caps).
  *   3. Individual orgs that legitimately need higher limits
  *      (`BETA_HOURLY_CAP_ALLOWLIST` — CSV of organizationIds that bypass
- *      the hourly cap; concurrency cap still applies).
+ *      the hourly cap; concurrency cap still applies, sized by tier).
+ *
+ * Concurrency tiering (new in Phase 36):
+ *   - TRIALING / unknown → `MAX_ACTIVE_DEPLOYMENTS_TRIAL` (default 10)
+ *   - ACTIVE / PAST_DUE  → `MAX_ACTIVE_DEPLOYMENTS_PAID`  (default 25)
+ *
+ * Rationale: trial users start with a bounded credit grant ($5), so even the
+ * maximum damage they can self-inflict is capped by balance. Once a user
+ * subscribes they've committed a payment method and we can trust them with
+ * a higher blast radius. `MAX_ACTIVE_DEPLOYMENTS_PER_ORG` acts as a hard
+ * global override (e.g. during an incident) and ALWAYS wins when set.
  *
  * Env vars are read per-call so ops can change them at runtime by rotating
  * the K8s configmap — no pod restart needed. `assertLaunchAllowed` is async
@@ -21,6 +32,7 @@
 
 import { GraphQLError } from 'graphql'
 import type { PrismaClient } from '@prisma/client'
+import type { SubscriptionStatusInfo } from './subscriptionCheck.js'
 
 function isTruthy(v: string | undefined): boolean {
   if (!v) return false
@@ -42,6 +54,30 @@ function parseCsvSet(v: string | undefined): Set<string> {
       .map(s => s.trim())
       .filter(Boolean),
   )
+}
+
+export type OrgTier = 'trial' | 'paid'
+
+/**
+ * Classify a subscription status into the two billing tiers that drive
+ * concurrency caps. `null` / unknown defaults to `'trial'` (most restrictive,
+ * fail-safe when the auth service is unreachable).
+ *
+ * TRIAL statuses: TRIALING, TRIAL_EXPIRED (the expired case is normally blocked
+ * earlier by `assertSubscriptionActive`, but if it leaks through we want the
+ * tighter cap).
+ *
+ * PAID statuses: ACTIVE (paid subscriber in good standing), PAST_DUE (paid
+ * subscriber with a temporarily failed payment — still trusted, grace period).
+ *
+ * Everything else (null, SUSPENDED, CANCELED, UNPAID, INCOMPLETE) → trial.
+ * Those paths are normally blocked upstream by `assertSubscriptionActive`;
+ * the conservative mapping here is defense-in-depth.
+ */
+export function classifyTier(status: SubscriptionStatusInfo | null): OrgTier {
+  const s = status?.status
+  if (s === 'ACTIVE' || s === 'PAST_DUE') return 'paid'
+  return 'trial'
 }
 
 /**
@@ -82,18 +118,13 @@ export function isHourlyCapAllowlisted(organizationId: string | undefined | null
  * Orgs listed in `BETA_HOURLY_CAP_ALLOWLIST` (CSV of organizationIds) bypass
  * this cap entirely. Use this to let specific power users launch $50/hr H200s
  * without lifting the platform-wide default.
- *
- * Rationale: the default cap is a safety net against mis-clicks and obvious
- * abuse. `assertDeployBalance` already ensures the user can actually afford
- * 1 hour of burn, so the cap is not a solvency gate — it's an upper bound on
- * "how wrong can a single click be".
  */
 export function assertWithinHourlyCap(
   organizationId: string | undefined | null,
   projectedHourlyCostCents: number,
 ): void {
   const cap = parsePositiveInt(process.env.BETA_MAX_HOURLY_CENTS)
-  if (cap === null) return // cap disabled globally
+  if (cap === null) return
   if (isHourlyCapAllowlisted(organizationId)) return
 
   if (projectedHourlyCostCents > cap) {
@@ -114,36 +145,53 @@ export function assertWithinHourlyCap(
 }
 
 /**
- * Enforce a max number of concurrently-active compute deployments per org.
+ * Resolve the active concurrency cap for a given tier, honoring:
+ *   1. `MAX_ACTIVE_DEPLOYMENTS_PER_ORG` — global override, ALWAYS wins if set
+ *      (including being set to exactly "0" which disables the guard entirely).
+ *      Intended for incident response (lower it fast) or demos (disable it).
+ *   2. `MAX_ACTIVE_DEPLOYMENTS_TRIAL` / `MAX_ACTIVE_DEPLOYMENTS_PAID` — normal
+ *      per-tier values.
+ *   3. Hard-coded defaults: 10 for trial, 25 for paid.
  *
- * Counts `AkashDeployment` + `PhalaDeployment` rows with status in an
- * "active or in-flight" set. Closed / suspended / failed do not count.
+ * Returns `null` when the guard is disabled (global override `"0"`). In that
+ * case `assertOrgConcurrency` skips the DB query entirely.
+ */
+export function resolveConcurrencyCap(tier: OrgTier): number | null {
+  const globalOverride = process.env.MAX_ACTIVE_DEPLOYMENTS_PER_ORG
+  if (globalOverride !== undefined) {
+    if (globalOverride.trim() === '0') return null
+    const parsed = parsePositiveInt(globalOverride)
+    if (parsed !== null) return parsed
+    // garbage → fall through to tier defaults
+  }
+
+  const tierEnv = tier === 'paid'
+    ? process.env.MAX_ACTIVE_DEPLOYMENTS_PAID
+    : process.env.MAX_ACTIVE_DEPLOYMENTS_TRIAL
+
+  const parsed = parsePositiveInt(tierEnv)
+  if (parsed !== null) return parsed
+
+  return tier === 'paid' ? 25 : 10
+}
+
+/**
+ * Enforce a max number of concurrently-active compute deployments per org,
+ * sized by the org's subscription tier.
  *
- * `MAX_ACTIVE_DEPLOYMENTS_PER_ORG` — default 10 if unset (conservative beta).
- * Set to 0 to disable.
- *
- * Rationale: prevents a griefer with a funded wallet from spinning up 50
- * simultaneous leases to exhaust the deployer wallet's float or rate-limit
- * the Akash RPC. Also bounds the blast radius of a client bug that retries
- * deploy mutations in a loop.
+ * Counts `AkashDeployment` + `PhalaDeployment` rows in any "active or in-flight"
+ * status. Closed / suspended / failed / stopped do not count.
  */
 export async function assertOrgConcurrency(
   organizationId: string | undefined | null,
   prisma: PrismaClient,
+  subscriptionStatus: SubscriptionStatusInfo | null,
 ): Promise<void> {
   if (!organizationId) return
 
-  const rawCap = process.env.MAX_ACTIVE_DEPLOYMENTS_PER_ORG
-  // Unset → default 10. "0" → disabled. Anything non-numeric → default 10.
-  let cap: number
-  if (rawCap === undefined) {
-    cap = 10
-  } else if (rawCap.trim() === '0') {
-    return // disabled
-  } else {
-    const parsed = parsePositiveInt(rawCap)
-    cap = parsed ?? 10
-  }
+  const tier = classifyTier(subscriptionStatus)
+  const cap = resolveConcurrencyCap(tier)
+  if (cap === null) return // disabled globally
 
   const [akashActive, phalaActive] = await Promise.all([
     prisma.akashDeployment.count({
@@ -162,16 +210,21 @@ export async function assertOrgConcurrency(
 
   const total = akashActive + phalaActive
   if (total >= cap) {
+    const upgradeHint = tier === 'trial'
+      ? ' Subscribe to a paid plan for a higher limit.'
+      : ' Close some before launching more, or contact support to raise your limit.'
+
     throw new GraphQLError(
-      `You have ${total} active deployments, which is at the current limit of ${cap}. ` +
-      `Close some before launching more, or contact support to raise your limit.`,
+      `You have ${total} active deployments, which is at the current limit of ${cap} for your ${tier} plan.${upgradeHint}`,
       {
         extensions: {
           code: 'CONCURRENCY_LIMIT_REACHED',
+          tier,
           activeDeployments: total,
           maxActiveDeployments: cap,
           akashActive,
           phalaActive,
+          upgradeable: tier === 'trial',
         },
       },
     )
@@ -181,7 +234,8 @@ export async function assertOrgConcurrency(
 /**
  * Convenience: run all three guards in order.
  * Call this at the very top of a deploy mutation, before any DB writes or
- * chain TXs. Pass the projected HOURLY cost (not daily).
+ * chain TXs. Pass the projected HOURLY cost (not daily) and the result of
+ * `assertSubscriptionActive` so we don't double-fetch the subscription.
  *
  * Order matters:
  *   1. Kill-switch — fail fast with no DB hits.
@@ -192,8 +246,9 @@ export async function assertLaunchAllowed(
   organizationId: string | undefined | null,
   prisma: PrismaClient,
   projectedHourlyCostCents: number,
+  subscriptionStatus: SubscriptionStatusInfo | null,
 ): Promise<void> {
   assertDeploymentsEnabled()
   assertWithinHourlyCap(organizationId, projectedHourlyCostCents)
-  await assertOrgConcurrency(organizationId, prisma)
+  await assertOrgConcurrency(organizationId, prisma, subscriptionStatus)
 }

--- a/src/resolvers/launchGuards.ts
+++ b/src/resolvers/launchGuards.ts
@@ -1,0 +1,199 @@
+/**
+ * Launch guards — operational kill-switch, hourly cost cap, concurrency cap.
+ *
+ * These are env-driven circuit breakers that reject new deployments before any
+ * on-chain or provider-side work happens. Complementary to `assertDeployBalance`
+ * (which protects per-user funds) — these protect the PLATFORM from:
+ *
+ *   1. Known-bad state we can flip off without redeploying code
+ *      (`DEPLOYMENTS_DISABLED=true`).
+ *   2. Mis-clicks and obvious abuse (a beta user accidentally launching a
+ *      $50/hr H200, or a griefer firing 20 leases in a minute)
+ *      (`BETA_MAX_HOURLY_CENTS`, `MAX_ACTIVE_DEPLOYMENTS_PER_ORG`).
+ *   3. Individual orgs that legitimately need higher limits
+ *      (`BETA_HOURLY_CAP_ALLOWLIST` — CSV of organizationIds that bypass
+ *      the hourly cap; concurrency cap still applies).
+ *
+ * Env vars are read per-call so ops can change them at runtime by rotating
+ * the K8s configmap — no pod restart needed. `assertLaunchAllowed` is async
+ * because the concurrency guard queries the DB.
+ */
+
+import { GraphQLError } from 'graphql'
+import type { PrismaClient } from '@prisma/client'
+
+function isTruthy(v: string | undefined): boolean {
+  if (!v) return false
+  const s = v.trim().toLowerCase()
+  return s === '1' || s === 'true' || s === 'yes' || s === 'on'
+}
+
+function parsePositiveInt(v: string | undefined): number | null {
+  if (!v) return null
+  const n = parseInt(v.trim(), 10)
+  if (!Number.isFinite(n) || n <= 0) return null
+  return n
+}
+
+function parseCsvSet(v: string | undefined): Set<string> {
+  if (!v) return new Set()
+  return new Set(
+    v.split(',')
+      .map(s => s.trim())
+      .filter(Boolean),
+  )
+}
+
+/**
+ * Reject all new deployments if the kill-switch is on.
+ *
+ * Set `DEPLOYMENTS_DISABLED=true` in the service-cloud-api configmap to flip
+ * this without a code deploy. Useful for emergency incident response: stops
+ * new bleed immediately while you debug.
+ */
+export function assertDeploymentsEnabled(): void {
+  if (isTruthy(process.env.DEPLOYMENTS_DISABLED)) {
+    const reason =
+      process.env.DEPLOYMENTS_DISABLED_REASON?.trim() ||
+      'Deployments are temporarily disabled while we investigate an issue. Please try again shortly.'
+    throw new GraphQLError(reason, {
+      extensions: { code: 'DEPLOYMENTS_DISABLED' },
+    })
+  }
+}
+
+/**
+ * True if `organizationId` is in `BETA_HOURLY_CAP_ALLOWLIST` (CSV).
+ * Exported so callers can surface the allowlist state in admin UIs if needed.
+ */
+export function isHourlyCapAllowlisted(organizationId: string | undefined | null): boolean {
+  if (!organizationId) return false
+  const allow = parseCsvSet(process.env.BETA_HOURLY_CAP_ALLOWLIST)
+  return allow.has(organizationId)
+}
+
+/**
+ * Enforce the per-deployment hourly cost cap.
+ *
+ * Set `BETA_MAX_HOURLY_CENTS` to a positive integer (e.g. 2000 = $20/hr) to
+ * prevent any single deployment from exceeding that hourly rate. Unset or 0
+ * disables the cap globally.
+ *
+ * Orgs listed in `BETA_HOURLY_CAP_ALLOWLIST` (CSV of organizationIds) bypass
+ * this cap entirely. Use this to let specific power users launch $50/hr H200s
+ * without lifting the platform-wide default.
+ *
+ * Rationale: the default cap is a safety net against mis-clicks and obvious
+ * abuse. `assertDeployBalance` already ensures the user can actually afford
+ * 1 hour of burn, so the cap is not a solvency gate — it's an upper bound on
+ * "how wrong can a single click be".
+ */
+export function assertWithinHourlyCap(
+  organizationId: string | undefined | null,
+  projectedHourlyCostCents: number,
+): void {
+  const cap = parsePositiveInt(process.env.BETA_MAX_HOURLY_CENTS)
+  if (cap === null) return // cap disabled globally
+  if (isHourlyCapAllowlisted(organizationId)) return
+
+  if (projectedHourlyCostCents > cap) {
+    throw new GraphQLError(
+      `Deployment hourly rate $${(projectedHourlyCostCents / 100).toFixed(2)}/hr ` +
+      `exceeds the current account limit of $${(cap / 100).toFixed(2)}/hr. ` +
+      `Contact support to raise your limit.`,
+      {
+        extensions: {
+          code: 'HOURLY_CAP_EXCEEDED',
+          projectedHourlyCostCents,
+          maxHourlyCostCents: cap,
+          allowlistable: true,
+        },
+      },
+    )
+  }
+}
+
+/**
+ * Enforce a max number of concurrently-active compute deployments per org.
+ *
+ * Counts `AkashDeployment` + `PhalaDeployment` rows with status in an
+ * "active or in-flight" set. Closed / suspended / failed do not count.
+ *
+ * `MAX_ACTIVE_DEPLOYMENTS_PER_ORG` — default 10 if unset (conservative beta).
+ * Set to 0 to disable.
+ *
+ * Rationale: prevents a griefer with a funded wallet from spinning up 50
+ * simultaneous leases to exhaust the deployer wallet's float or rate-limit
+ * the Akash RPC. Also bounds the blast radius of a client bug that retries
+ * deploy mutations in a loop.
+ */
+export async function assertOrgConcurrency(
+  organizationId: string | undefined | null,
+  prisma: PrismaClient,
+): Promise<void> {
+  if (!organizationId) return
+
+  const rawCap = process.env.MAX_ACTIVE_DEPLOYMENTS_PER_ORG
+  // Unset → default 10. "0" → disabled. Anything non-numeric → default 10.
+  let cap: number
+  if (rawCap === undefined) {
+    cap = 10
+  } else if (rawCap.trim() === '0') {
+    return // disabled
+  } else {
+    const parsed = parsePositiveInt(rawCap)
+    cap = parsed ?? 10
+  }
+
+  const [akashActive, phalaActive] = await Promise.all([
+    prisma.akashDeployment.count({
+      where: {
+        status: { in: ['CREATING', 'WAITING_BIDS', 'SELECTING_BID', 'CREATING_LEASE', 'SENDING_MANIFEST', 'DEPLOYING', 'ACTIVE'] },
+        service: { project: { organizationId } },
+      },
+    }),
+    prisma.phalaDeployment.count({
+      where: {
+        status: { in: ['CREATING', 'STARTING', 'ACTIVE'] },
+        organizationId,
+      },
+    }),
+  ])
+
+  const total = akashActive + phalaActive
+  if (total >= cap) {
+    throw new GraphQLError(
+      `You have ${total} active deployments, which is at the current limit of ${cap}. ` +
+      `Close some before launching more, or contact support to raise your limit.`,
+      {
+        extensions: {
+          code: 'CONCURRENCY_LIMIT_REACHED',
+          activeDeployments: total,
+          maxActiveDeployments: cap,
+          akashActive,
+          phalaActive,
+        },
+      },
+    )
+  }
+}
+
+/**
+ * Convenience: run all three guards in order.
+ * Call this at the very top of a deploy mutation, before any DB writes or
+ * chain TXs. Pass the projected HOURLY cost (not daily).
+ *
+ * Order matters:
+ *   1. Kill-switch — fail fast with no DB hits.
+ *   2. Hourly cap  — synchronous env check, no DB.
+ *   3. Concurrency — one DB count, runs last.
+ */
+export async function assertLaunchAllowed(
+  organizationId: string | undefined | null,
+  prisma: PrismaClient,
+  projectedHourlyCostCents: number,
+): Promise<void> {
+  assertDeploymentsEnabled()
+  assertWithinHourlyCap(organizationId, projectedHourlyCostCents)
+  await assertOrgConcurrency(organizationId, prisma)
+}

--- a/src/resolvers/launchGuards.ts
+++ b/src/resolvers/launchGuards.ts
@@ -33,6 +33,15 @@
 import { GraphQLError } from 'graphql'
 import type { PrismaClient } from '@prisma/client'
 import type { SubscriptionStatusInfo } from './subscriptionCheck.js'
+import { opsAlert } from '../lib/opsAlert.js'
+
+/**
+ * How long between disabled-guard alerts (per process). The guard being off is
+ * a steady-state config, not an event — alerting on every deploy attempt would
+ * spam the channel. One hour is loud enough that nobody forgets, quiet enough
+ * to not be annoying. `opsAlert`'s built-in dedupe handles the throttling.
+ */
+const DISABLED_GUARD_ALERT_SUPPRESS_MS = 60 * 60 * 1000
 
 function isTruthy(v: string | undefined): boolean {
   if (!v) return false
@@ -191,7 +200,24 @@ export async function assertOrgConcurrency(
 
   const tier = classifyTier(subscriptionStatus)
   const cap = resolveConcurrencyCap(tier)
-  if (cap === null) return // disabled globally
+  if (cap === null) {
+    // Guard is disabled by `MAX_ACTIVE_DEPLOYMENTS_PER_ORG="0"`. This is a
+    // legitimate state during demos/incidents, but it's also the kind of thing
+    // that gets set "for 5 minutes" and forgotten for a week. Fire a
+    // hourly-deduped alert so it stays visible in the ops channel without
+    // spamming on every deploy attempt.
+    void opsAlert({
+      key: 'launch-guards:concurrency-disabled',
+      severity: 'warning',
+      title: 'Concurrency cap disabled',
+      message:
+        'MAX_ACTIVE_DEPLOYMENTS_PER_ORG="0" is in effect — orgs can launch unlimited concurrent deployments. ' +
+        'If this was intentional (demo/incident), ignore. Otherwise unset the env var to re-enable per-tier caps.',
+      context: { organizationId, tier },
+      suppressMs: DISABLED_GUARD_ALERT_SUPPRESS_MS,
+    })
+    return
+  }
 
   const [akashActive, phalaActive] = await Promise.all([
     prisma.akashDeployment.count({

--- a/src/resolvers/phala.ts
+++ b/src/resolvers/phala.ts
@@ -6,6 +6,7 @@ import { getPhalaOrchestrator } from '../services/phala/index.js'
 import { processFinalPhalaBilling } from '../services/billing/deploymentSettlement.js'
 import { assertSubscriptionActive } from './subscriptionCheck.js'
 import { assertDeployBalance, checkTimeLimitedDeployBalance } from './balanceCheck.js'
+import { assertLaunchAllowed } from './launchGuards.js'
 import { BILLING_CONFIG } from '../config/billing.js'
 import { resolvePhalaInstanceType } from '../services/phala/instanceTypes.js'
 import { validatePolicyInput } from '../services/policy/validator.js'
@@ -446,6 +447,12 @@ export const phalaMutations = {
       })
       policyId = policyRecord.id
     }
+
+    await assertLaunchAllowed(
+      context.organizationId,
+      context.prisma,
+      estimatedDailyCostCents / 24,
+    )
 
     await assertDeployBalance(context.organizationId, 'phala', context.prisma, {
       dailyCostCents: estimatedDailyCostCents,

--- a/src/resolvers/phala.ts
+++ b/src/resolvers/phala.ts
@@ -283,7 +283,7 @@ export const phalaMutations = {
       throw new GraphQLError('Not authenticated')
     }
 
-    await assertSubscriptionActive(context.organizationId)
+    const subscriptionStatus = await assertSubscriptionActive(context.organizationId)
 
     const service = await context.prisma.service.findUnique({
       where: { id: input.serviceId },
@@ -452,6 +452,7 @@ export const phalaMutations = {
       context.organizationId,
       context.prisma,
       estimatedDailyCostCents / 24,
+      subscriptionStatus,
     )
 
     await assertDeployBalance(context.organizationId, 'phala', context.prisma, {

--- a/src/resolvers/subscriptionCheck.ts
+++ b/src/resolvers/subscriptionCheck.ts
@@ -1,8 +1,10 @@
 /**
  * Pre-deploy subscription status check.
  *
- * Calls service-auth's internal API to verify the org's subscription
- * is not SUSPENDED before allowing deployments.
+ * Calls service-auth's internal API to verify the org's subscription is not
+ * SUSPENDED before allowing deployments, and returns the resolved status so
+ * downstream guards (e.g. tier-based concurrency caps in `launchGuards.ts`)
+ * can reuse it without a second round-trip.
  */
 
 import { GraphQLError } from 'graphql'
@@ -11,8 +13,24 @@ import { createLogger } from '../lib/logger.js'
 
 const log = createLogger('subscription-check')
 
-export async function assertSubscriptionActive(organizationId?: string): Promise<void> {
-  if (!organizationId) return
+/**
+ * Raw subscription status object returned by `service-auth`.
+ * `status` is `null` when the billing API fail-opened (unreachable) — callers
+ * that depend on tier-specific behavior should treat that as the most
+ * restrictive tier (trial).
+ */
+export interface SubscriptionStatusInfo {
+  status: string | null
+  trialEnd: number | null
+  daysRemaining: number | null
+  graceRemaining: number | null
+  planName: string | null
+}
+
+export async function assertSubscriptionActive(
+  organizationId?: string,
+): Promise<SubscriptionStatusInfo | null> {
+  if (!organizationId) return null
 
   try {
     const client = getBillingApiClient()
@@ -21,12 +39,17 @@ export async function assertSubscriptionActive(organizationId?: string): Promise
     if (status.status === 'SUSPENDED') {
       throw new GraphQLError(
         'Your subscription is suspended. Please subscribe to continue deploying.',
-        { extensions: { code: 'SUBSCRIPTION_SUSPENDED' } }
+        { extensions: { code: 'SUBSCRIPTION_SUSPENDED' } },
       )
     }
+
+    return status
   } catch (error) {
     if (error instanceof GraphQLError) throw error
-    // If the billing API is unreachable, allow the deploy (fail-open)
+    // If the billing API is unreachable, allow the deploy (fail-open) but
+    // return null so downstream tier-aware guards fall back to the most
+    // restrictive tier.
     log.warn(error as Error, 'failed to check subscription status — allowing deploy (fail-open)')
+    return null
   }
 }

--- a/src/services/billing/computeBillingScheduler.test.ts
+++ b/src/services/billing/computeBillingScheduler.test.ts
@@ -215,6 +215,66 @@ describe('ComputeBillingScheduler.processAkashEscrows — idempotency drift', ()
     expect(topUpDeploymentDepositMock).toHaveBeenCalledWith(123, 60_000) // ppb=100 * 600 blocks
   })
 
+  it('advances lastBilledAt by exactly hoursToBill * 1h so fractional time rolls forward', async () => {
+    // Regression for the first-hour leak (Phase 36):
+    // Setting lastBilledAt=now discarded the partial hour between the previous
+    // marker and the current cron tick, causing a systemic under-charge of up
+    // to 1 hour of runtime across every deployment's lifetime.
+    //
+    // The fix advances lastBilledAt by exactly `hoursToBill * 1h` instead, so
+    // the fractional remainder is preserved and picked up on the next cycle
+    // (or at final settlement). Capped at `now` so forceMode cannot future-date.
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000)
+    const { prisma } = buildPrisma([buildEscrow({ lastBilledAt: twoHoursAgo })])
+
+    computeDebitMock.mockResolvedValue({
+      success: true,
+      balanceCents: 99_900,
+      alreadyProcessed: false,
+    })
+
+    const scheduler = new ComputeBillingScheduler(prisma)
+    await scheduler.runNow({ noPause: true })
+
+    const updateArg = prisma.deploymentEscrow.update.mock.calls[0][0]
+    const newLastBilledAt = updateArg.data.lastBilledAt as Date
+    // dailyRateCents=2400 → hourlyRateCents=100. hoursSinceLastBill≈2,
+    // hoursToBill=2 → new lastBilledAt = twoHoursAgo + 2h ≈ now.
+    const expectedMs = twoHoursAgo.getTime() + 2 * 3_600_000
+
+    // Should be at the 2h-advanced mark, not the raw `now`.
+    // Tolerance: 1s for test runtime.
+    expect(Math.abs(newLastBilledAt.getTime() - expectedMs)).toBeLessThan(1000)
+
+    // And must not be in the future (forceMode guard).
+    expect(newLastBilledAt.getTime()).toBeLessThanOrEqual(Date.now() + 100)
+  })
+
+  it('does not future-date lastBilledAt under forceMode when <1h elapsed', async () => {
+    // Force-billing with only 30min elapsed would otherwise try to advance
+    // lastBilledAt 1h into the future (hoursToBill=Math.max(1, floor(0.5))=1).
+    // The Math.min(now, ...) cap prevents that: user gets billed for 1h (the
+    // ceiling behavior of the scheduler under force) but next cycle is not
+    // silently skipped by a future lastBilledAt.
+    const thirtyMinAgo = new Date(Date.now() - 30 * 60 * 1000)
+    const { prisma } = buildPrisma([buildEscrow({ lastBilledAt: thirtyMinAgo })])
+
+    computeDebitMock.mockResolvedValue({
+      success: true,
+      balanceCents: 99_900,
+      alreadyProcessed: false,
+    })
+
+    const scheduler = new ComputeBillingScheduler(prisma)
+    await scheduler.runNow({ force: true, noPause: true })
+
+    const updateArg = prisma.deploymentEscrow.update.mock.calls[0][0]
+    const newLastBilledAt = updateArg.data.lastBilledAt as Date
+
+    expect(newLastBilledAt.getTime()).toBeLessThanOrEqual(Date.now() + 100)
+    expect(newLastBilledAt.getTime()).toBeGreaterThan(thirtyMinAgo.getTime())
+  })
+
   it('does not double-bill after a simulated prior-run crash (sequential runs)', async () => {
     // Simulate: hour H had a prior crash (auth billed, DB not updated).
     // This run is hour H+1. Auth will alreadyProcess key for H-old? No —

--- a/src/services/billing/computeBillingScheduler.ts
+++ b/src/services/billing/computeBillingScheduler.ts
@@ -281,17 +281,32 @@ export class ComputeBillingScheduler {
             },
           })
 
-          // Always mirror the auth-side charge into our DB — even on
-          // idempotency hits. An `alreadyProcessed=true` response means auth
-          // has already debited this key on a prior attempt; if we don't
-          // advance lastBilledAt/consumedCents locally, the next cron cycle
-          // will compute a larger hoursToBill with a FRESH idempotency key
-          // and double-charge the user. This is the core of the M1 bug.
+          // Advance lastBilledAt by exactly hoursToBill*1h (NOT to `now`).
+          //
+          // Why: the billing cron charges for integer hours via
+          // Math.floor(hoursSinceLastBill). If we set lastBilledAt=now, the
+          // fractional tail gets discarded forever. Example: deployment
+          // created 23:08, first cron hits at 01:00 → hoursSinceLastBill=1.87,
+          // hoursToBill=1. With `now`, the 0.87h from 23:08→00:08 is never
+          // billed. With `lastBilled + hoursToBill*1h`, lastBilledAt becomes
+          // 00:08 and that 0.87h rolls forward for the next cycle / final
+          // settlement to pick up.
+          //
+          // Cap at `now` so forceMode (which bypasses the 1h minimum check)
+          // cannot future-date lastBilledAt and silently skip the next cycle.
+          //
+          // Also mirror the auth-side charge into our DB even on idempotency
+          // hits: `alreadyProcessed=true` means auth already debited this key
+          // on a prior attempt; without the mirror the next cron cycle would
+          // compute a larger hoursToBill with a FRESH key and double-charge.
+          const advancedLastBilledAt = new Date(
+            Math.min(now.getTime(), lastBilled.getTime() + hoursToBill * 3_600_000)
+          )
           await this.prisma.deploymentEscrow.update({
             where: { id: escrow.id },
             data: {
               consumedCents: escrow.consumedCents + amountCents,
-              lastBilledAt: now,
+              lastBilledAt: advancedLastBilledAt,
             },
           })
 


### PR DESCRIPTION
Replace flat MAX_ACTIVE_DEPLOYMENTS_PER_ORG with subscription-tier-aware caps:
TRIALING (+ unknown/fail-safe) → 10, ACTIVE/PAST_DUE → 25. assertSubscriptionActive
now returns the status object so deploy mutations pass it to assertLaunchAllowed
without a second auth round-trip.

- launchGuards.ts: classifyTier (ACTIVE/PAST_DUE=paid, all else=trial),
  resolveConcurrencyCap (per-tier envs + global override + hard-coded defaults 10/25),
  assertOrgConcurrency now accepts SubscriptionStatusInfo and emits tier +
  upgradeable in error extensions so the UI can branch upgrade CTA vs close-list.
- MAX_ACTIVE_DEPLOYMENTS_PER_ORG retained as emergency global override that wins
  over tier envs (set to "0" to disable guard entirely for demos).
- subscriptionCheck.ts: return SubscriptionStatusInfo | null instead of void;
  fail-open path returns null which classifies as trial (fail-safe).
- akash.ts + phala.ts: capture status from assertSubscriptionActive and forward.
- launchGuards.test.ts: 44 tests (was 29) covering classifyTier, resolveConcurrencyCap,
  tier-aware concurrency, PAST_DUE grace, null fail-safe, global override precedence.
- Docs: Phase 36 + Runbook K rewritten with tier table and rationale; deploy protocol
  configmap row updated with the two new env vars.