### PR TITLE
close subscription/billing/log leaks; pin deploys to image digest

### DIFF
--- a/.github/workflows/deploy-aws-staging.yml
+++ b/.github/workflows/deploy-aws-staging.yml
@@ -43,15 +43,30 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: service-cloud-api/Dockerfile
           push: true
           platforms: linux/amd64
+          provenance: false
           tags: |
             ${{ env.IMAGE }}:staging
             ${{ env.IMAGE }}:staging-${{ github.sha }}
+
+      - name: Resolve immutable image reference
+        id: image
+        run: |
+          DIGEST="${{ steps.build.outputs.digest }}"
+          if [ -z "${DIGEST}" ]; then
+            echo "::error::docker/build-push-action did not emit a digest"
+            exit 1
+          fi
+          IMAGE_REF="${{ env.IMAGE }}@${DIGEST}"
+          echo "ref=${IMAGE_REF}" >> $GITHUB_OUTPUT
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+          echo "Pinned image: ${IMAGE_REF}"
 
       - name: Set up kubectl (staging)
         run: |
@@ -62,7 +77,7 @@ jobs:
       - name: Deploy to K3s staging
         run: |
           kubectl set image deployment/service-cloud-api \
-            service-cloud-api=${{ env.IMAGE }}:staging-${{ github.sha }} \
+            service-cloud-api=${{ steps.image.outputs.ref }} \
             -n ${{ env.NAMESPACE }}
           kubectl rollout status deployment/service-cloud-api \
             -n ${{ env.NAMESPACE }} --timeout=180s

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -27,6 +27,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write   # keyless cosign signing via Sigstore OIDC
+      security-events: write   # upload Trivy SARIF to code scanning
 
     steps:
       - name: Checkout into service-cloud-api subdirectory
@@ -66,6 +68,98 @@ jobs:
           echo "ref=${IMAGE_REF}" >> $GITHUB_OUTPUT
           echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
           echo "Pinned image: ${IMAGE_REF}"
+
+      # ---------------------------------------------------------------
+      # Supply-chain: cosign keyless signing, SBOM (syft), trivy scan.
+      # Set SUPPLY_CHAIN_DISABLED=true on the run to skip during an
+      # incident. Trivy blocks on CRITICAL by default; flip
+      # SUPPLY_CHAIN_TRIVY_BLOCK=false to demote to warnings.
+      # ---------------------------------------------------------------
+      - name: Install cosign
+        if: ${{ env.SUPPLY_CHAIN_DISABLED != 'true' }}
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: v2.4.1
+
+      - name: Install syft
+        if: ${{ env.SUPPLY_CHAIN_DISABLED != 'true' }}
+        uses: anchore/sbom-action/download-syft@v0
+
+      - name: Install trivy
+        if: ${{ env.SUPPLY_CHAIN_DISABLED != 'true' }}
+        uses: aquasecurity/setup-trivy@v0.2.0
+        with:
+          version: v0.56.2
+
+      - name: Sign image with cosign (keyless / Sigstore OIDC)
+        if: ${{ env.SUPPLY_CHAIN_DISABLED != 'true' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: cosign sign --yes "${{ steps.image.outputs.ref }}"
+
+      - name: Generate SBOM (CycloneDX + SPDX)
+        if: ${{ env.SUPPLY_CHAIN_DISABLED != 'true' }}
+        run: |
+          syft "${{ steps.image.outputs.ref }}" \
+            -o cyclonedx-json=sbom.cyclonedx.json \
+            -o spdx-json=sbom.spdx.json
+
+      - name: Attach SBOM as cosign attestation
+        if: ${{ env.SUPPLY_CHAIN_DISABLED != 'true' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          cosign attest --yes \
+            --predicate sbom.cyclonedx.json \
+            --type cyclonedx \
+            "${{ steps.image.outputs.ref }}"
+
+      - name: Upload SBOM artifacts
+        if: ${{ env.SUPPLY_CHAIN_DISABLED != 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-${{ github.sha }}
+          path: |
+            sbom.cyclonedx.json
+            sbom.spdx.json
+          retention-days: 90
+
+      - name: Trivy vulnerability scan (blocks on CRITICAL)
+        if: ${{ env.SUPPLY_CHAIN_DISABLED != 'true' }}
+        env:
+          TRIVY_EXIT_CODE: ${{ env.SUPPLY_CHAIN_TRIVY_BLOCK == 'false' && '0' || '1' }}
+        run: |
+          trivy image \
+            --severity CRITICAL \
+            --ignore-unfixed \
+            --exit-code "${TRIVY_EXIT_CODE}" \
+            --no-progress \
+            --format table \
+            "${{ steps.image.outputs.ref }}"
+
+          # Informational HIGH report (never blocks)
+          trivy image \
+            --severity HIGH \
+            --ignore-unfixed \
+            --no-progress \
+            --format table \
+            "${{ steps.image.outputs.ref }}" || true
+
+          # SARIF for code scanning upload
+          trivy image \
+            --severity HIGH,CRITICAL \
+            --ignore-unfixed \
+            --format sarif \
+            --output trivy.sarif \
+            "${{ steps.image.outputs.ref }}" || true
+
+      - name: Upload Trivy SARIF to code scanning
+        if: ${{ env.SUPPLY_CHAIN_DISABLED != 'true' && always() }}
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy.sarif
+          category: trivy-${{ github.workflow }}
 
       - name: Set up kubectl
         run: |

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -42,15 +42,30 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: service-cloud-api/Dockerfile
           push: true
           platforms: linux/amd64
+          provenance: false
           tags: |
             ${{ env.IMAGE }}:latest
             ${{ env.IMAGE }}:${{ github.sha }}
+
+      - name: Resolve immutable image reference
+        id: image
+        run: |
+          DIGEST="${{ steps.build.outputs.digest }}"
+          if [ -z "${DIGEST}" ]; then
+            echo "::error::docker/build-push-action did not emit a digest"
+            exit 1
+          fi
+          IMAGE_REF="${{ env.IMAGE }}@${DIGEST}"
+          echo "ref=${IMAGE_REF}" >> $GITHUB_OUTPUT
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+          echo "Pinned image: ${IMAGE_REF}"
 
       - name: Set up kubectl
         run: |
@@ -63,7 +78,7 @@ jobs:
           DB_URL=$(kubectl get secret database-credentials -n af-production \
             -o jsonpath='{.data.API_DATABASE_URL}' | base64 -d)
           kubectl run prisma-migrate-${GITHUB_SHA::7} \
-            --image=${{ env.IMAGE }}:${{ github.sha }} \
+            --image=${{ steps.image.outputs.ref }} \
             --restart=Never --rm -i \
             --pod-running-timeout=5m \
             --overrides='{"spec":{"imagePullSecrets":[{"name":"ghcr-credentials"}]}}' \
@@ -74,7 +89,7 @@ jobs:
       - name: Deploy to K3s
         run: |
           kubectl set image deployment/service-cloud-api \
-            service-cloud-api=${{ env.IMAGE }}:${{ github.sha }} \
+            service-cloud-api=${{ steps.image.outputs.ref }} \
             -n af-production
           kubectl rollout status deployment/service-cloud-api \
             -n af-production --timeout=180s
@@ -103,7 +118,7 @@ jobs:
           curl -sf -H "Content-Type: application/json" -d "{
             \"embeds\": [{
               \"title\": \"✅ service-cloud-api deployed\",
-              \"description\": \"Commit: \`${GITHUB_SHA::7}\`\nHealth: ${{ steps.verify.outputs.healthy == 'true' && 'passing' || 'pending' }}\n[View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\",
+              \"description\": \"Commit: \`${GITHUB_SHA::7}\`\nDigest: \`${{ steps.image.outputs.digest }}\`\nHealth: ${{ steps.verify.outputs.healthy == 'true' && 'passing' || 'pending' }}\n[View run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})\",
               \"color\": 3066993,
               \"footer\": {\"text\": \"Alternate Clouds Deploy\"},
               \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"

--- a/prisma/migrations/20260418041800_add_close_failed_status/migration.sql
+++ b/prisma/migrations/20260418041800_add_close_failed_status/migration.sql
@@ -1,0 +1,19 @@
+-- Akash strict close mode.
+--
+-- Add CLOSE_FAILED to the AkashDeployment status enum so callers
+-- can distinguish:
+--   * CLOSED: the on-chain `tx deployment close` was accepted (or the
+--     chain reports the deployment as already gone) — done, no further
+--     action.
+--   * CLOSE_FAILED: the local close attempt threw because of an
+--     environmental issue (RPC unreachable, wallet out of gas, account
+--     sequence collision). The lease may still be running on-chain
+--     and incurring escrow draw — operators / the stale-deployment
+--     sweeper must retry.
+--
+-- Previously every close failure collapsed to CLOSED in the database
+-- regardless of chain outcome, which masked stuck leases until the
+-- escrow drained.
+
+-- AlterEnum
+ALTER TYPE "AkashDeploymentStatus" ADD VALUE 'CLOSE_FAILED';

--- a/prisma/migrations/20260418050000_add_escrow_writeahead_states/migration.sql
+++ b/prisma/migrations/20260418050000_add_escrow_writeahead_states/migration.sql
@@ -1,0 +1,26 @@
+-- Write-ahead lifecycle states for DeploymentEscrow.
+--
+-- PENDING_DEPOSIT:
+--   Set BEFORE calling the deposit RPC against auth, so we never end up with a
+--   debit on the auth side and no local row to track it (or vice-versa). The
+--   escrow reconciler in EscrowService.reconcilePendingDeposits() drives stuck
+--   rows to ACTIVE (deposit succeeded) or FAILED (insufficient balance /
+--   persistent error).
+--
+-- REFUNDING:
+--   Set BEFORE calling the refund RPC. Lets a partial-failure reconciler tell
+--   the difference between "we never started the refund" and "the credit landed
+--   on auth but our local row never updated" — both are unsafe states without
+--   the marker.
+--
+-- FAILED:
+--   Terminal state for write-ahead deposits that cannot be completed. The
+--   deployment lifecycle should reject billing operations against FAILED rows
+--   and trigger upstream cleanup.
+--
+-- Postgres requires ALTER TYPE ... ADD VALUE outside a transaction, so each
+-- value gets its own statement. IF NOT EXISTS keeps re-runs safe in dev.
+
+ALTER TYPE "EscrowStatus" ADD VALUE IF NOT EXISTS 'PENDING_DEPOSIT';
+ALTER TYPE "EscrowStatus" ADD VALUE IF NOT EXISTS 'REFUNDING';
+ALTER TYPE "EscrowStatus" ADD VALUE IF NOT EXISTS 'FAILED';

--- a/prisma/migrations/20260418060000_add_policy_settlement_ledger/migration.sql
+++ b/prisma/migrations/20260418060000_add_policy_settlement_ledger/migration.sql
@@ -1,0 +1,55 @@
+-- Write-ahead ledger for deployment settlement charges.
+--
+-- Every pre-close settlement debit MUST be inserted here as PENDING BEFORE
+-- the auth-side computeDebit RPC fires. A crash between "advance local
+-- state" and "auth credited the charge" is then recoverable by the
+-- reconciler:
+--
+--   * PENDING + no auth charge  → retry, charge lands, mark COMMITTED.
+--   * PENDING + auth has charge → retry returns alreadyProcessed=true,
+--                                  mark COMMITTED.
+--   * Persistent failure        → mark FAILED, page ops.
+--
+-- The UNIQUE constraint on idempotency_key doubles as a duplicate-charge
+-- guard: even a buggy caller cannot insert two rows for the same
+-- settlement window and end up double-billing the user.
+
+-- CreateEnum
+CREATE TYPE "SettlementProvider" AS ENUM ('AKASH', 'PHALA');
+
+-- CreateEnum
+CREATE TYPE "SettlementKind" AS ENUM ('FINAL_SETTLEMENT', 'HOURLY_ACCRUAL');
+
+-- CreateEnum
+CREATE TYPE "PolicySettlementStatus" AS ENUM ('PENDING', 'COMMITTED', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "policy_settlement_ledger" (
+    "id" TEXT NOT NULL,
+    "provider" "SettlementProvider" NOT NULL,
+    "kind" "SettlementKind" NOT NULL,
+    "deployment_ref" TEXT NOT NULL,
+    "idempotency_key" TEXT NOT NULL,
+    "org_billing_id" TEXT NOT NULL,
+    "amount_cents" INTEGER NOT NULL,
+    "settled_to" TIMESTAMP(3) NOT NULL,
+    "status" "PolicySettlementStatus" NOT NULL DEFAULT 'PENDING',
+    "attempt_count" INTEGER NOT NULL DEFAULT 0,
+    "last_error" TEXT,
+    "committed_at" TIMESTAMP(3),
+    "policy_id" TEXT,
+    "metadata" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "policy_settlement_ledger_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "policy_settlement_ledger_idempotency_key_key" ON "policy_settlement_ledger"("idempotency_key");
+
+-- CreateIndex
+CREATE INDEX "policy_settlement_ledger_status_createdAt_idx" ON "policy_settlement_ledger"("status", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "policy_settlement_ledger_deployment_ref_idx" ON "policy_settlement_ledger"("deployment_ref");

--- a/prisma/migrations/20260418070000_add_org_concurrency_counter/migration.sql
+++ b/prisma/migrations/20260418070000_add_org_concurrency_counter/migration.sql
@@ -1,0 +1,18 @@
+-- Per-org concurrent-deployment counter.
+--
+-- Replaces the racy `COUNT(*)` on (AkashDeployment + PhalaDeployment)
+-- inside `assertOrgConcurrency` with a single source-of-truth row that
+-- is incremented under SELECT FOR UPDATE. Two concurrent launches now
+-- serialize on the row, so the cap is enforced strictly.
+--
+-- The hourly reconciler recomputes activeCount from the deployment
+-- tables and clamps drift, so a forgotten decrement in one of the close
+-- paths cannot permanently lock an org out of new launches.
+
+CREATE TABLE "organization_concurrency_counter" (
+    "organization_id" TEXT NOT NULL,
+    "active_count" INTEGER NOT NULL DEFAULT 0,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "organization_concurrency_counter_pkey" PRIMARY KEY ("organization_id")
+);

--- a/prisma/migrations/20260418080000_add_leader_lease/migration.sql
+++ b/prisma/migrations/20260418080000_add_leader_lease/migration.sql
@@ -1,0 +1,21 @@
+-- Heartbeat-based leader lease for singleton schedulers.
+--
+-- Enables REPLICAS > 1 for service-cloud-api. With more than one pod,
+-- multiple billing crons / escrow monitors / sweepers running in
+-- parallel would race on chain TXs and rows. Schedulers now wrap their
+-- `.start()` in `runWithLeadership(prisma, schedulerKey)` and only the
+-- pod that holds the lease runs the loop.
+--
+-- The leader renews `expires_at` every `LEADER_HEARTBEAT_MS`; if it
+-- crashes, followers detect the expired lease and one of them claims
+-- it on their next poll.
+
+CREATE TABLE "scheduler_leader_lease" (
+    "scheduler_key" TEXT NOT NULL,
+    "leader_id" TEXT NOT NULL,
+    "acquired_at" TIMESTAMP(3) NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "scheduler_leader_lease_pkey" PRIMARY KEY ("scheduler_key")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1134,17 +1134,131 @@ enum AkashDeploymentStatus {
   CLOSED             // Deployment closed (permanent)
   SUSPENDED          // Paused due to low balance (will auto-resume on topup)
   PERMANENTLY_FAILED // Failed after all retries exhausted
+  CLOSE_FAILED       // Local close attempt failed on-chain (RPC down, wallet empty, etc.) — needs operator/sweeper retry
 }
 
 // ============================================
 // DEPLOYMENT ESCROW (Platform-level USD escrow for Akash)
 // ============================================
 
+// Heartbeat-based leader lease for singleton schedulers.
+//
+// With REPLICAS > 1 every pod would otherwise start its own copy of the
+// billing cron, escrow monitor, etc. The lease ensures exactly one pod
+// (the "leader") runs each scheduler at any given time. The leader
+// renews `expiresAt` every `LEADER_HEARTBEAT_MS`; if it crashes,
+// followers see an expired lease and one of them grabs it. There is a
+// brief gap (< heartbeat interval) where no scheduler runs — that is
+// acceptable because every scheduler in this codebase is built to
+// tolerate "skipped a tick" (cron-style catch-up logic).
+//
+// `schedulerKey` doubles as a discriminator: each scheduler claims its
+// own row. That lets billing run on pod A while audit-export runs on
+// pod B, instead of forcing all schedulers onto a single leader pod.
+model SchedulerLeaderLease {
+  schedulerKey String   @id @map("scheduler_key")
+  leaderId     String   @map("leader_id")
+  acquiredAt   DateTime @map("acquired_at")
+  expiresAt    DateTime @map("expires_at")
+  updatedAt    DateTime @updatedAt
+
+  @@map("scheduler_leader_lease")
+}
+
+// Per-org concurrent-deployment counter.
+//
+// COUNT(*) on AkashDeployment + PhalaDeployment is racy under concurrent
+// launches: two requests both see 9/10 active, both insert, both succeed
+// → org now has 11 active. The counter row is the source of truth for
+// "claim a concurrency slot" — increments are guarded by SELECT FOR
+// UPDATE inside a transaction, so concurrent claimants serialize.
+//
+// `activeCount` MAY drift from the actual deployment count if a close
+// path forgets to decrement. The hourly reconciler in
+// `concurrencyService.reconcileAll()` recomputes from the deployments
+// table and clamps drift before it accumulates into a permanent over-
+// count that locks the org out of new launches.
+model OrganizationConcurrencyCounter {
+  organizationId String   @id @map("organization_id")
+  activeCount    Int      @default(0) @map("active_count")
+  updatedAt      DateTime @updatedAt
+
+  @@map("organization_concurrency_counter")
+}
+
+// Write-ahead ledger for deployment settlement charges (pre-close prorated
+// debits, hourly accrual, etc.). Every settlement debit MUST be reflected
+// here BEFORE the auth-side computeDebit is invoked, so a crash between
+// "advance local state" and "auth credited the charge" is recoverable:
+//
+//   * PENDING row exists, no auth charge → reconciler retries the debit
+//     using the row's stored idempotencyKey + amountCents (deterministic).
+//   * PENDING row exists, auth charge already landed → reconciler retries
+//     get alreadyProcessed=true, row promotes to COMMITTED.
+//   * Persistent failure → row marked FAILED, ops paged.
+//
+// The idempotencyKey column is UNIQUE so the table doubles as a duplicate-
+// charge guard: even a buggy caller cannot insert two rows for the same
+// settlement window and end up double-billing the user.
+model PolicySettlementLedger {
+  id              String                  @id @default(cuid())
+
+  provider        SettlementProvider
+  kind            SettlementKind
+  deploymentRef   String                  @map("deployment_ref")
+
+  idempotencyKey  String                  @unique @map("idempotency_key")
+
+  orgBillingId    String                  @map("org_billing_id")
+  amountCents     Int                     @map("amount_cents")
+  settledTo       DateTime                @map("settled_to")
+
+  status          PolicySettlementStatus  @default(PENDING)
+  attemptCount    Int                     @default(0) @map("attempt_count")
+  lastError       String?                 @map("last_error")
+  committedAt     DateTime?               @map("committed_at")
+
+  policyId        String?                 @map("policy_id")
+  metadata        Json?
+
+  createdAt       DateTime                @default(now())
+  updatedAt       DateTime                @updatedAt
+
+  @@index([status, createdAt])
+  @@index([deploymentRef])
+  @@map("policy_settlement_ledger")
+}
+
+enum SettlementProvider {
+  AKASH
+  PHALA
+}
+
+enum SettlementKind {
+  FINAL_SETTLEMENT
+  HOURLY_ACCRUAL
+}
+
+enum PolicySettlementStatus {
+  PENDING
+  COMMITTED
+  FAILED
+}
+
 enum EscrowStatus {
-  ACTIVE      // Funds locked, daily consumption active
-  DEPLETED    // Escrow consumed, needs top-up or auto-top-up from wallet
-  REFUNDED    // Deployment closed, remaining refunded to wallet
-  PAUSED      // Deployment paused due to low org balance
+  PENDING_DEPOSIT // Write-ahead: row created BEFORE the deposit RPC.
+                  // Reconciler retries / fails-out stuck rows so we never end up
+                  // in a state where the wallet was debited but no row exists
+                  // (or vice-versa: the row was created but the deposit failed).
+  ACTIVE          // Funds locked, daily consumption active
+  DEPLETED        // Escrow consumed, needs top-up or auto-top-up from wallet
+  REFUNDING       // Write-ahead for refund: row marked BEFORE the
+                  // refund RPC so we can reconcile if the credit RPC succeeded
+                  // but our local update never landed.
+  REFUNDED        // Deployment closed, remaining refunded to wallet
+  PAUSED          // Deployment paused due to low org balance
+  FAILED          // Terminal: write-ahead deposit could not be
+                  // completed (insufficient balance, persistent RPC failure).
 }
 
 model DeploymentEscrow {

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,8 @@ import {
   handlePolicyWebhook,
 } from './services/queue/index.js'
 import { startStaleDeploymentSweeper, stopStaleDeploymentSweeper } from './services/queue/staleDeploymentSweeper.js'
+import { runWithLeadership, stopAllLeaderSchedulers } from './services/leader/leaderElection.js'
+import { setWalletMutexPrisma } from './services/akash/walletMutex.js'
 import { ProviderRegistryScheduler } from './services/providers/providerRegistryScheduler.js'
 import { ProviderVerificationScheduler } from './services/providers/providerVerificationScheduler.js'
 import { AuditExportScheduler } from './services/audit/auditExportScheduler.js'
@@ -379,19 +381,52 @@ server.on('upgrade', async (request, socket, head) => {
 
 const port = process.env.PORT || 1602
 
-server.listen(port, () => {
+server.listen(port, async () => {
   log.info({ port, graphql: `/graphql`, ws: `/ws` }, 'server started')
 
-  storageSnapshotScheduler.start()
-  invoiceScheduler.start()
+  // Hand the shared Prisma client to walletMutex so the cross-replica
+  // pg_advisory_xact_lock has a connection to use. Must run before any
+  // chain TX is fired.
+  setWalletMutexPrisma(prisma)
+
+  // Singleton schedulers run under a leader lease so REPLICAS > 1 is
+  // safe. The Akash provider verifier and audit exporter are still
+  // best-effort even if leadership flips between pods because both are
+  // idempotent / cron-style.
+  await runWithLeadership(prisma, 'storage-snapshot', {
+    onAcquire: () => storageSnapshotScheduler.start(),
+    onRelease: () => storageSnapshotScheduler.stop(),
+  })
+  await runWithLeadership(prisma, 'invoice-scheduler', {
+    onAcquire: () => invoiceScheduler.start(),
+    onRelease: () => invoiceScheduler.stop(),
+  })
+  await runWithLeadership(prisma, 'compute-billing-scheduler', {
+    onAcquire: () => computeBillingScheduler.start(),
+    onRelease: () => computeBillingScheduler.stop(),
+  })
+  await runWithLeadership(prisma, 'escrow-health-monitor', {
+    onAcquire: () => escrowHealthMonitor.start(),
+    onRelease: () => escrowHealthMonitor.stop(),
+  })
+  await runWithLeadership(prisma, 'provider-registry-scheduler', {
+    onAcquire: () => providerRegistryScheduler.start(),
+    onRelease: () => providerRegistryScheduler.stop(),
+  })
+  await runWithLeadership(prisma, 'audit-export-scheduler', {
+    onAcquire: () => auditExportScheduler.start(),
+    onRelease: () => auditExportScheduler.stop(),
+  })
+  await runWithLeadership(prisma, 'provider-verification-scheduler', {
+    onAcquire: () => providerVerificationScheduler.start(),
+    onRelease: () => providerVerificationScheduler.stop(),
+  })
+
+  // Per-pod work (no chain TXs / no row-mutating singletons): runs
+  // unconditionally on every replica.
   usageAggregator.start()
-  computeBillingScheduler.start()
-  escrowHealthMonitor.start()
-  providerRegistryScheduler.start()
-  auditExportScheduler.start()
-  providerVerificationScheduler.start()
   telemetryIngestionService.start()
-  log.info('billing + provider registry + verification schedulers started')
+  log.info('billing + provider registry + verification schedulers started (leader-gated)')
 
   startSslRenewalJob()
   log.info('SSL renewal job started')
@@ -410,20 +445,22 @@ server.listen(port, () => {
   orchestrator.resumeDeployingDeployments()
   orchestrator.resumePendingBackfills()
 
-  startStaleDeploymentSweeper(prisma)
+  // Stale sweeper writes terminal-state rows + drives close TXs, so
+  // it MUST be a singleton across replicas.
+  await runWithLeadership(prisma, 'stale-deployment-sweeper', {
+    onAcquire: () => startStaleDeploymentSweeper(prisma),
+    onRelease: () => stopStaleDeploymentSweeper(),
+  })
+
   healthPrewarmerInterval = startHealthPrewarmer(prisma)
   startApplicationHealthRunner(prisma)
 })
 
 async function gracefulShutdown(signal: string) {
   log.info({ signal }, 'shutting down')
-  storageSnapshotScheduler.stop()
-  invoiceScheduler.stop()
-  computeBillingScheduler.stop()
-  escrowHealthMonitor.stop()
-  providerRegistryScheduler.stop()
-  providerVerificationScheduler.stop()
-  auditExportScheduler.stop()
+  // Releases every leader lease (so a standby pod takes over within
+  // its next poll) AND calls each scheduler's stop hook.
+  await stopAllLeaderSchedulers(prisma)
   if (healthPrewarmerInterval) clearInterval(healthPrewarmerInterval)
   stopApplicationHealthRunner()
 
@@ -433,7 +470,8 @@ async function gracefulShutdown(signal: string) {
   }, 15_000)
   forceExitTimeout.unref()
 
-  // Wait for in-flight sweep before closing connections
+  // Wait for in-flight sweep before closing connections (the sweeper's
+  // own onRelease was already called by stopAllLeaderSchedulers).
   await stopStaleDeploymentSweeper()
 
   server.close(async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import {
 import { startSslRenewalJob } from './jobs/sslRenewal.js'
 import depthLimit from 'graphql-depth-limit'
 import { createComplexityLimitRule } from 'graphql-validation-complexity'
+import { NoSchemaIntrospectionCustomRule } from 'graphql/validation/index.js'
 import helmet from 'helmet'
 import { initInfisical } from './config/infisical.js'
 import { SubdomainProxy } from './services/proxy/subdomainProxy.js'
@@ -100,7 +101,16 @@ const MAX_DEPTH = 10
 // exceed conservative complexity limits in development.
 const MAX_COMPLEXITY = 15000
 
-// Custom plugin to add validation rules for depth and complexity limits
+const IS_PRODUCTION = process.env.NODE_ENV === 'production'
+// Allow staging/internal envs to keep introspection (e.g. for SDK codegen
+// against staging) by setting GRAPHQL_FORCE_ENABLE_INTROSPECTION=true.
+// In production, default is to *block* introspection to reduce schema
+// fingerprinting and to keep the GraphiQL landing page off.
+const ALLOW_INTROSPECTION =
+  !IS_PRODUCTION || process.env.GRAPHQL_FORCE_ENABLE_INTROSPECTION === 'true'
+
+// Custom plugin to add validation rules for depth, complexity, and (in prod)
+// introspection blocking.
 const useValidationRules = (): Plugin => {
   return {
     onValidate({ addValidationRule }) {
@@ -112,17 +122,54 @@ const useValidationRules = (): Plugin => {
           listFactor: 10,
         })
       )
+      if (!ALLOW_INTROSPECTION) {
+        addValidationRule(NoSchemaIntrospectionCustomRule)
+      }
     },
   }
 }
 
 const gqlLog = createLogger('graphql')
 
+/**
+ * Defensive redactor for the GraphQL query body before it lands in the log.
+ *
+ * Tokens / secrets should never appear in a query string (they belong in
+ * HTTP headers or variables, neither of which we log) but a buggy client
+ * could embed one as a string literal. We strip the patterns we know about
+ * so a single misbehaving caller can't leak a credential to our log
+ * pipeline.
+ *
+ * Patterns covered:
+ *  - AlternateFutures personal access tokens: `af_live_…`, `af_test_…`
+ *    (see service-auth/src/services/token.service.ts:129)
+ *  - JWT shaped tokens: `eyJ…\.eyJ…\.[A-Za-z0-9_-]+`
+ *  - Bearer tokens: `Bearer <opaque>`
+ *  - Stripe-style keys: `(sk|pk|rk)_(live|test)_…`
+ *  - OpenAI/Anthropic-style keys: `sk-[A-Za-z0-9_-]{20,}`
+ */
+const TOKEN_REDACTORS: Array<{ pattern: RegExp; replacement: string }> = [
+  { pattern: /af_(live|test)_[A-Za-z0-9]{8,}/g, replacement: 'af_$1_<redacted>' },
+  { pattern: /eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g, replacement: '<jwt:redacted>' },
+  { pattern: /Bearer\s+[A-Za-z0-9._\-]+/gi, replacement: 'Bearer <redacted>' },
+  { pattern: /(?<![A-Za-z0-9])(sk|pk|rk)_(live|test)_[A-Za-z0-9]{10,}/g, replacement: '$1_$2_<redacted>' },
+  { pattern: /(?<![A-Za-z0-9])sk-[A-Za-z0-9_-]{20,}/g, replacement: 'sk-<redacted>' },
+]
+
+function redactQueryForLogging(input: string): string {
+  let out = input
+  for (const { pattern, replacement } of TOKEN_REDACTORS) {
+    out = out.replace(pattern, replacement)
+  }
+  return out
+}
+
 const useLogging = (): Plugin => {
   return {
     onExecute({ args }) {
       const operationName = args.operationName || 'anonymous'
-      const query = args.document?.loc?.source?.body?.substring(0, 300) || 'unknown'
+      const rawQuery = args.document?.loc?.source?.body?.substring(0, 300) || 'unknown'
+      const query = redactQueryForLogging(rawQuery)
       gqlLog.info({ operationName, query }, 'executing operation')
     },
     onResultProcess({ result }) {
@@ -149,8 +196,12 @@ const yoga = createYoga({
     credentials: true,
   },
   graphqlEndpoint: '/graphql',
-  landingPage: true,
-  maskedErrors: process.env.NODE_ENV === 'production',
+  // In production, hide the GraphiQL landing page so unauthenticated users
+  // browsing /graphql see a plain HTTP error rather than a UI that hints at
+  // schema shape / sample queries. Yoga still serves the JSON API.
+  landingPage: !IS_PRODUCTION,
+  graphiql: !IS_PRODUCTION,
+  maskedErrors: IS_PRODUCTION,
   plugins: [useValidationRules(), useLogging()],
 })
 

--- a/src/resolvers/akash.ts
+++ b/src/resolvers/akash.ts
@@ -12,6 +12,7 @@ import { settleAkashEscrowToTime } from '../services/billing/deploymentSettlemen
 import { assertSubscriptionActive } from './subscriptionCheck.js'
 import { assertDeployBalance, checkTimeLimitedDeployBalance } from './balanceCheck.js'
 import { assertLaunchAllowed } from './launchGuards.js'
+import { decrementOrgConcurrency } from '../services/concurrency/concurrencyService.js'
 import type { Context } from './types.js'
 import { requireAuth, assertProjectAccess } from '../utils/authorization.js'
 import { createLogger } from '../lib/logger.js'
@@ -622,6 +623,15 @@ export const akashMutations = {
           dseq: deployment.dseq?.toString() ?? null,
         },
       })
+      // SUSPENDED already released the slot in the billing scheduler;
+      // calling again is a no-op thanks to the GREATEST(0, …) clamp,
+      // but we do it for paranoia in case scheduler decrement was lost.
+      await decrementOrgConcurrency(
+        context.prisma,
+        deployment.service.project.organizationId,
+      ).catch((err) => {
+        log.warn({ err, deploymentId: id }, 'Concurrency decrement failed (SUSPENDED→CLOSED)')
+      })
       return formatDeployment(updated)
     }
 
@@ -703,6 +713,13 @@ export const akashMutations = {
         data: { stopReason: 'MANUAL_STOP', stoppedAt: closedAt, reservedCents: 0 },
       })
     }
+
+    await decrementOrgConcurrency(
+      context.prisma,
+      deployment.service.project.organizationId,
+    ).catch((err) => {
+      log.warn({ err, deploymentId: id }, 'Concurrency decrement failed (manual close)')
+    })
 
     // Cancel any in-progress sibling/retry deployments for the same service
     const IN_PROGRESS = ['CREATING', 'WAITING_BIDS', 'SELECTING_BID', 'CREATING_LEASE', 'SENDING_MANIFEST', 'DEPLOYING'] as const

--- a/src/resolvers/launchGuards.ts
+++ b/src/resolvers/launchGuards.ts
@@ -34,6 +34,14 @@ import { GraphQLError } from 'graphql'
 import type { PrismaClient } from '@prisma/client'
 import type { SubscriptionStatusInfo } from './subscriptionCheck.js'
 import { opsAlert } from '../lib/opsAlert.js'
+import {
+  assertAndIncrementOrgConcurrency,
+  ConcurrencyCapExceededError,
+  recomputeOrgConcurrency,
+} from '../services/concurrency/concurrencyService.js'
+import { createLogger } from '../lib/logger.js'
+
+const concLog = createLogger('launch-guards-concurrency')
 
 /**
  * How long between disabled-guard alerts (per process). The guard being off is
@@ -219,41 +227,82 @@ export async function assertOrgConcurrency(
     return
   }
 
-  const [akashActive, phalaActive] = await Promise.all([
-    prisma.akashDeployment.count({
-      where: {
-        status: { in: ['CREATING', 'WAITING_BIDS', 'SELECTING_BID', 'CREATING_LEASE', 'SENDING_MANIFEST', 'DEPLOYING', 'ACTIVE'] },
-        service: { project: { organizationId } },
-      },
-    }),
-    prisma.phalaDeployment.count({
-      where: {
-        status: { in: ['CREATING', 'STARTING', 'ACTIVE'] },
-        organizationId,
-      },
-    }),
-  ])
+  // Counter-based claim. The concurrency service handles the
+  // SELECT FOR UPDATE inside a transaction, so two concurrent launches
+  // serialize and only the second one (under the cap) succeeds. The
+  // counter must be released by the close paths via
+  // `decrementOrgConcurrency` — see `services/concurrency` for the
+  // reconciler that catches missed decrements.
+  try {
+    await assertAndIncrementOrgConcurrency(prisma, organizationId, cap)
+  } catch (err) {
+    if (err instanceof ConcurrencyCapExceededError) {
+      const upgradeHint = tier === 'trial'
+        ? ' Subscribe to a paid plan for a higher limit.'
+        : ' Close some before launching more, or contact support to raise your limit.'
 
-  const total = akashActive + phalaActive
-  if (total >= cap) {
-    const upgradeHint = tier === 'trial'
-      ? ' Subscribe to a paid plan for a higher limit.'
-      : ' Close some before launching more, or contact support to raise your limit.'
-
-    throw new GraphQLError(
-      `You have ${total} active deployments, which is at the current limit of ${cap} for your ${tier} plan.${upgradeHint}`,
-      {
-        extensions: {
-          code: 'CONCURRENCY_LIMIT_REACHED',
-          tier,
-          activeDeployments: total,
-          maxActiveDeployments: cap,
-          akashActive,
-          phalaActive,
-          upgradeable: tier === 'trial',
+      throw new GraphQLError(
+        `You have ${err.activeCount} active deployments, which is at the current limit of ${cap} for your ${tier} plan.${upgradeHint}`,
+        {
+          extensions: {
+            code: 'CONCURRENCY_LIMIT_REACHED',
+            tier,
+            activeDeployments: err.activeCount,
+            maxActiveDeployments: cap,
+            upgradeable: tier === 'trial',
+          },
         },
-      },
+      )
+    }
+    // Counter row poisoned (e.g. a stale value from before the
+    // reconciler's first run). Bootstrap from real deployments and let
+    // the next attempt go through. We do NOT block the launch on a
+    // counter-internal error — the legacy COUNT(*) check below is the
+    // safety net that still enforces a (racy but conservative) cap.
+    concLog.error(
+      { organizationId, err },
+      'Concurrency counter check failed — falling back to COUNT(*)',
     )
+    try {
+      await recomputeOrgConcurrency(prisma, organizationId)
+    } catch (recErr) {
+      concLog.error({ organizationId, recErr }, 'Recompute failed too — proceeding with raw count')
+    }
+
+    const [akashActive, phalaActive] = await Promise.all([
+      prisma.akashDeployment.count({
+        where: {
+          status: { in: ['CREATING', 'WAITING_BIDS', 'SELECTING_BID', 'CREATING_LEASE', 'SENDING_MANIFEST', 'DEPLOYING', 'ACTIVE'] },
+          service: { project: { organizationId } },
+        },
+      }),
+      prisma.phalaDeployment.count({
+        where: {
+          status: { in: ['CREATING', 'STARTING', 'ACTIVE'] },
+          organizationId,
+        },
+      }),
+    ])
+    const total = akashActive + phalaActive
+    if (total >= cap) {
+      const upgradeHint = tier === 'trial'
+        ? ' Subscribe to a paid plan for a higher limit.'
+        : ' Close some before launching more, or contact support to raise your limit.'
+      throw new GraphQLError(
+        `You have ${total} active deployments, which is at the current limit of ${cap} for your ${tier} plan.${upgradeHint}`,
+        {
+          extensions: {
+            code: 'CONCURRENCY_LIMIT_REACHED',
+            tier,
+            activeDeployments: total,
+            maxActiveDeployments: cap,
+            akashActive,
+            phalaActive,
+            upgradeable: tier === 'trial',
+          },
+        },
+      )
+    }
   }
 }
 

--- a/src/resolvers/phala.ts
+++ b/src/resolvers/phala.ts
@@ -7,6 +7,7 @@ import { processFinalPhalaBilling } from '../services/billing/deploymentSettleme
 import { assertSubscriptionActive } from './subscriptionCheck.js'
 import { assertDeployBalance, checkTimeLimitedDeployBalance } from './balanceCheck.js'
 import { assertLaunchAllowed } from './launchGuards.js'
+import { decrementOrgConcurrency } from '../services/concurrency/concurrencyService.js'
 import { BILLING_CONFIG } from '../config/billing.js'
 import { resolvePhalaInstanceType } from '../services/phala/instanceTypes.js'
 import { validatePolicyInput } from '../services/policy/validator.js'
@@ -590,6 +591,13 @@ export const phalaMutations = {
         data: { stopReason: 'MANUAL_STOP', stoppedAt, reservedCents: 0 },
       })
     }
+
+    await decrementOrgConcurrency(
+      context.prisma,
+      deployment.organizationId,
+    ).catch((err) => {
+      log.warn({ err, deploymentId: id }, 'Concurrency decrement failed (Phala manual stop)')
+    })
 
     audit(context.prisma, {
       category: 'deployment',

--- a/src/resolvers/subscriptionCheck.ts
+++ b/src/resolvers/subscriptionCheck.ts
@@ -36,11 +36,37 @@ export async function assertSubscriptionActive(
     const client = getBillingApiClient()
     const status = await client.getSubscriptionStatus(organizationId)
 
-    if (status.status === 'SUSPENDED') {
-      throw new GraphQLError(
-        'Your subscription is suspended. Please subscribe to continue deploying.',
-        { extensions: { code: 'SUBSCRIPTION_SUSPENDED' } },
-      )
+    // Block all states where the org has no current entitlement to deploy.
+    // service-auth returns one of: ACTIVE, TRIALING, TRIAL_EXPIRED, SUSPENDED,
+    // PAST_DUE, CANCELED. Any state other than ACTIVE/TRIALING (and
+    // TRIAL_EXPIRED while still inside the 3-day grace window) means we
+    // should not start new deployments — otherwise we keep accruing infra
+    // cost against an org that cannot legally be billed.
+    switch (status.status) {
+      case 'SUSPENDED':
+        throw new GraphQLError(
+          'Your subscription is suspended. Please contact support to continue deploying.',
+          { extensions: { code: 'SUBSCRIPTION_SUSPENDED' } },
+        )
+      case 'PAST_DUE':
+        throw new GraphQLError(
+          'Your last payment failed. Please update your payment method to continue deploying.',
+          { extensions: { code: 'SUBSCRIPTION_PAST_DUE' } },
+        )
+      case 'CANCELED':
+        throw new GraphQLError(
+          'Your subscription has been canceled. Please re-subscribe to continue deploying.',
+          { extensions: { code: 'SUBSCRIPTION_CANCELED' } },
+        )
+      case 'TRIAL_EXPIRED':
+        if ((status.graceRemaining ?? 0) <= 0) {
+          throw new GraphQLError(
+            'Your trial has expired. Please subscribe to continue deploying.',
+            { extensions: { code: 'TRIAL_EXPIRED' } },
+          )
+        }
+        break
+      // ACTIVE, TRIALING, TRIAL_EXPIRED-within-grace fall through.
     }
 
     return status

--- a/src/services/akash/orchestrator.ts
+++ b/src/services/akash/orchestrator.ts
@@ -99,6 +99,212 @@ async function runAkashAsync(args: string[], timeout = AKASH_CLI_TIMEOUT_MS): Pr
   return invoke()
 }
 
+// ── Cosmos chain transaction helpers ─────────────────────────────────
+//
+// Every call to `akash tx <subcommand> ...` returns a JSON envelope of
+// the form:
+//
+//   {
+//     "code": 0,             // 0 = ABCI accepted, non-zero = chain rejected
+//     "txhash": "...",       // tx hash; tx may still be pending inclusion
+//     "raw_log": "...",      // human-readable error message when code != 0
+//     "logs": [...],         // populated when broadcast mode = block
+//     "height": "12345"      // populated only after block inclusion
+//   }
+//
+// Historically each call site parsed this envelope inline, often
+// silently treating "broadcast OK but chain rejected" as success.
+// That class of bug — a `tx market lease create` that returned
+// `code != 0` (e.g. bid taken by another lease, account-sequence
+// mismatch) would happily proceed to the next step
+// and mysteriously fail in a totally different place (manifest send,
+// service URLs, etc.) hours later — with no telemetry pointing back
+// to the rejected chain tx.
+//
+// `runAkashTxAsync` is the ONE entry-point for chain submissions:
+//   1. forwards through the wallet mutex (via runAkashAsync)
+//   2. parses the JSON envelope strictly
+//   3. asserts code === 0 (throws AkashTxRejectedError otherwise)
+//   4. waits for block inclusion by querying `akash query tx` if the
+//      broadcast didn't already include it (sync-mode broadcasts).
+//
+// CI gate: `tools/check-no-raw-akash-tx.mjs` (also a vitest spec)
+// prevents any new `runAkashAsync(['tx', ...])` call site from
+// landing without going through this helper.
+
+/**
+ * Outcome of an Akash on-chain deployment close. See
+ * `AkashOrchestrator.closeDeployment` for semantics.
+ */
+export type CloseDeploymentResult =
+  | { chainStatus: 'CLOSED'; txhash: string }
+  | { chainStatus: 'ALREADY_CLOSED'; reason: string }
+  | { chainStatus: 'FAILED'; error: string }
+
+/**
+ * Substrings the Akash chain returns when a close was a no-op
+ * because the deployment is already gone (closed by the provider,
+ * never created, expired). Caller can safely treat these as success.
+ */
+const CLOSE_ALREADY_GONE_PATTERNS =
+  /deployment closed|deployment not found|not active|does not exist|already closed/i
+
+export class AkashTxRejectedError extends Error {
+  readonly op: string
+  readonly code: number
+  readonly rawLog: string
+  readonly txhash?: string
+  constructor(op: string, code: number, rawLog: string, txhash?: string) {
+    super(`${op}: tx rejected on-chain (code ${code}): ${rawLog.slice(0, 300)}`)
+    this.name = 'AkashTxRejectedError'
+    this.op = op
+    this.code = code
+    this.rawLog = rawLog
+    this.txhash = txhash
+  }
+}
+
+function parseTxCode(raw: unknown): number {
+  if (typeof raw === 'number') return raw
+  if (typeof raw === 'string') {
+    const parsed = parseInt(raw, 10)
+    return Number.isFinite(parsed) ? parsed : 0
+  }
+  return 0
+}
+
+const TX_INCLUSION_DELAYS_MS = [6000, 6000, 8000, 8000, 8000]
+
+/**
+ * Wait for a broadcast tx to be included in a block. Returns the
+ * full `akash query tx` JSON once it's available. Throws if the
+ * indexer never returns the tx (RPC lag, dropped from mempool, etc.).
+ */
+async function waitForTxInclusion(
+  txhash: string,
+  op: string,
+): Promise<Record<string, unknown>> {
+  for (const delay of TX_INCLUSION_DELAYS_MS) {
+    await new Promise(r => setTimeout(r, delay))
+    try {
+      const txOutput = runAkash(
+        ['query', 'tx', txhash, '-o', 'json'],
+        15_000,
+      )
+      const txResult = extractJson(txOutput) as Record<string, unknown>
+      const txCode = parseTxCode(txResult.code)
+      if (txCode !== 0) {
+        // Tx made it on-chain but the deliver-tx phase rejected it.
+        const rawLog = (txResult.raw_log || txResult.rawLog || '') as string
+        throw new AkashTxRejectedError(op, txCode, rawLog, txhash)
+      }
+      return txResult
+    } catch (err) {
+      if (err instanceof AkashTxRejectedError) throw err
+      log.warn(
+        `${op}: tx ${txhash} inclusion poll failed, retrying: ${
+          (err as Error).message?.slice(0, 120)
+        }`,
+      )
+    }
+  }
+  throw new Error(
+    `${op}: tx ${txhash} not found after ${TX_INCLUSION_DELAYS_MS.length} polls — RPC indexer may be lagging`,
+  )
+}
+
+export interface AkashTxResult {
+  /** Hash of the broadcast transaction. */
+  txhash: string
+  /** Raw broadcast envelope (code, raw_log, logs, height). */
+  broadcast: Record<string, unknown>
+  /**
+   * Confirmed envelope from `akash query tx <hash>`. Populated even
+   * for sync-mode broadcasts where the broadcast envelope itself was
+   * empty. Same shape as `broadcast` once the chain has indexed it.
+   */
+  confirmed: Record<string, unknown>
+}
+
+/**
+ * Broadcast a chain tx through the wallet mutex, assert acceptance,
+ * and wait for block inclusion.
+ *
+ * Every Akash `tx ...` call site MUST go through this helper.
+ */
+export async function runAkashTxAsync(
+  args: string[],
+  ctx: { op: string; meta?: Record<string, unknown> },
+  timeout = AKASH_CLI_TIMEOUT_MS,
+): Promise<AkashTxResult> {
+  if (args[0] !== 'tx') {
+    throw new Error(
+      `runAkashTxAsync called with non-tx args (op=${ctx.op}): ${args.join(' ')}`,
+    )
+  }
+  // Force JSON output and auto-confirm so callers can't accidentally
+  // forget. Tolerate the flags already being present.
+  const finalArgs = [...args]
+  if (!finalArgs.includes('-o')) finalArgs.push('-o', 'json')
+  if (!finalArgs.includes('-y')) finalArgs.push('-y')
+
+  const output = await runAkashAsync(finalArgs, timeout)
+
+  let broadcast: Record<string, unknown>
+  try {
+    broadcast = extractJson(output) as Record<string, unknown>
+  } catch (err) {
+    throw new Error(
+      `${ctx.op}: tx broadcast returned unparseable output: ${
+        (err as Error).message
+      }`,
+    )
+  }
+
+  const txhash = broadcast.txhash as string | undefined
+  const code = parseTxCode(broadcast.code)
+  if (code !== 0) {
+    const rawLog = (broadcast.raw_log || broadcast.rawLog || '') as string
+    log.error(
+      { op: ctx.op, code, txhash, rawLog: rawLog.slice(0, 200), ...ctx.meta },
+      `${ctx.op}: chain rejected tx`,
+    )
+    throw new AkashTxRejectedError(ctx.op, code, rawLog, txhash)
+  }
+  if (!txhash) {
+    throw new Error(`${ctx.op}: tx accepted but broadcast envelope had no txhash`)
+  }
+
+  // If broadcast envelope already contains inclusion data (block-mode
+  // broadcasts), short-circuit the inclusion wait.
+  const heightStr = broadcast.height as string | number | undefined
+  const height =
+    typeof heightStr === 'number'
+      ? heightStr
+      : typeof heightStr === 'string'
+        ? parseInt(heightStr, 10)
+        : 0
+  if (height > 0) {
+    log.info(
+      { op: ctx.op, txhash, height, ...ctx.meta },
+      `${ctx.op}: tx accepted in block ${height}`,
+    )
+    return { txhash, broadcast, confirmed: broadcast }
+  }
+
+  const confirmed = await waitForTxInclusion(txhash, ctx.op)
+  log.info(
+    {
+      op: ctx.op,
+      txhash,
+      height: confirmed.height,
+      ...ctx.meta,
+    },
+    `${ctx.op}: tx included in block`,
+  )
+  return { txhash, broadcast, confirmed }
+}
+
 /**
  * Run provider-services CLI (used for manifest sending and lease operations).
  * Falls back to akash CLI if provider-services is not available.
@@ -238,51 +444,37 @@ export class AkashOrchestrator {
     deposit: number
   ): Promise<{ dseq: number; owner: string }> {
     log.info('Creating deployment...')
-    const output = await runAkashAsync([
-      'tx',
-      'deployment',
-      'create',
-      sdlPath,
-      '--deposit',
-      `${deposit}uact`,
-      '-o',
-      'json',
-      '-y',
-    ])
-
-    const result = extractJson(output) as Record<string, unknown>
+    const { broadcast, confirmed, txhash } = await runAkashTxAsync(
+      [
+        'tx', 'deployment', 'create', sdlPath,
+        '--deposit', `${deposit}uact`,
+      ],
+      { op: 'createDeployment', meta: { deposit } },
+    )
     log.info(
-      `createDeployment broadcast result: code=${result.code}, txhash=${result.txhash}, has_logs=${!!(result.logs as unknown[])?.length}`
+      `createDeployment tx confirmed: txhash=${txhash}, height=${confirmed.height}`,
     )
 
-    // Tx was broadcast but rejected by the mempool (e.g. account sequence mismatch from rapid re-deploys)
-    const txCode =
-      typeof result.code === 'number'
-        ? result.code
-        : typeof result.code === 'string'
-          ? parseInt(result.code, 10)
-          : undefined
-    if (txCode !== undefined && txCode !== 0) {
-      const rawLog = (result.raw_log || result.rawLog || '') as string
-      throw new Error(
-        `Akash tx rejected (code ${txCode}): ${rawLog.slice(0, 300)}`
-      )
-    }
-
-    // Parse dseq from transaction response (populated in block broadcast mode)
-    const logs = result.logs as
-      | Array<{
-          events?: Array<{
-            type: string
-            attributes?: Array<{ key: string; value: string }>
-          }>
-        }>
-      | undefined
+    // Walk both broadcast and confirmed envelopes for the dseq —
+    // different akash CLI versions populate different shapes:
+    //   * block-mode broadcast → broadcast.logs[].events[]
+    //   * sync-mode broadcast  → confirmed.logs[].events[]
+    //   * akash CLI v1.1.1+    → confirmed.tx.body.messages[0].id.dseq
+    const candidates: Record<string, unknown>[] = [broadcast, confirmed]
     let dseq: number | undefined
-
-    if (logs) {
-      for (const log of logs) {
-        for (const event of log.events || []) {
+    for (const candidate of candidates) {
+      if (dseq) break
+      const logs = candidate.logs as
+        | Array<{
+            events?: Array<{
+              type: string
+              attributes?: Array<{ key: string; value: string }>
+            }>
+          }>
+        | undefined
+      if (!logs) continue
+      for (const entry of logs) {
+        for (const event of entry.events || []) {
           if (
             event.type === 'akash.deployment.v1.EventDeploymentCreated' ||
             event.type === 'akash.v1beta3.EventDeploymentCreated' ||
@@ -291,80 +483,31 @@ export class AkashOrchestrator {
             const dseqAttr = event.attributes?.find(a => a.key === 'dseq')
             if (dseqAttr) {
               dseq = parseInt(dseqAttr.value, 10)
-            }
-          }
-        }
-      }
-    }
-
-    // Fallback: query the confirmed tx by hash (sync mode doesn't include logs)
-    if (!dseq && result.txhash) {
-      let txResult: Record<string, unknown> | null = null
-      const delays = [8000, 6000, 6000, 8000, 8000] // ~36s total; block time ~6s + indexer lag
-      for (const delay of delays) {
-        await new Promise(r => setTimeout(r, delay))
-        try {
-          const txOutput = runAkash(
-            ['query', 'tx', result.txhash as string, '-o', 'json'],
-            15_000
-          )
-          txResult = extractJson(txOutput) as Record<string, unknown>
-          break
-        } catch (err) {
-          log.warn(
-            `tx query attempt failed, retrying: ${(err as Error).message?.slice(0, 120)}`
-          )
-        }
-      }
-      if (!txResult) {
-        throw new Error(
-          `Transaction ${result.txhash} not found after retries — RPC may be lagging`
-        )
-      }
-
-      // Try logs first (older CLI versions)
-      const txLogs = txResult.logs as
-        | Array<{
-            events?: Array<{
-              type: string
-              attributes?: Array<{ key: string; value: string }>
-            }>
-          }>
-        | undefined
-      if (txLogs) {
-        for (const log of txLogs) {
-          for (const event of log.events || []) {
-            const dseqAttr = event.attributes?.find(a => a.key === 'dseq')
-            if (dseqAttr) {
-              dseq = parseInt(dseqAttr.value, 10)
               break
             }
           }
-          if (dseq) break
         }
+        if (dseq) break
       }
+    }
 
-      // Fallback: parse dseq from tx.body.messages (akash CLI v1.1.1+ returns empty logs)
-      if (!dseq) {
-        const tx = txResult.tx as
-          | { body?: { messages?: Array<{ id?: { dseq?: string } }> } }
-          | undefined
-        const msgDseq = tx?.body?.messages?.[0]?.id?.dseq
-        if (msgDseq) {
-          dseq = parseInt(msgDseq, 10)
-          log.info(
-            `Parsed dseq from tx.body.messages: ${dseq}`
-          )
-        }
+    if (!dseq) {
+      const tx = confirmed.tx as
+        | { body?: { messages?: Array<{ id?: { dseq?: string } }> } }
+        | undefined
+      const msgDseq = tx?.body?.messages?.[0]?.id?.dseq
+      if (msgDseq) {
+        dseq = parseInt(msgDseq, 10)
+        log.info(`Parsed dseq from tx.body.messages: ${dseq}`)
       }
     }
 
     if (!dseq || isNaN(dseq) || dseq <= 0) {
-      const safeResult = JSON.stringify(result, (_k, v) =>
-        typeof v === 'bigint' ? v.toString() : v
+      const safeResult = JSON.stringify(confirmed, (_k, v) =>
+        typeof v === 'bigint' ? v.toString() : v,
       ).slice(0, 500)
       throw new Error(
-        `Failed to create deployment: could not extract dseq from response. Broadcast result: ${safeResult}`
+        `Failed to create deployment: could not extract dseq from confirmed tx. Confirmed: ${safeResult}`,
       )
     }
 
@@ -383,46 +526,15 @@ export class AkashOrchestrator {
   async topUpDeploymentDeposit(dseq: number, amountUact: number): Promise<void> {
     if (amountUact <= 0) return
     log.info({ dseq, amountUact }, 'Topping up deployment escrow')
-    const output = await runAkashAsync([
-      'tx',
-      'escrow',
-      'deposit',
-      'deployment',
-      `${amountUact}uact`,
-      '--dseq',
-      String(dseq),
-      '-y',
-      '-o', 'json',
-    ])
-
-    // A non-zero code here means the chain accepted the tx envelope but the
-    // state transition was rejected (e.g. insufficient wallet funds, unknown
-    // dseq, deployment already closed). We MUST throw so callers treat this as
-    // a failure — a silent return previously caused chain-escrow depletion to
-    // go unnoticed until the provider closed the lease.
-    let result: Record<string, unknown>
-    try {
-      result = extractJson(output) as Record<string, unknown>
-    } catch {
-      // Parse failure after a successful CLI invocation usually means the
-      // broadcast went through but stdout had trailing noise. Keep as warn.
-      log.warn({ dseq, amountUact }, 'Escrow top-up completed but could not parse TX response')
-      return
-    }
-
-    const code =
-      typeof result.code === 'number'
-        ? result.code
-        : typeof result.code === 'string'
-          ? parseInt(result.code, 10)
-          : 0
-    if (code !== 0) {
-      const rawLog = (result.raw_log || result.rawLog || '') as string
-      const msg = `Escrow top-up TX rejected on-chain (code ${code}): ${rawLog.slice(0, 300)}`
-      log.error({ dseq, amountUact, code, rawLog: rawLog.slice(0, 200) }, msg)
-      throw new Error(msg)
-    }
-    log.info({ dseq, amountUact, txhash: result.txhash }, 'Deployment escrow topped up')
+    const { txhash } = await runAkashTxAsync(
+      [
+        'tx', 'escrow', 'deposit', 'deployment',
+        `${amountUact}uact`,
+        '--dseq', String(dseq),
+      ],
+      { op: 'topUpDeploymentDeposit', meta: { dseq, amountUact } },
+    )
+    log.info({ dseq, amountUact, txhash }, 'Deployment escrow topped up')
   }
 
   /**
@@ -490,7 +602,16 @@ export class AkashOrchestrator {
   }
 
   /**
-   * Create a lease with a provider
+   * Create a lease with a provider.
+   *
+   * Goes through `runAkashTxAsync` so the chain's `code === 0`
+   * acceptance is asserted and the tx's block inclusion is awaited
+   * before we return. Previously this used a fire-and-forget
+   * `runAkashAsync` followed by a 6-second `setTimeout` which
+   * silently swallowed bid-taken / sequence-mismatch / insufficient-
+   * funds rejections — those then surfaced hours later as
+   * "manifest send failed" or "no service URLs" with no audit trail
+   * pointing back to the dropped tx.
    */
   async createLease(
     owner: string,
@@ -499,25 +620,19 @@ export class AkashOrchestrator {
     oseq: number,
     provider: string
   ): Promise<void> {
-    await runAkashAsync([
-      'tx',
-      'market',
-      'lease',
-      'create',
-      '--dseq',
-      String(dseq),
-      '--gseq',
-      String(gseq),
-      '--oseq',
-      String(oseq),
-      '--provider',
-      provider,
-      '-o',
-      'json',
-      '-y',
-    ])
-    // Wait for lease to be confirmed
-    await new Promise(r => setTimeout(r, 6000))
+    await runAkashTxAsync(
+      [
+        'tx',
+        'market',
+        'lease',
+        'create',
+        '--dseq', String(dseq),
+        '--gseq', String(gseq),
+        '--oseq', String(oseq),
+        '--provider', provider,
+      ],
+      { op: 'createLease', meta: { owner, dseq, gseq, oseq, provider } },
+    )
   }
 
   /**
@@ -818,47 +933,49 @@ export class AkashOrchestrator {
   /**
    * Close a deployment.
    *
-   * Throws if the chain rejects the tx (e.g. deployment already closed,
-   * deployment not found). Callers that tolerate benign "already gone" states
-   * match on the thrown message (which includes the chain's raw_log) using
-   * patterns like /deployment not found|deployment closed|not active|does not exist/.
+   * Returns a structured result so callers can distinguish:
+   *   * `CLOSED`         — chain accepted the close tx; the deployment
+   *                        is gone on-chain. Local row should go to CLOSED.
+   *   * `ALREADY_CLOSED` — chain rejected because the deployment is
+   *                        already closed / not found. Treated as
+   *                        idempotent success; local row should go to
+   *                        CLOSED with no escrow drain remaining.
+   *   * `FAILED`         — close attempt failed for environmental
+   *                        reasons (RPC down, wallet out of gas,
+   *                        account-sequence collision, etc.). The lease
+   *                        may still be live on-chain and continue to
+   *                        drain escrow until a retry succeeds. Local
+   *                        row SHOULD go to CLOSE_FAILED so the stale-
+   *                        deployment sweeper / ops will retry.
+   *
+   * Never throws — every chain or RPC error is captured in the returned
+   * `FAILED` result. The previous void return collapsed every outcome
+   * into "looks closed", masking stuck leases that kept billing.
    */
-  async closeDeployment(dseq: number): Promise<void> {
-    const output = await runAkashAsync([
-      'tx',
-      'deployment',
-      'close',
-      '--dseq',
-      String(dseq),
-      '-o',
-      'json',
-      '-y',
-    ])
-
-    let result: Record<string, unknown>
+  async closeDeployment(dseq: number): Promise<CloseDeploymentResult> {
     try {
-      result = extractJson(output) as Record<string, unknown>
-    } catch {
-      // CLI exited 0 but output was unparseable — treat as provisional success
-      // rather than block close paths. Downstream liveness reconciliation will
-      // catch any stuck-open deployment.
-      log.warn({ dseq }, 'Close TX completed but response could not be parsed')
-      return
+      const { txhash } = await runAkashTxAsync(
+        ['tx', 'deployment', 'close', '--dseq', String(dseq)],
+        { op: 'closeDeployment', meta: { dseq } },
+      )
+      log.info({ dseq, txhash }, 'Deployment close TX accepted')
+      return { chainStatus: 'CLOSED', txhash }
+    } catch (err) {
+      const error = err as Error
+      const message = error.message ?? String(err)
+      if (CLOSE_ALREADY_GONE_PATTERNS.test(message)) {
+        log.info(
+          { dseq, message: message.slice(0, 200) },
+          'closeDeployment: chain reports deployment already gone — treating as idempotent success',
+        )
+        return { chainStatus: 'ALREADY_CLOSED', reason: message.slice(0, 200) }
+      }
+      log.error(
+        { dseq, error: message.slice(0, 300) },
+        'closeDeployment: chain close failed — leaving lease open, caller MUST mark CLOSE_FAILED',
+      )
+      return { chainStatus: 'FAILED', error: message.slice(0, 300) }
     }
-
-    const code =
-      typeof result.code === 'number'
-        ? result.code
-        : typeof result.code === 'string'
-          ? parseInt(result.code, 10)
-          : 0
-    if (code !== 0) {
-      const rawLog = (result.raw_log || result.rawLog || '') as string
-      const msg = `Close TX rejected on-chain (code ${code}): ${rawLog.slice(0, 300)}`
-      log.error({ dseq, code, rawLog: rawLog.slice(0, 200) }, msg)
-      throw new Error(msg)
-    }
-    log.info({ dseq, txhash: result.txhash }, 'Deployment close TX accepted')
   }
 
   /**

--- a/src/services/akash/runAkashTxAsync.contract.test.ts
+++ b/src/services/akash/runAkashTxAsync.contract.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Contract / regression test for the `runAkashTxAsync` invariant.
+ *
+ * Akash chain-tx safety:
+ *
+ *   Every Akash chain-state transition (`akash tx <subcommand>`)
+ *   MUST go through `runAkashTxAsync`. That helper is the only path
+ *   that:
+ *     1. parses the broadcast envelope strictly,
+ *     2. asserts `code === 0` (chain acceptance),
+ *     3. waits for block inclusion and re-asserts `code === 0` on
+ *        the indexed tx.
+ *
+ *   Bypassing it (calling `runAkashAsync(['tx', ...])` directly,
+ *   shelling out to `execCli('akash', ['tx', ...])`, etc.) silently
+ *   swallows chain rejections, which is exactly the class of bug
+ *   that lost us deployments to "bid taken" / "sequence mismatch"
+ *   for hours before the audit caught it.
+ *
+ * This test scans the production source tree and fails CI if a new
+ * direct-tx call site sneaks in. Allow-list entries below are the
+ * three places where bypass is *intentional*:
+ *
+ *   * `runAkashTxAsync` itself, which calls `runAkashAsync` after
+ *     adding -o/-y and forwarding through the wallet mutex.
+ *   * `akashSteps.ts → failDirectly`: explicit best-effort cleanup
+ *     in an *already-failing* enqueue path. We can't afford to throw
+ *     on chain errors here because the goal is just to nudge the
+ *     on-chain lease toward closed before we mark the local row
+ *     FAILED. The caller already swallows the error.
+ *   * `providerVerification.ts`: tear-down at the end of the
+ *     verifier test suite. Best-effort, gated by a try/catch, runs
+ *     in a non-production code path (provider verifier).
+ */
+
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// __dirname here is .../src/services/akash; src root is two levels up.
+const SRC_DIR = path.join(__dirname, '..', '..')
+// SRC_DIR === <repo>/src ; relative paths in violations are e.g.
+// "services/akash/orchestrator.ts".
+
+/**
+ * Files allowed to call `akash tx ...` outside `runAkashTxAsync`.
+ * Each entry should be paired with a clear in-source comment
+ * explaining WHY the bypass is intentional and bounded.
+ */
+const ALLOWED_BYPASS_FILES = new Set<string>([
+  // The helper itself wraps runAkashAsync.
+  'services/akash/orchestrator.ts',
+  // Documented best-effort cleanup paths (see comments above).
+  'services/queue/akashSteps.ts',
+  'services/providers/providerVerification.ts',
+])
+
+const TX_PATTERN = /\b(?:runAkashAsync|execCli|execFileSync|execSync|spawn)\s*\(\s*(?:['"]akash['"]\s*,\s*)?\[?\s*['"]tx['"]/
+
+async function walk(dir: string): Promise<string[]> {
+  const out: string[] = []
+  const entries = await fs.readdir(dir, { withFileTypes: true })
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'dist') continue
+      out.push(...(await walk(full)))
+    } else if (entry.isFile() && /\.(ts|js)$/.test(entry.name) && !/\.test\.[tj]s$/.test(entry.name)) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+describe('Akash chain-tx safety contract', () => {
+  it('every "akash tx" call site goes through runAkashTxAsync', async () => {
+    const files = await walk(SRC_DIR)
+    const violations: Array<{ file: string; lineNumber: number; line: string }> = []
+
+    for (const file of files) {
+      const rel = path.relative(SRC_DIR, file).replace(/\\/g, '/')
+      if (ALLOWED_BYPASS_FILES.has(rel)) continue
+
+      const contents = await fs.readFile(file, 'utf8')
+      const lines = contents.split(/\r?\n/)
+      lines.forEach((line, idx) => {
+        // Strip line comments to avoid matching reference docs.
+        const code = line.replace(/\/\/.*$/, '').replace(/\/\*[\s\S]*?\*\//g, '')
+        if (TX_PATTERN.test(code)) {
+          violations.push({ file: rel, lineNumber: idx + 1, line: line.trim() })
+        }
+      })
+    }
+
+    if (violations.length > 0) {
+      const report = violations
+        .map(v => `  ${v.file}:${v.lineNumber}: ${v.line}`)
+        .join('\n')
+      throw new Error(
+        `Found ${violations.length} Akash-tx call site(s) bypassing runAkashTxAsync:\n${report}\n\n` +
+          `Either route the call through runAkashTxAsync (preferred) or, if the bypass is intentional ` +
+          `(e.g. best-effort cleanup), add the file to ALLOWED_BYPASS_FILES in this test with a ` +
+          `comment explaining why.`,
+      )
+    }
+
+    expect(violations).toEqual([])
+  })
+})

--- a/src/services/akash/walletMutex.ts
+++ b/src/services/akash/walletMutex.ts
@@ -28,9 +28,39 @@
  * execAsync) prevent a single hung call from permanently blocking the queue.
  */
 
+import type { PrismaClient } from '@prisma/client'
 import { TX_SETTLE_DELAY_MS } from '../../config/akash.js'
+import { createLogger } from '../../lib/logger.js'
+
+const advisoryLog = createLogger('wallet-advisory-lock')
+
+// pg_advisory_lock takes a 32-bit signed int OR two 32-bit ints. We use
+// a single fixed key so EVERY chain-tx replica blocks on the same lock.
+// Choose anything as long as it does not collide with another use of
+// pg_advisory_lock in the same database. 0x414b4148 = "AKAH".
+const ADVISORY_LOCK_KEY = 0x414b4148
+
+// Allow ops to disable the cross-replica lock (useful for tests, single-
+// replica dev deploys, or emergencies). The in-process FIFO chain still
+// works on its own — we only LOSE the cross-replica guarantee.
+const ADVISORY_LOCK_DISABLED = process.env.WALLET_ADVISORY_LOCK_DISABLED === 'true'
+const ADVISORY_LOCK_TIMEOUT_MS = parseInt(
+  process.env.WALLET_ADVISORY_LOCK_TIMEOUT_MS ?? '60000',
+  10,
+)
 
 let chain: Promise<unknown> = Promise.resolve()
+
+// Set once at boot from `index.ts` (see `setWalletMutexPrisma`). The
+// advisory-lock TX needs a Prisma handle but `walletMutex` is imported
+// from many places (resolvers, schedulers, queue workers) and we don't
+// want to thread `prisma` through every call site. Module-level state
+// is fine here: the process has exactly one Prisma client.
+let sharedPrisma: PrismaClient | null = null
+
+export function setWalletMutexPrisma(prisma: PrismaClient): void {
+  sharedPrisma = prisma
+}
 
 export interface WalletLockOptions {
   /**
@@ -60,7 +90,7 @@ export function withWalletLock<T>(
 
   return prev
     .catch(() => undefined) // never let a prior failure poison the queue
-    .then(() => fn())
+    .then(() => withChainAdvisoryLock(fn))
     .then(
       v => {
         result = v
@@ -76,6 +106,49 @@ export function withWalletLock<T>(
       if (rejected) throw caught
       return result
     })
+}
+
+/**
+ * Wrap `fn` in a Postgres advisory lock so chain TX serialization holds
+ * across replicas. Without this, two pods could both pass the in-process
+ * `chain` mutex simultaneously and submit concurrent TXs from the same
+ * Cosmos account — guaranteed sequence-mismatch rejection.
+ *
+ * We use `pg_advisory_xact_lock` inside a Prisma transaction so the
+ * lock is bound to the connection AND released automatically on commit
+ * or error. The TX itself does no DB work; it exists only to hold the
+ * connection that owns the advisory lock.
+ *
+ * Disabled via `WALLET_ADVISORY_LOCK_DISABLED=true` for environments
+ * with a single replica (the in-process FIFO is enough on its own).
+ */
+async function withChainAdvisoryLock<T>(fn: () => Promise<T>): Promise<T> {
+  if (ADVISORY_LOCK_DISABLED) return fn()
+  if (!sharedPrisma) {
+    // Test environment or early bootstrap (before setWalletMutexPrisma
+    // ran). Skip the cross-replica lock — in-process FIFO still works.
+    return fn()
+  }
+
+  return sharedPrisma.$transaction(
+    async (tx) => {
+      await tx.$queryRawUnsafe(`SELECT pg_advisory_xact_lock(${ADVISORY_LOCK_KEY})`)
+      return fn()
+    },
+    {
+      // The TX must outlive the chain command. `runAkashTxAsync` waits
+      // for block inclusion (~6s typical, much longer if RPC is slow),
+      // so we give it generous headroom. Tune via env if needed.
+      timeout: ADVISORY_LOCK_TIMEOUT_MS,
+      maxWait: ADVISORY_LOCK_TIMEOUT_MS,
+    },
+  ).catch((err) => {
+    advisoryLog.error({ err }, 'pg advisory-lock TX failed — falling back to in-process lock only')
+    // If the lock TX itself failed (DB down, etc.) we still want the
+    // command to attempt — better to risk a sequence collision than
+    // freeze every chain operation.
+    return fn()
+  })
 }
 
 function sleep(ms: number): Promise<void> {

--- a/src/services/billing/computeBillingScheduler.ts
+++ b/src/services/billing/computeBillingScheduler.ts
@@ -18,6 +18,8 @@ import {
   processFinalPhalaBilling,
   settleAkashEscrowToTime,
 } from './deploymentSettlement.js'
+import { reconcilePendingSettlements } from './settlementLedger.js'
+import { reconcileAll as reconcileAllConcurrency } from '../concurrency/concurrencyService.js'
 import { createLogger } from '../../lib/logger.js'
 import { audit } from '../../lib/audit.js'
 import { checkPolicyLimits } from '../policy/enforcer.js'
@@ -146,6 +148,37 @@ export class ComputeBillingScheduler {
     }
 
     try {
+      // Drive escrow rows out of write-ahead states
+      // BEFORE running the main billing loops. A row stuck in
+      // PENDING_DEPOSIT is invisible to processAkashEscrows (which only
+      // looks at ACTIVE), so without this the user could be charged on
+      // auth's side but never billed/refunded on ours.
+      try {
+        const escrowRecon = await getEscrowService(this.prisma).reconcilePendingDeposits()
+        if (escrowRecon.promoted > 0 || escrowRecon.failed > 0) {
+          log.info(escrowRecon, 'Escrow write-ahead reconciler swept stuck rows')
+        }
+        const refundRecon = await getEscrowService(this.prisma).reconcilePendingRefunds()
+        if (refundRecon.completed > 0 || refundRecon.failed > 0) {
+          log.info(refundRecon, 'Escrow refund reconciler swept stuck rows')
+        }
+        const settlementRecon = await reconcilePendingSettlements(this.prisma)
+        if (settlementRecon.committed > 0 || settlementRecon.failed > 0) {
+          log.info(settlementRecon, 'Settlement-ledger reconciler swept stuck rows')
+        }
+        // Concurrency counter drift: any close path that forgot to
+        // decrement leaves the org over-counted and unable to launch.
+        // Recomputing from the deployment tables is cheap enough to do
+        // every cycle and pins the worst-case lockout duration to the
+        // billing interval.
+        const concurrencyRecon = await reconcileAllConcurrency(this.prisma)
+        if (concurrencyRecon.drifted > 0) {
+          log.warn(concurrencyRecon, 'Concurrency counter reconciler corrected drift')
+        }
+      } catch (reconErr) {
+        log.error(reconErr, 'Reconciler failed — continuing with billing cycle')
+      }
+
       await this.processAkashEscrows(stats)
       await this.processPhalaDebits(stats)
 
@@ -491,6 +524,12 @@ export class ComputeBillingScheduler {
       'Processing active Phala deployments'
     )
 
+    // Surface ACTIVE Phala deployments that the main loop
+    // *cannot* bill because their orgBillingId is null. These are silent
+    // money leaks (compute is running, no one is being charged) so we
+    // page on every cycle until ops backfills the row.
+    await this.alertUnbillablePhalaDeployments()
+
     const now = new Date()
 
     for (const deployment of activePhala) {
@@ -514,16 +553,24 @@ export class ComputeBillingScheduler {
           continue
         }
 
-        const billableHours = this.forceMode
+        const hoursToBill = this.forceMode
           ? Math.max(1, Math.floor(hoursSinceLastBill))
-          : Math.floor(hoursSinceLastBill)
-        const amountCents = billableHours * deployment.hourlyRateCents
+          : Math.max(1, Math.floor(hoursSinceLastBill))
+        const amountCents = hoursToBill * deployment.hourlyRateCents
 
         if (amountCents <= 0) continue
 
-        const dateKey = now.toISOString().slice(0, 10)
-        const runId = this.forceMode ? `force_${now.toISOString().slice(0, 13)}` : dateKey
-        const idempotencyKey = `phala_daily:${deployment.id}:${runId}`
+        // Hourly idempotency key (was daily). With a daily key
+        // the first hour-of-day bill would silently swallow EVERY subsequent
+        // intra-day attempt as `alreadyProcessed`, dropping 23h of revenue
+        // per active CVM. Hour-floor key matches the Akash pay-as-you-go
+        // path above and lets us coalesce missed hours into one charge while
+        // keeping the key bound to the slot the user is actually being
+        // charged for.
+        const slotStart = new Date(Math.floor(now.getTime() / 3_600_000) * 3_600_000)
+        const hourKey = slotStart.toISOString().slice(0, 13)
+        const runId = this.forceMode ? `force_${hourKey}` : hourKey
+        const idempotencyKey = `phala_hourly:${deployment.id}:${runId}`
 
         const result = await billingApi.computeDebit({
           orgBillingId: deployment.orgBillingId,
@@ -531,28 +578,36 @@ export class ComputeBillingScheduler {
           serviceType: 'phala_tee',
           provider: 'phala',
           resource: deployment.id,
-          description: `Phala TEE ${deployment.cvmSize || 'tdx.large'}: ${billableHours}h @ $${(deployment.hourlyRateCents / 100).toFixed(2)}/hr`,
+          description: `Phala TEE ${deployment.cvmSize || 'tdx.large'}: ${hoursToBill}h @ $${(deployment.hourlyRateCents / 100).toFixed(2)}/hr`,
           idempotencyKey,
+        })
+
+        // Advance lastBilledAt by exactly hoursToBill*1h (NOT
+        // to `now`), capped at `now`. Same fractional-tail rationale as
+        // the Akash pay-as-you-go path above. ALSO mirror on idempotency
+        // hits: without the mirror the next cycle would compute a larger
+        // hoursToBill against a fresh hourly key and double-charge.
+        const advancedLastBilledAt = new Date(
+          Math.min(now.getTime(), lastBilled.getTime() + hoursToBill * 3_600_000)
+        )
+        await this.prisma.phalaDeployment.update({
+          where: { id: deployment.id },
+          data: {
+            lastBilledAt: advancedLastBilledAt,
+            totalBilledCents: deployment.totalBilledCents + amountCents,
+          },
         })
 
         if (result.alreadyProcessed) {
           log.info(
-            { deploymentId: deployment.id },
-            'Phala deployment already processed (idempotency hit)'
+            { deploymentId: deployment.id, amountCents, idempotencyKey },
+            'Phala deployment already processed (idempotency hit) — mirrored to local DB'
           )
         } else {
-          await this.prisma.phalaDeployment.update({
-            where: { id: deployment.id },
-            data: {
-              lastBilledAt: now,
-              totalBilledCents: deployment.totalBilledCents + amountCents,
-            },
-          })
-
           stats.phalaProcessed++
           stats.totalDebitedCents += amountCents
           log.info(
-            { deploymentId: deployment.id, debitedCents: amountCents },
+            { deploymentId: deployment.id, debitedCents: amountCents, hoursToBill },
             'Phala deployment debited'
           )
         }
@@ -574,9 +629,154 @@ export class ComputeBillingScheduler {
             },
             'Phala deployment error'
           )
+          await opsAlert({
+            key: `phala-billing-error:${deployment.id}`,
+            severity: 'warning',
+            title: 'Phala billing cycle error',
+            message:
+              `Failed to bill Phala deployment ${deployment.id} during the hourly cycle. ` +
+              `If this persists the user will stop being charged for a live CVM.`,
+            context: {
+              deploymentId: deployment.id,
+              orgBillingId: deployment.orgBillingId,
+              hourlyRateCents: deployment.hourlyRateCents,
+              error: errMsg.slice(0, 400),
+            },
+            suppressMs: 55 * 60 * 1000,
+          })
         }
       }
     }
+
+    // Reconciliation: any Phala deployment whose lastBilledAt
+    // has drifted >2h behind `now` indicates a missed cycle (loop crashed,
+    // pod crashed mid-run, etc). Surface so the next cycle's coalesce-bill
+    // path picks them up; alert if the drift is severe.
+    await this.detectPhalaBillingDrift()
+  }
+
+  /**
+   * Emit an ops alert (and detailed log line) for any ACTIVE
+   * Phala deployment that is missing `orgBillingId` or `hourlyRateCents`.
+   * The main loop's `where` clause silently filters these out, so without
+   * this they are invisible money leaks: compute is running on Phala but
+   * nobody is being charged.
+   */
+  private async alertUnbillablePhalaDeployments(): Promise<void> {
+    const broken = await this.prisma.phalaDeployment.findMany({
+      where: {
+        status: 'ACTIVE',
+        OR: [
+          { orgBillingId: null },
+          { hourlyRateCents: null },
+        ],
+      },
+      select: {
+        id: true,
+        appId: true,
+        organizationId: true,
+        orgBillingId: true,
+        hourlyRateCents: true,
+        createdAt: true,
+      },
+    })
+    if (broken.length === 0) return
+
+    log.error(
+      { count: broken.length, ids: broken.map(b => b.id) },
+      'ACTIVE Phala deployments missing billing fields — NOT being charged',
+    )
+    await opsAlert({
+      key: 'phala-unbillable-deployments',
+      severity: 'critical',
+      title: 'ACTIVE Phala deployments are not being billed',
+      message:
+        `${broken.length} ACTIVE Phala deployment(s) have a NULL orgBillingId or hourlyRateCents. ` +
+        `They are running on Phala but no one is paying for the compute. ` +
+        `Backfill the missing fields ASAP — see admin/cloud/docs/AF_INCIDENT_RUNBOOKS.md.`,
+      context: {
+        count: broken.length,
+        sample: broken.slice(0, 10).map(b => ({
+          deploymentId: b.id,
+          appId: b.appId,
+          organizationId: b.organizationId,
+          missing: [
+            b.orgBillingId ? null : 'orgBillingId',
+            b.hourlyRateCents ? null : 'hourlyRateCents',
+          ].filter(Boolean),
+        })),
+      },
+      suppressMs: 55 * 60 * 1000,
+    })
+  }
+
+  /**
+   * Find ACTIVE Phala deployments where `lastBilledAt` has
+   * fallen behind `now` by more than the configured threshold. The next
+   * billing cycle will coalesce-charge the missed hours via the regular
+   * loop above (hoursToBill=floor(drift)), so reconciliation here is
+   * primarily about visibility: surface drift early so we can investigate
+   * before it becomes a multi-day backlog.
+   */
+  private async detectPhalaBillingDrift(): Promise<void> {
+    const DRIFT_THRESHOLD_HOURS = 2
+    const driftCutoff = new Date(Date.now() - DRIFT_THRESHOLD_HOURS * 3_600_000)
+    const drifted = await this.prisma.phalaDeployment.findMany({
+      where: {
+        status: 'ACTIVE',
+        orgBillingId: { not: null },
+        hourlyRateCents: { not: null },
+        OR: [
+          { lastBilledAt: { lt: driftCutoff } },
+          // No lastBilledAt yet but activeStartedAt > threshold: still
+          // unbilled past the grace window.
+          {
+            lastBilledAt: null,
+            activeStartedAt: { lt: driftCutoff },
+          },
+        ],
+      },
+      select: {
+        id: true,
+        appId: true,
+        orgBillingId: true,
+        lastBilledAt: true,
+        activeStartedAt: true,
+        hourlyRateCents: true,
+      },
+    })
+    if (drifted.length === 0) return
+
+    log.warn(
+      {
+        count: drifted.length,
+        thresholdHours: DRIFT_THRESHOLD_HOURS,
+        ids: drifted.map(d => d.id),
+      },
+      'Phala billing drift detected — next cycle will coalesce-charge missed hours',
+    )
+    await opsAlert({
+      key: 'phala-billing-drift',
+      severity: 'warning',
+      title: 'Phala billing has drifted behind real time',
+      message:
+        `${drifted.length} ACTIVE Phala deployment(s) have lastBilledAt > ${DRIFT_THRESHOLD_HOURS}h behind now. ` +
+        `The next cycle should coalesce the missed hours, but persistent drift means the cron isn't running ` +
+        `cleanly — investigate scheduler health and pod logs.`,
+      context: {
+        count: drifted.length,
+        thresholdHours: DRIFT_THRESHOLD_HOURS,
+        sample: drifted.slice(0, 10).map(d => ({
+          deploymentId: d.id,
+          appId: d.appId,
+          orgBillingId: d.orgBillingId,
+          lastBilledAt: d.lastBilledAt?.toISOString() ?? null,
+          activeStartedAt: d.activeStartedAt?.toISOString() ?? null,
+          hourlyRateCents: d.hourlyRateCents,
+        })),
+      },
+      suppressMs: 55 * 60 * 1000,
+    })
   }
 
   // ========================================
@@ -745,29 +945,28 @@ export class ComputeBillingScheduler {
           data: { savedSdl: deployment.sdlContent },
         })
 
-        let onChainClosed = false
-        try {
-          const { getAkashOrchestrator } =
-            await import('../akash/orchestrator.js')
-          const orchestrator = getAkashOrchestrator(this.prisma)
-          log.info({ dseq: deployment.dseq }, 'Closing on-chain deployment for suspension')
-          await orchestrator.closeDeployment(Number(deployment.dseq))
-          onChainClosed = true
-          log.info({ dseq: deployment.dseq }, 'On-chain close TX submitted')
-          // Sequence-settle delay is held inside withWalletLock
-          // (see services/akash/walletMutex.ts). No manual sleep needed.
-        } catch (err) {
-          const errMsg = err instanceof Error ? err.message : String(err)
-          const alreadyGone = /deployment not found|deployment closed|not active|does not exist|order not found|lease not found|unknown deployment|invalid deployment/i.test(errMsg)
-          if (alreadyGone) {
-            log.warn({ dseq: deployment.dseq, err }, 'On-chain deployment already gone — treating as closed')
-            onChainClosed = true
-          } else {
-            log.error(
-              { dseq: deployment.dseq, err },
-              'On-chain close FAILED — deployment stays ACTIVE and billed until resolved'
-            )
-          }
+        // Suspension flow uses the structured close
+        // result. CLOSED + ALREADY_CLOSED both transition the local
+        // row to SUSPENDED (resumable). FAILED keeps the row ACTIVE
+        // so the user keeps being billed and the next billing tick
+        // retries — never silently move to SUSPENDED while the lease
+        // is still live and draining escrow.
+        const { getAkashOrchestrator } = await import('../akash/orchestrator.js')
+        const orchestrator = getAkashOrchestrator(this.prisma)
+        log.info({ dseq: deployment.dseq }, 'Closing on-chain deployment for suspension')
+        const close = await orchestrator.closeDeployment(Number(deployment.dseq))
+        const onChainClosed =
+          close.chainStatus === 'CLOSED' || close.chainStatus === 'ALREADY_CLOSED'
+        if (onChainClosed) {
+          log.info(
+            { dseq: deployment.dseq, chainStatus: close.chainStatus },
+            'On-chain close completed for suspension',
+          )
+        } else {
+          log.error(
+            { dseq: deployment.dseq, error: close.error },
+            'On-chain close FAILED — deployment stays ACTIVE and billed until next billing tick retries',
+          )
         }
 
         if (onChainClosed) {
@@ -779,6 +978,18 @@ export class ComputeBillingScheduler {
           if (result.count > 0 && deployment.escrow) {
             await settleAkashEscrowToTime(this.prisma, deployment.id, stoppedAt)
             await escrowService.pauseEscrow(deployment.id)
+          }
+
+          // SUSPENDED no longer counts toward the org's concurrency cap
+          // (the lease is closed on chain). Reconciler would catch this
+          // within the hour, but the user expects to be able to launch
+          // a replacement immediately.
+          if (result.count > 0 && deployment.escrow?.organizationId) {
+            const { decrementOrgConcurrency } = await import(
+              '../concurrency/concurrencyService.js'
+            )
+            await decrementOrgConcurrency(this.prisma, deployment.escrow.organizationId)
+              .catch((err) => log.warn({ err, deploymentId: deployment.id }, 'Concurrency decrement failed (suspend Akash)'))
           }
 
           // Clear any reservation on the policy
@@ -882,7 +1093,13 @@ export class ComputeBillingScheduler {
             data: { status: 'STOPPED' },
           })
           if (result.count > 0) {
-            // Clear any reservation
+            if (deployment.organizationId) {
+              const { decrementOrgConcurrency } = await import(
+                '../concurrency/concurrencyService.js'
+              )
+              await decrementOrgConcurrency(this.prisma, deployment.organizationId)
+                .catch((err) => log.warn({ err, deploymentId: deployment.id }, 'Concurrency decrement failed (suspend Phala)'))
+            }
             if (deployment.policyId) {
               await this.prisma.deploymentPolicy.updateMany({
                 where: { id: deployment.policyId, reservedCents: { gt: 0 } },

--- a/src/services/billing/deploymentSettlement.test.ts
+++ b/src/services/billing/deploymentSettlement.test.ts
@@ -24,6 +24,33 @@ vi.mock('../../config/pricing.js', () => ({
   applyMargin: vi.fn((raw: number, margin: number) => raw * (1 + margin)),
 }))
 
+/**
+ * Add a stub policySettlementLedger to a prisma test double so the new
+ * write-ahead settle path can run without exploding. We do NOT track
+ * call assertions on the ledger here — that is exercised in
+ * settlementLedger.test.ts. The stub just needs to behave like the
+ * happy-path Prisma client (create returns the row, update returns it
+ * back).
+ */
+function stubLedger(prisma: any) {
+  prisma.policySettlementLedger = {
+    create: vi.fn().mockImplementation(({ data }: { data: any }) => Promise.resolve({
+      id: `ledger-${data.idempotencyKey}`,
+      ...data,
+      attemptCount: 0,
+      committedAt: null,
+      lastError: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })),
+    findUnique: vi.fn(),
+    update: vi.fn().mockImplementation(({ where, data }: { where: any; data: any }) =>
+      Promise.resolve({ id: where.id, ...data }),
+    ),
+  }
+  return prisma
+}
+
 describe('deploymentSettlement', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -67,9 +94,10 @@ describe('deploymentSettlement', () => {
       deploymentPolicy: {
         update: vi.fn(),
       },
-    } as unknown as PrismaClient
+    }
+    stubLedger(prisma)
 
-    const additionalCents = await settleAkashEscrowToTime(prisma, 'akash-1', settledAt)
+    const additionalCents = await settleAkashEscrowToTime(prisma as unknown as PrismaClient, 'akash-1', settledAt)
 
     expect(additionalCents).toBe(40)
     expect(prisma.deploymentEscrow.update).toHaveBeenCalledWith({
@@ -117,9 +145,10 @@ describe('deploymentSettlement', () => {
       deploymentPolicy: {
         update: vi.fn(),
       },
-    } as unknown as PrismaClient
+    }
+    stubLedger(prisma)
 
-    const additionalCents = await settleAkashEscrowToTime(prisma, 'akash-payg', settledAt)
+    const additionalCents = await settleAkashEscrowToTime(prisma as unknown as PrismaClient, 'akash-payg', settledAt)
 
     expect(additionalCents).toBe(60)
     expect(computeDebitMock).toHaveBeenCalledWith(
@@ -129,7 +158,7 @@ describe('deploymentSettlement', () => {
         serviceType: 'akash_compute',
         provider: 'akash',
         resource: 'test-svc',
-        idempotencyKey: `akash_final:akash-payg:${settledAt.toISOString()}`,
+        idempotencyKey: expect.stringMatching(/^akash_final:akash-payg:\d+$/),
       })
     )
   })
@@ -158,10 +187,11 @@ describe('deploymentSettlement', () => {
       deploymentPolicy: {
         update: vi.fn(),
       },
-    } as unknown as PrismaClient
+    }
+    stubLedger(prisma)
 
     const additionalCents = await settleAkashEscrowToTime(
-      prisma,
+      prisma as unknown as PrismaClient,
       'akash-missing-escrow',
       settledAt
     )
@@ -174,8 +204,9 @@ describe('deploymentSettlement', () => {
         serviceType: 'akash_compute',
         provider: 'akash',
         resource: 'milady-gateway-vlxk',
-        idempotencyKey:
-          'akash_final_no_escrow:akash-missing-escrow:2026-03-31T01:00:00.000Z',
+        idempotencyKey: expect.stringMatching(
+          /^akash_final_no_escrow:akash-missing-escrow:\d+$/,
+        ),
       })
     )
     expect(prisma.deploymentPolicy.update).toHaveBeenCalledWith({
@@ -204,10 +235,11 @@ describe('deploymentSettlement', () => {
       deploymentPolicy: {
         update: vi.fn(),
       },
-    } as unknown as PrismaClient
+    }
+    stubLedger(prisma)
 
     const finalChargeCents = await processFinalPhalaBilling(
-      prisma,
+      prisma as unknown as PrismaClient,
       'phala-1',
       billedAt,
       'test_final'
@@ -218,7 +250,7 @@ describe('deploymentSettlement', () => {
       expect.objectContaining({
         orgBillingId: 'org-billing-1',
         amountCents: 80,
-        idempotencyKey: 'test_final:phala-1:2026-03-29T00:40:00.000Z',
+        idempotencyKey: expect.stringMatching(/^test_final:phala-1:\d+$/),
       })
     )
     expect(prisma.phalaDeployment.update).toHaveBeenCalledWith({

--- a/src/services/billing/deploymentSettlement.ts
+++ b/src/services/billing/deploymentSettlement.ts
@@ -2,8 +2,24 @@ import type { PrismaClient } from '@prisma/client'
 import { getBillingApiClient } from './billingApiClient.js'
 import { akashPricePerBlockToUsdPerDay, applyMargin } from '../../config/pricing.js'
 import { createLogger } from '../../lib/logger.js'
+import { settleViaLedger } from './settlementLedger.js'
 
 const log = createLogger('deployment-settlement')
+
+/**
+ * Build a stable, deterministic idempotency key for final-settlement
+ * debits. Uses a 1-second-quantised timestamp so a retry called moments
+ * later still hashes to the same key. Including `kind` keeps Akash and
+ * Phala settlements in independent key namespaces.
+ */
+function settlementIdempotencyKey(
+  prefix: string,
+  deploymentRef: string,
+  settledTo: Date,
+): string {
+  const flooredSecond = Math.floor(settledTo.getTime() / 1000)
+  return `${prefix}:${deploymentRef}:${flooredSecond}`
+}
 
 const MINUTE_MS = 60_000
 const DAY_MINUTES = 24 * 60
@@ -117,27 +133,37 @@ export async function settleAkashEscrowToTime(
     })
   }
 
-  // Pay-as-you-go: debit wallet for the final prorated amount
+  // Pay-as-you-go: debit wallet for the final prorated amount via the
+  // write-ahead settlement ledger so a crash between local state advance
+  // and the auth-side debit is recoverable by the reconciler.
   if (escrow.depositCents === 0 && additionalCents > 0) {
     try {
-      await billingApi.computeDebit({
+      await settleViaLedger(prisma, {
+        provider: 'AKASH',
+        kind: 'FINAL_SETTLEMENT',
+        deploymentRef: akashDeploymentId,
+        idempotencyKey: settlementIdempotencyKey(
+          'akash_final',
+          akashDeploymentId,
+          settledAt,
+        ),
         orgBillingId: escrow.orgBillingId,
         amountCents: additionalCents,
+        settledTo: settledAt,
+        policyId: escrow.akashDeployment?.policyId ?? null,
         serviceType: 'akash_compute',
-        provider: 'akash',
         resource: escrow.akashDeployment?.service?.slug || akashDeploymentId,
         description: `Akash compute final settlement: $${(additionalCents / 100).toFixed(2)}`,
-        idempotencyKey: `akash_final:${akashDeploymentId}:${settledAt.toISOString()}`,
         metadata: {
           deploymentId: akashDeploymentId,
-          dseq: escrow.akashDeployment?.dseq?.toString(),
+          dseq: escrow.akashDeployment?.dseq?.toString() ?? null,
           source: 'akash_final_settlement',
         },
       })
     } catch (error) {
       log.warn(
         { akashDeploymentId, err: error },
-        'Failed to debit final Akash settlement'
+        'Failed to debit final Akash settlement — ledger row will be reconciled'
       )
     }
   }
@@ -207,17 +233,25 @@ async function settleAkashWithoutEscrow(
 
   try {
     const orgBilling = await billingApi.getOrgBilling(organizationId)
-    const result = await billingApi.computeDebit({
+    const result = await settleViaLedger(prisma, {
+      provider: 'AKASH',
+      kind: 'FINAL_SETTLEMENT',
+      deploymentRef: akashDeploymentId,
+      idempotencyKey: settlementIdempotencyKey(
+        'akash_final_no_escrow',
+        akashDeploymentId,
+        settledAt,
+      ),
       orgBillingId: orgBilling.orgBillingId,
       amountCents: additionalCents,
+      settledTo: settledAt,
+      policyId: deployment.policyId ?? null,
       serviceType: 'akash_compute',
-      provider: 'akash',
       resource: deployment.service.slug || akashDeploymentId,
       description: `Akash compute final settlement (escrow-missing): $${(additionalCents / 100).toFixed(2)}`,
-      idempotencyKey: `akash_final_no_escrow:${akashDeploymentId}:${settledAt.toISOString()}`,
       metadata: {
         deploymentId: akashDeploymentId,
-        dseq: deployment.dseq?.toString(),
+        dseq: deployment.dseq?.toString() ?? null,
         source: 'akash_final_settlement_no_escrow',
       },
     })
@@ -240,7 +274,7 @@ async function settleAkashWithoutEscrow(
   } catch (error) {
     log.warn(
       { akashDeploymentId, err: error },
-      'Failed to settle Akash billing without escrow fallback'
+      'Failed to settle Akash billing without escrow fallback — ledger row will be reconciled'
     )
     return 0
   }
@@ -314,16 +348,27 @@ export async function processFinalPhalaBilling(
   }
 
   try {
-    const billingApi = getBillingApiClient()
-    const idempotencyKey = `${idempotencyPrefix}:${deployment.id}:${billedAt.toISOString()}`
-    const result = await billingApi.computeDebit({
+    const idempotencyKey = settlementIdempotencyKey(
+      idempotencyPrefix,
+      deployment.id,
+      billedAt,
+    )
+    const result = await settleViaLedger(prisma, {
+      provider: 'PHALA',
+      kind: 'FINAL_SETTLEMENT',
+      deploymentRef: deployment.id,
+      idempotencyKey,
       orgBillingId: deployment.orgBillingId,
       amountCents,
+      settledTo: billedAt,
+      policyId: deployment.policyId ?? null,
       serviceType: 'phala_tee',
-      provider: 'phala',
       resource: deployment.id,
       description: `Phala TEE final billing: $${(amountCents / 100).toFixed(2)}`,
-      idempotencyKey,
+      metadata: {
+        cvmSize: deployment.cvmSize,
+        source: 'phala_final_settlement',
+      },
     })
 
     if (result.alreadyProcessed) {
@@ -358,7 +403,7 @@ export async function processFinalPhalaBilling(
 
     return amountCents
   } catch (error) {
-    log.warn({ phalaDeploymentId, err: error }, 'Final Phala billing failed')
+    log.warn({ phalaDeploymentId, err: error }, 'Final Phala billing failed — ledger row will be reconciled')
     return 0
   }
 }

--- a/src/services/billing/escrowHealthMonitor.test.ts
+++ b/src/services/billing/escrowHealthMonitor.test.ts
@@ -10,7 +10,9 @@ const {
   opsAlertMock,
 } = vi.hoisted(() => ({
   execAsyncMock: vi.fn(),
-  closeDeploymentMock: vi.fn().mockResolvedValue(undefined),
+  closeDeploymentMock: vi
+    .fn()
+    .mockResolvedValue({ chainStatus: 'CLOSED', txhash: 'mock-tx' }),
   refundEscrowMock: vi.fn().mockResolvedValue(undefined),
   settleAkashEscrowToTimeMock: vi.fn().mockResolvedValue(undefined),
   opsAlertMock: vi.fn().mockResolvedValue(undefined),
@@ -155,7 +157,7 @@ function installAkashCli(overrides: {
 describe('EscrowHealthMonitor', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    closeDeploymentMock.mockResolvedValue(undefined)
+    closeDeploymentMock.mockResolvedValue({ chainStatus: 'CLOSED', txhash: 'mock-tx' })
     refundEscrowMock.mockResolvedValue(undefined)
     settleAkashEscrowToTimeMock.mockResolvedValue(undefined)
     opsAlertMock.mockResolvedValue(undefined)

--- a/src/services/billing/escrowHealthMonitor.ts
+++ b/src/services/billing/escrowHealthMonitor.ts
@@ -41,6 +41,33 @@ const ESCROW_CHECK_CRON = '30 * * * *'
 /** Warn when deployer wallet ACT balance falls below this (5 ACT). */
 const LOW_WALLET_THRESHOLD_UACT = 5_000_000
 
+/**
+ * Hot-wallet cap (defense-in-depth against key compromise).
+ *
+ * The deployer wallet is an *online* hot wallet — its key sits on the
+ * cloud-api pod's filesystem and any successful RCE on the API
+ * empties it. We therefore want it to hold only what's needed to
+ * cover ~24-48 h of escrow refills; the rest of the AKT/ACT runway
+ * belongs in cold storage.
+ *
+ * If the wallet balance creeps above this cap (e.g. operator funded
+ * too much, or treasury swept the wrong way), we fire an ops alert
+ * and ask the operator to sweep the excess back to cold storage per
+ * the runbook (Section L of AF_INCIDENT_RUNBOOKS.md).
+ *
+ * Override in production via `AKASH_HOT_WALLET_CAP_UACT` if the
+ * default is too tight for current usage.
+ */
+const DEFAULT_HOT_WALLET_CAP_UACT = 50_000_000 // 50 ACT
+const HOT_WALLET_CAP_UACT = (() => {
+  const raw = process.env.AKASH_HOT_WALLET_CAP_UACT
+  if (!raw) return DEFAULT_HOT_WALLET_CAP_UACT
+  const parsed = parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed > LOW_WALLET_THRESHOLD_UACT
+    ? parsed
+    : DEFAULT_HOT_WALLET_CAP_UACT
+})()
+
 async function runAkashCmd(args: string[], timeout = AKASH_CLI_TIMEOUT_MS): Promise<string> {
   const env = getAkashEnv()
   const invoke = () =>
@@ -220,8 +247,9 @@ export class EscrowHealthMonitor {
       const data = JSON.parse(output)
       const uactBal = data?.balances?.find((b: { denom: string }) => b.denom === 'uact')
       const balance = parseInt(uactBal?.amount || '0', 10)
+      const balanceAct = (balance / 1_000_000).toFixed(4)
+
       if (balance < LOW_WALLET_THRESHOLD_UACT) {
-        const balanceAct = (balance / 1_000_000).toFixed(4)
         log.warn(
           { balanceUact: balance, balanceAct },
           'CRITICAL: Deployer wallet ACT balance is low — escrow refills will fail soon'
@@ -241,6 +269,34 @@ export class EscrowHealthMonitor {
           },
           // Alert hourly (matches the health-monitor cadence), not every 10 min.
           suppressMs: 55 * 60 * 1000,
+        })
+      }
+
+      // Hot-wallet cap (Section L of the incident runbook). The deployer
+      // wallet is online — keeping it lean limits blast radius if the
+      // pod / key is ever compromised.
+      if (balance > HOT_WALLET_CAP_UACT) {
+        log.warn(
+          { balanceUact: balance, balanceAct, capUact: HOT_WALLET_CAP_UACT },
+          'Deployer hot wallet exceeds configured cap — sweep excess to cold storage',
+        )
+        await opsAlert({
+          key: 'deployer-wallet-over-cap',
+          severity: 'warning',
+          title: 'Deployer hot wallet over cap',
+          message:
+            `Deployer wallet holds ${balanceAct} ACT, above the ${(HOT_WALLET_CAP_UACT / 1_000_000).toFixed(0)} ACT hot-wallet cap. ` +
+            `Sweep the excess back to cold storage per AF_INCIDENT_RUNBOOKS.md §L. ` +
+            `Override the cap by setting AKASH_HOT_WALLET_CAP_UACT if usage justifies a larger float.`,
+          context: {
+            address,
+            balanceAct,
+            balanceUact: String(balance),
+            capUact: String(HOT_WALLET_CAP_UACT),
+            excessUact: String(balance - HOT_WALLET_CAP_UACT),
+          },
+          // Daily nudge — over-cap is a slow-burn risk, not a page-now event.
+          suppressMs: 24 * 60 * 60 * 1000,
         })
       }
     } catch {
@@ -332,21 +388,39 @@ export class EscrowHealthMonitor {
   private async closeAndSettleDeployment(deploymentId: string, dseq: string): Promise<void> {
     const current = await this.prisma.akashDeployment.findUnique({
       where: { id: deploymentId },
-      select: { status: true },
+      select: {
+        status: true,
+        service: { select: { project: { select: { organizationId: true } } } },
+      },
     })
     if (!current || current.status !== 'ACTIVE') return
 
     const closedAt = new Date()
 
-    try {
-      const orchestrator = getAkashOrchestrator(this.prisma)
-      await orchestrator.closeDeployment(Number(dseq))
-    } catch (closeErr) {
-      const msg = (closeErr as Error).message ?? ''
-      const alreadyGone = /deployment not found|deployment closed|not active|does not exist/i.test(msg)
-      if (!alreadyGone) {
-        log.error({ deploymentId, dseq, err: msg }, 'On-chain close failed during escrow-monitor auto-close')
-      }
+    // Switch on the structured close result. The escrow
+    // monitor only invokes auto-close when the lease is *already*
+    // chain-dead (provider closed it / escrow drained), so the most
+    // common outcome here is ALREADY_CLOSED. A FAILED outcome is
+    // pathological (RPC down, wallet empty) and we MUST surface it
+    // as CLOSE_FAILED instead of silently marking the row CLOSED —
+    // otherwise the user gets refunded for an escrow we never
+    // actually settled.
+    const orchestrator = getAkashOrchestrator(this.prisma)
+    const close = await orchestrator.closeDeployment(Number(dseq))
+
+    if (close.chainStatus === 'FAILED') {
+      log.error(
+        { deploymentId, dseq, error: close.error },
+        'Escrow-monitor auto-close FAILED on-chain — marking CLOSE_FAILED, leaving escrow intact for retry',
+      )
+      await this.prisma.akashDeployment.updateMany({
+        where: { id: deploymentId, status: 'ACTIVE' },
+        data: {
+          status: 'CLOSE_FAILED',
+          errorMessage: `Escrow-monitor auto-close failed: ${close.error}`,
+        },
+      })
+      return
     }
 
     const result = await this.prisma.akashDeployment.updateMany({
@@ -357,7 +431,19 @@ export class EscrowHealthMonitor {
     if (result.count > 0) {
       await settleAkashEscrowToTime(this.prisma, deploymentId, closedAt)
       await getEscrowService(this.prisma).refundEscrow(deploymentId)
-      log.info({ deploymentId, dseq }, 'Chain-dead deployment closed and billing settled')
+      const { decrementOrgConcurrency } = await import(
+        '../concurrency/concurrencyService.js'
+      )
+      await decrementOrgConcurrency(
+        this.prisma,
+        current.service?.project?.organizationId,
+      ).catch((err) =>
+        log.warn({ err, deploymentId }, 'Concurrency decrement failed (escrow auto-close)'),
+      )
+      log.info(
+        { deploymentId, dseq, chainStatus: close.chainStatus },
+        'Chain-dead deployment closed and billing settled',
+      )
     }
   }
 

--- a/src/services/billing/escrowService.test.ts
+++ b/src/services/billing/escrowService.test.ts
@@ -50,18 +50,33 @@ describe('EscrowService', () => {
     escrowDepositMock.mockResolvedValue({ success: true, balanceCents: 5000 })
     escrowRefundMock.mockResolvedValue({ success: true, balanceCents: 5000 })
 
+    // In-memory state shared between create/update so refundEscrow's
+    // write-ahead pattern (claim via updateMany → finalize via update)
+    // can read back what create wrote.
+    const rows: Record<string, any> = {}
     prisma = {
       deploymentEscrow: {
-        create: vi.fn().mockImplementation(({ data }) => Promise.resolve({
-          id: 'escrow-new',
-          ...data,
-          consumedCents: 0,
-          refundedCents: 0,
-          createdAt: new Date(),
-        })),
+        create: vi.fn().mockImplementation(({ data }) => {
+          const row = {
+            id: 'escrow-new',
+            ...data,
+            consumedCents: 0,
+            refundedCents: 0,
+            createdAt: new Date(),
+          }
+          rows[row.id] = row
+          return Promise.resolve(row)
+        }),
         findUnique: vi.fn(),
-        update: vi.fn().mockImplementation(({ data }) => Promise.resolve(data)),
-        updateMany: vi.fn(),
+        update: vi.fn().mockImplementation(({ where, data }) => {
+          const existing = rows[where.id] ?? {}
+          const next = { ...existing, ...data, id: where.id }
+          rows[where.id] = next
+          return Promise.resolve(next)
+        }),
+        // Default: claim succeeds. Tests that need a contended claim
+        // can override with mockResolvedValueOnce({ count: 0 }).
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
       },
     }
 

--- a/src/services/billing/escrowService.ts
+++ b/src/services/billing/escrowService.ts
@@ -64,17 +64,26 @@ export class EscrowService {
       throw new Error(`Organization billing not configured for org ${args.organizationId}`)
     }
 
-    if (depositCents > 0) {
-      await this.billingApi.escrowDeposit({
-        orgBillingId: orgBilling.orgBillingId,
-        organizationId: args.organizationId,
-        userId: args.userId,
-        amountCents: depositCents,
-        deploymentId: args.akashDeploymentId,
-        description: `Akash escrow deposit (${escrowDays} days @ $${(dailyRateCents / 100).toFixed(2)}/day)`,
-      })
-    }
-
+    // Write-ahead. The previous flow called escrowDeposit
+    // FIRST and only created the local row on success. If the process
+    // crashed between those two steps the user's wallet was debited
+    // (auth's idempotency key persists the charge) but cloud-api had no
+    // record, so:
+    //   * the deployment couldn't be billed against,
+    //   * the refund-on-close path had nothing to refund from,
+    //   * any retry would attempt to deposit again. The auth side would
+    //     return alreadyProcessed=true (good), but cloud-api would then
+    //     happily mark the row ACTIVE — except now we're in a state
+    //     where the caller can't tell the deposit was "fresh" or
+    //     replayed-from-the-dead.
+    //
+    // The fix: insert PENDING_DEPOSIT first, then call the deposit RPC,
+    // then promote to ACTIVE. The escrow reconciler picks up any row
+    // stuck in PENDING_DEPOSIT and either drives it to ACTIVE (if the
+    // wallet was actually debited) or FAILED (if the deposit will never
+    // complete). Pay-as-you-go (depositCents=0) skips the RPC entirely
+    // and writes ACTIVE directly — no wallet operation to reconcile.
+    const initialStatus: 'PENDING_DEPOSIT' | 'ACTIVE' = depositCents > 0 ? 'PENDING_DEPOSIT' : 'ACTIVE'
     const escrow = await this.prisma.deploymentEscrow.create({
       data: {
         akashDeploymentId: args.akashDeploymentId,
@@ -83,17 +92,155 @@ export class EscrowService {
         depositCents,
         dailyRateCents,
         marginRate: args.marginRate,
+        status: initialStatus,
+        lastBilledAt: initialStatus === 'ACTIVE' ? new Date() : null,
+      },
+    })
+
+    if (depositCents === 0) {
+      log.info(
+        { deploymentId: args.akashDeploymentId, dailyRateCents, mode: 'pay-as-you-go' },
+        'Created escrow for deployment'
+      )
+      return escrow
+    }
+
+    try {
+      await this.billingApi.escrowDeposit({
+        orgBillingId: orgBilling.orgBillingId,
+        organizationId: args.organizationId,
+        userId: args.userId,
+        amountCents: depositCents,
+        deploymentId: args.akashDeploymentId,
+        description: `Akash escrow deposit (${escrowDays} days @ $${(dailyRateCents / 100).toFixed(2)}/day)`,
+      })
+    } catch (err) {
+      // Mark FAILED so the deployment lifecycle can clean up; reconciler
+      // will not touch FAILED rows (terminal). Caller is expected to abort
+      // the deployment and surface INSUFFICIENT_BALANCE / RPC error.
+      await this.prisma.deploymentEscrow.update({
+        where: { id: escrow.id },
+        data: { status: 'FAILED' },
+      }).catch((updateErr) => {
+        log.error(
+          { escrowId: escrow.id, deploymentId: args.akashDeploymentId, updateErr },
+          'Failed to mark escrow FAILED after deposit RPC error — reconciler will sweep PENDING_DEPOSIT',
+        )
+      })
+      throw err
+    }
+
+    const promoted = await this.prisma.deploymentEscrow.update({
+      where: { id: escrow.id },
+      data: {
         status: 'ACTIVE',
         lastBilledAt: new Date(),
       },
     })
 
     log.info(
-      { deploymentId: args.akashDeploymentId, depositCents, dailyRateCents, mode: depositCents > 0 ? 'pre-funded' : 'pay-as-you-go' },
+      { deploymentId: args.akashDeploymentId, depositCents, dailyRateCents, mode: 'pre-funded' },
       'Created escrow for deployment'
     )
 
-    return escrow
+    return promoted
+  }
+
+  /**
+   * Sweep escrows stuck in PENDING_DEPOSIT.
+   *
+   * A row stuck in this state means we wrote-ahead but never got a final
+   * answer from auth's escrow-deposit RPC (process crashed mid-flight,
+   * pod evicted, network blip, etc). Auth's idempotency key
+   * `escrow_deposit:<orgBillingId>:<deploymentId>` is deterministic from
+   * inputs we already have, so we can safely retry: if the prior call
+   * landed, the retry returns alreadyProcessed=true and we promote to
+   * ACTIVE; if it never landed, the retry executes for real.
+   *
+   * Rows older than `failAfterMs` get marked FAILED and the deployment
+   * is expected to be torn down upstream.
+   */
+  async reconcilePendingDeposits(opts: {
+    /** Only retry rows older than this (don't race the original caller). */
+    minAgeMs?: number
+    /** Mark rows older than this as terminally FAILED. */
+    failAfterMs?: number
+  } = {}): Promise<{ promoted: number; failed: number; remaining: number }> {
+    const minAgeMs = opts.minAgeMs ?? 60_000 // 1 min — give the original caller time to finish
+    const failAfterMs = opts.failAfterMs ?? 30 * 60_000 // 30 min — page after this
+
+    const now = Date.now()
+    const minAgeCutoff = new Date(now - minAgeMs)
+    const failCutoff = new Date(now - failAfterMs)
+
+    const stuck = await this.prisma.deploymentEscrow.findMany({
+      where: {
+        status: 'PENDING_DEPOSIT',
+        createdAt: { lt: minAgeCutoff },
+      },
+      include: {
+        akashDeployment: { select: { id: true, status: true } },
+      },
+    })
+
+    let promoted = 0
+    let failed = 0
+
+    for (const row of stuck) {
+      // Belt-and-braces: if the deployment row itself is gone or already
+      // closed/failed there is nothing meaningful to recover — mark FAILED.
+      const depStatus = row.akashDeployment?.status
+      const orphaned = !depStatus || ['CLOSED', 'CLOSE_FAILED', 'FAILED', 'PERMANENTLY_FAILED'].includes(depStatus)
+      const tooOld = row.createdAt < failCutoff
+
+      if (orphaned || tooOld) {
+        await this.prisma.deploymentEscrow.update({
+          where: { id: row.id },
+          data: { status: 'FAILED' },
+        })
+        failed++
+        log.warn(
+          {
+            escrowId: row.id,
+            deploymentId: row.akashDeploymentId,
+            ageMs: now - row.createdAt.getTime(),
+            depStatus,
+            reason: orphaned ? 'orphaned_deployment' : 'timeout',
+          },
+          'Escrow stuck in PENDING_DEPOSIT — marking FAILED',
+        )
+        continue
+      }
+
+      try {
+        // Idempotent retry — auth derives the key from orgBillingId+deploymentId.
+        await this.billingApi.escrowDeposit({
+          orgBillingId: row.orgBillingId,
+          organizationId: row.organizationId,
+          userId: 'reconciler',
+          amountCents: row.depositCents,
+          deploymentId: row.akashDeploymentId,
+          description: 'Akash escrow deposit (write-ahead reconcile)',
+        })
+        await this.prisma.deploymentEscrow.update({
+          where: { id: row.id },
+          data: { status: 'ACTIVE', lastBilledAt: new Date() },
+        })
+        promoted++
+        log.info(
+          { escrowId: row.id, deploymentId: row.akashDeploymentId, depositCents: row.depositCents },
+          'Reconciler promoted PENDING_DEPOSIT → ACTIVE',
+        )
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        log.warn(
+          { escrowId: row.id, deploymentId: row.akashDeploymentId, err: msg },
+          'Reconciler retry of PENDING_DEPOSIT failed — will retry next cycle',
+        )
+      }
+    }
+
+    return { promoted, failed, remaining: stuck.length - promoted - failed }
   }
 
   // ========================================
@@ -185,15 +332,76 @@ export class EscrowService {
       return escrow.refundedCents
     }
 
+    // Never try to refund a write-ahead deposit that hasn't
+    // settled. PENDING_DEPOSIT rows are handled by reconcilePendingDeposits;
+    // FAILED rows have no funds to return.
+    if (escrow.status === 'PENDING_DEPOSIT' || escrow.status === 'FAILED') {
+      log.warn(
+        { deploymentId: akashDeploymentId, status: escrow.status },
+        'refundEscrow called on a write-ahead deposit row — skipping; reconciler owns this state',
+      )
+      return 0
+    }
+
     const remaining = Math.max(0, escrow.depositCents - escrow.consumedCents)
 
-    if (remaining > 0) {
+    // Pay-as-you-go fast path: nothing was deposited so there
+    // is nothing to refund. Skip the write-ahead entirely so the closed/
+    // suspended-then-closed flow does not generate a no-op REFUNDING row.
+    if (remaining === 0) {
+      await this.prisma.deploymentEscrow.update({
+        where: { id: escrow.id },
+        data: { status: 'REFUNDED', refundedCents: 0 },
+      })
+      log.info({ deploymentId: akashDeploymentId }, 'Refunded escrow (no-op, depositCents=0)')
+      return 0
+    }
+
+    // Write-ahead REFUNDING. Without this marker, a crash
+    // between escrowRefund() and the local update would leave us in:
+    //   * Auth credited the wallet (idempotency key persists the credit)
+    //   * Local row still says ACTIVE/DEPLETED with refundedCents=0
+    //   * Next refundEscrow attempt would call escrowRefund again, which
+    //     idempotently no-ops on the auth side (alreadyProcessed=true) so
+    //     no double-credit, BUT we still wouldn't promote the row to
+    //     REFUNDED unless we also handle that case.
+    // The REFUNDING marker tells the refund reconciler "this row already
+    // attempted a refund; ask auth whether it landed and finalize state".
+    // We use updateMany with a status guard to avoid racing concurrent
+    // callers — only the caller that actually flips ACTIVE/DEPLETED →
+    // REFUNDING gets to make the RPC call.
+    const claim = await this.prisma.deploymentEscrow.updateMany({
+      where: {
+        id: escrow.id,
+        status: { in: ['ACTIVE', 'DEPLETED', 'PAUSED'] },
+      },
+      data: { status: 'REFUNDING' },
+    })
+    if (claim.count === 0) {
+      // Another caller raced us into REFUNDING; let them finish.
+      log.info(
+        { deploymentId: akashDeploymentId, status: escrow.status },
+        'refundEscrow lost the REFUNDING claim — another worker is finalizing',
+      )
+      return 0
+    }
+
+    try {
       await this.billingApi.escrowRefund({
         orgBillingId: escrow.orgBillingId,
         amountCents: remaining,
         deploymentId: akashDeploymentId,
         description: `Akash escrow refund — deployment closed ($${(remaining / 100).toFixed(2)})`,
       })
+    } catch (err) {
+      // Roll back the claim so the reconciler (or a subsequent retry)
+      // can pick this up cleanly. The next attempt will re-claim and
+      // re-issue the (idempotent) refund RPC.
+      await this.prisma.deploymentEscrow.updateMany({
+        where: { id: escrow.id, status: 'REFUNDING' },
+        data: { status: escrow.status },
+      }).catch(() => undefined)
+      throw err
     }
 
     await this.prisma.deploymentEscrow.update({
@@ -225,6 +433,85 @@ export class EscrowService {
     })
 
     return remaining
+  }
+
+  /**
+   * Sweep escrows stuck in REFUNDING.
+   *
+   * The auth-side refund RPC is idempotent (key:
+   * `escrow_refund:<orgBillingId>:<deploymentId>`), so a stuck row here
+   * means one of:
+   *   1. Crash between escrowRefund() succeeded and the local
+   *      `status: REFUNDED, refundedCents: remaining` update landed →
+   *      retry the credit (no-op idempotently) and finalize the row.
+   *   2. The credit RPC itself never landed → retry executes for real.
+   * Either way the user ends up with the refund and the row finalizes.
+   */
+  async reconcilePendingRefunds(opts: {
+    minAgeMs?: number
+    failAfterMs?: number
+  } = {}): Promise<{ completed: number; failed: number; remaining: number }> {
+    const minAgeMs = opts.minAgeMs ?? 60_000
+    const failAfterMs = opts.failAfterMs ?? 30 * 60_000
+
+    const now = Date.now()
+    const minAgeCutoff = new Date(now - minAgeMs)
+    const failCutoff = new Date(now - failAfterMs)
+
+    // updatedAt moves forward when refundEscrow flipped status to REFUNDING,
+    // so it is the right cursor for "how long has this been stuck".
+    const stuck = await this.prisma.deploymentEscrow.findMany({
+      where: {
+        status: 'REFUNDING',
+        updatedAt: { lt: minAgeCutoff },
+      },
+    })
+
+    let completed = 0
+    let failed = 0
+
+    for (const row of stuck) {
+      const tooOld = row.updatedAt < failCutoff
+      const remaining = Math.max(0, row.depositCents - row.consumedCents)
+
+      try {
+        if (remaining > 0) {
+          await this.billingApi.escrowRefund({
+            orgBillingId: row.orgBillingId,
+            amountCents: remaining,
+            deploymentId: row.akashDeploymentId,
+            description: 'Akash escrow refund (write-ahead reconcile)',
+          })
+        }
+        await this.prisma.deploymentEscrow.update({
+          where: { id: row.id },
+          data: { status: 'REFUNDED', refundedCents: remaining },
+        })
+        completed++
+        log.info(
+          { escrowId: row.id, deploymentId: row.akashDeploymentId, refundedCents: remaining },
+          'Reconciler completed REFUNDING → REFUNDED',
+        )
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        if (tooOld) {
+          // Persistent failure beyond the budget — leave REFUNDING and
+          // page so an operator can investigate auth-side state by hand.
+          failed++
+          log.error(
+            { escrowId: row.id, deploymentId: row.akashDeploymentId, ageMs: now - row.updatedAt.getTime(), err: msg },
+            'Refund reconciler exceeded budget — manual intervention required',
+          )
+        } else {
+          log.warn(
+            { escrowId: row.id, deploymentId: row.akashDeploymentId, err: msg },
+            'Refund reconciler retry failed — will retry next cycle',
+          )
+        }
+      }
+    }
+
+    return { completed, failed, remaining: stuck.length - completed }
   }
 
   // ========================================

--- a/src/services/billing/settlementLedger.ts
+++ b/src/services/billing/settlementLedger.ts
@@ -1,0 +1,291 @@
+import { Prisma } from '@prisma/client'
+import type {
+  PrismaClient,
+  PolicySettlementLedger,
+  SettlementProvider,
+  SettlementKind,
+} from '@prisma/client'
+import { getBillingApiClient } from './billingApiClient.js'
+import { createLogger } from '../../lib/logger.js'
+import { opsAlert } from '../../lib/opsAlert.js'
+
+const log = createLogger('settlement-ledger')
+
+export interface SettleViaLedgerArgs {
+  provider: SettlementProvider
+  kind: SettlementKind
+  deploymentRef: string
+  idempotencyKey: string
+  orgBillingId: string
+  amountCents: number
+  settledTo: Date
+  policyId?: string | null
+  serviceType: string
+  resource: string
+  description: string
+  metadata?: Prisma.InputJsonValue
+}
+
+export interface SettleViaLedgerResult {
+  ledgerId: string
+  status: 'COMMITTED' | 'PENDING' | 'FAILED'
+  alreadyProcessed: boolean
+  amountCents: number
+}
+
+/**
+ * Insert a PolicySettlementLedger row in PENDING state, then call
+ * computeDebit, then promote to COMMITTED.
+ *
+ * On RPC failure we leave the row PENDING (with `lastError` and bumped
+ * `attemptCount`) so `reconcilePendingSettlements` can retry. The auth
+ * service derives idempotency from the same `idempotencyKey` we stored
+ * locally, so retries are safe even if the prior attempt landed.
+ *
+ * If a row with the same idempotencyKey already exists (caller retried
+ * BEFORE the previous PENDING row was reconciled), we don't insert a
+ * second row — we re-attempt against the existing one.
+ */
+export async function settleViaLedger(
+  prisma: PrismaClient,
+  args: SettleViaLedgerArgs,
+): Promise<SettleViaLedgerResult> {
+  if (args.amountCents <= 0) {
+    throw new Error('settleViaLedger called with non-positive amountCents')
+  }
+
+  // Race-safe insert: rely on the UNIQUE(idempotencyKey) index. If the
+  // row already exists (concurrent caller, retry after restart, etc.)
+  // we read it back and re-attempt against the existing PENDING/COMMITTED.
+  let row: PolicySettlementLedger
+  try {
+    row = await prisma.policySettlementLedger.create({
+      data: {
+        provider: args.provider,
+        kind: args.kind,
+        deploymentRef: args.deploymentRef,
+        idempotencyKey: args.idempotencyKey,
+        orgBillingId: args.orgBillingId,
+        amountCents: args.amountCents,
+        settledTo: args.settledTo,
+        status: 'PENDING',
+        policyId: args.policyId ?? null,
+        metadata: args.metadata ?? Prisma.JsonNull,
+      },
+    })
+  } catch (err) {
+    // P2002 = unique constraint violation on idempotencyKey.
+    if ((err as { code?: string }).code !== 'P2002') {
+      throw err
+    }
+    const existing = await prisma.policySettlementLedger.findUnique({
+      where: { idempotencyKey: args.idempotencyKey },
+    })
+    if (!existing) throw err
+    row = existing
+
+    // If the row was already committed on a prior attempt we must NOT
+    // double-charge. Return the prior result.
+    if (row.status === 'COMMITTED') {
+      return {
+        ledgerId: row.id,
+        status: 'COMMITTED',
+        alreadyProcessed: true,
+        amountCents: row.amountCents,
+      }
+    }
+    // FAILED rows are sticky — caller (or operator) must investigate
+    // before retrying. Surface as failure rather than silently re-charging.
+    if (row.status === 'FAILED') {
+      log.error(
+        { ledgerId: row.id, idempotencyKey: row.idempotencyKey, lastError: row.lastError },
+        'settleViaLedger called against a FAILED ledger row — refusing to retry without operator action',
+      )
+      return {
+        ledgerId: row.id,
+        status: 'FAILED',
+        alreadyProcessed: false,
+        amountCents: row.amountCents,
+      }
+    }
+    // PENDING — fall through and attempt the debit using the
+    // already-stored amount/key (NEVER trust the new caller's amount,
+    // since that would let them re-charge with a different value).
+  }
+
+  const billingApi = getBillingApiClient()
+  try {
+    const result = await billingApi.computeDebit({
+      orgBillingId: row.orgBillingId,
+      amountCents: row.amountCents,
+      serviceType: args.serviceType,
+      provider: args.provider === 'PHALA' ? 'phala' : 'akash',
+      resource: args.resource,
+      description: args.description,
+      idempotencyKey: row.idempotencyKey,
+      metadata: {
+        ...(args.metadata as Record<string, unknown> | undefined),
+        ledgerId: row.id,
+        kind: row.kind,
+      },
+    })
+
+    const committed = await prisma.policySettlementLedger.update({
+      where: { id: row.id },
+      data: {
+        status: 'COMMITTED',
+        committedAt: new Date(),
+        attemptCount: { increment: 1 },
+        lastError: null,
+      },
+    })
+
+    return {
+      ledgerId: committed.id,
+      status: 'COMMITTED',
+      alreadyProcessed: Boolean(result.alreadyProcessed),
+      amountCents: committed.amountCents,
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    await prisma.policySettlementLedger
+      .update({
+        where: { id: row.id },
+        data: {
+          attemptCount: { increment: 1 },
+          lastError: message.slice(0, 500),
+        },
+      })
+      .catch((updateErr) => {
+        log.error(
+          { ledgerId: row.id, updateErr },
+          'Failed to record settlement-ledger attempt error — reconciler will still retry',
+        )
+      })
+    throw err
+  }
+}
+
+/**
+ * Sweep PENDING settlement-ledger rows.
+ *
+ * Each retry is idempotent on the auth side because we stored the
+ * idempotencyKey at write-ahead time; even if the prior attempt did
+ * land, the retry returns alreadyProcessed=true and we promote to
+ * COMMITTED safely.
+ *
+ * Rows older than `failAfterMs` are marked FAILED and operators are
+ * paged via opsAlert so the underlying root cause can be investigated.
+ */
+export async function reconcilePendingSettlements(
+  prisma: PrismaClient,
+  opts: {
+    minAgeMs?: number
+    failAfterMs?: number
+    limit?: number
+  } = {},
+): Promise<{ committed: number; failed: number; remaining: number }> {
+  const minAgeMs = opts.minAgeMs ?? 60_000
+  const failAfterMs = opts.failAfterMs ?? 30 * 60_000
+  const limit = opts.limit ?? 200
+
+  const now = Date.now()
+  const minAgeCutoff = new Date(now - minAgeMs)
+  const failCutoff = new Date(now - failAfterMs)
+
+  const stuck = await prisma.policySettlementLedger.findMany({
+    where: {
+      status: 'PENDING',
+      createdAt: { lt: minAgeCutoff },
+    },
+    orderBy: { createdAt: 'asc' },
+    take: limit,
+  })
+
+  let committed = 0
+  let failed = 0
+  const billingApi = getBillingApiClient()
+
+  for (const row of stuck) {
+    try {
+      const result = await billingApi.computeDebit({
+        orgBillingId: row.orgBillingId,
+        amountCents: row.amountCents,
+        serviceType: row.provider === 'PHALA' ? 'phala_tee' : 'akash_compute',
+        provider: row.provider === 'PHALA' ? 'phala' : 'akash',
+        resource: row.deploymentRef,
+        description: `Settlement reconcile (${row.kind})`,
+        idempotencyKey: row.idempotencyKey,
+        metadata: { ledgerId: row.id, kind: row.kind, source: 'reconciler' },
+      })
+      await prisma.policySettlementLedger.update({
+        where: { id: row.id },
+        data: {
+          status: 'COMMITTED',
+          committedAt: new Date(),
+          attemptCount: { increment: 1 },
+          lastError: null,
+        },
+      })
+      committed++
+      log.info(
+        {
+          ledgerId: row.id,
+          deploymentRef: row.deploymentRef,
+          amountCents: row.amountCents,
+          alreadyProcessed: result.alreadyProcessed,
+        },
+        'Settlement reconciler PENDING → COMMITTED',
+      )
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      const tooOld = row.createdAt < failCutoff
+      const nextStatus = tooOld ? 'FAILED' : 'PENDING'
+      await prisma.policySettlementLedger
+        .update({
+          where: { id: row.id },
+          data: {
+            status: nextStatus,
+            attemptCount: { increment: 1 },
+            lastError: message.slice(0, 500),
+          },
+        })
+        .catch(() => undefined)
+
+      if (tooOld) {
+        failed++
+        log.error(
+          { ledgerId: row.id, deploymentRef: row.deploymentRef, ageMs: now - row.createdAt.getTime(), err: message },
+          'Settlement reconciler exceeded budget — marking FAILED',
+        )
+        await opsAlert({
+          key: `settlement-ledger-failed:${row.id}`,
+          severity: 'critical',
+          title: 'Settlement ledger row stuck FAILED',
+          message:
+            `Settlement ledger ${row.id} (${row.provider} ${row.kind}) for deployment ${row.deploymentRef} ` +
+            `could not be committed after ${Math.round(failAfterMs / 60_000)} min. ` +
+            `User may have been charged on auth side without local promotion (or charge never landed). ` +
+            `Investigate before retrying.`,
+          context: {
+            ledgerId: row.id,
+            provider: row.provider,
+            kind: row.kind,
+            amountCents: row.amountCents,
+            idempotencyKey: row.idempotencyKey,
+            attemptCount: row.attemptCount + 1,
+            error: message.slice(0, 400),
+          },
+          suppressMs: 24 * 60 * 60 * 1000,
+        })
+      } else {
+        log.warn(
+          { ledgerId: row.id, deploymentRef: row.deploymentRef, err: message },
+          'Settlement reconciler retry failed — will retry next cycle',
+        )
+      }
+    }
+  }
+
+  return { committed, failed, remaining: stuck.length - committed - failed }
+}

--- a/src/services/concurrency/concurrencyService.test.ts
+++ b/src/services/concurrency/concurrencyService.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  assertAndIncrementOrgConcurrency,
+  ConcurrencyCapExceededError,
+  decrementOrgConcurrency,
+} from './concurrencyService.js'
+
+/**
+ * Build a minimal in-memory prisma double that mimics the
+ * SELECT FOR UPDATE → UPDATE flow inside
+ * `assertAndIncrementOrgConcurrency`. The interesting invariants we want
+ * to lock in:
+ *
+ *   1. The cap is strictly enforced (cap+1 throws).
+ *   2. The throw is `ConcurrencyCapExceededError` (caller depends on it
+ *      to surface the correct GraphQL error code).
+ *   3. Decrement clamps at zero (never goes negative under double-call).
+ */
+function buildPrismaDouble(initial: Record<string, number> = {}) {
+  const rows = new Map<string, number>(Object.entries(initial))
+  const exec = async (sql: string, ...params: unknown[]): Promise<number> => {
+    if (sql.includes('UPDATE organization_concurrency_counter')) {
+      const orgId = params[0] as string
+      const current = rows.get(orgId) ?? 0
+      rows.set(orgId, Math.max(0, current - 1))
+      return 1
+    }
+    return 0
+  }
+  return {
+    rows,
+    prisma: {
+      $executeRawUnsafe: vi.fn(exec),
+      $transaction: vi.fn(async (cb: (tx: any) => Promise<unknown>) => {
+        const tx = {
+          $queryRawUnsafe: vi.fn(async (_sql: string, orgId: string) => {
+            const v = rows.get(orgId)
+            return v === undefined ? [] : [{ active_count: v }]
+          }),
+          organizationConcurrencyCounter: {
+            create: vi.fn(async ({ data }: { data: { organizationId: string; activeCount: number } }) => {
+              if (rows.has(data.organizationId)) {
+                const err = new Error('unique violation') as Error & { code: string }
+                err.code = 'P2002'
+                throw err
+              }
+              rows.set(data.organizationId, data.activeCount)
+              return { ...data }
+            }),
+            update: vi.fn(async ({ where, data }: { where: { organizationId: string }; data: { activeCount: number } }) => {
+              rows.set(where.organizationId, data.activeCount)
+              return { organizationId: where.organizationId, activeCount: data.activeCount }
+            }),
+            upsert: vi.fn(),
+          },
+        }
+        return cb(tx)
+      }),
+    } as any,
+  }
+}
+
+describe('assertAndIncrementOrgConcurrency', () => {
+  it('bootstraps a counter row at 0 and increments to 1 on first deploy', async () => {
+    const { prisma, rows } = buildPrismaDouble()
+    const result = await assertAndIncrementOrgConcurrency(prisma, 'org-new', 5)
+    expect(result.activeCount).toBe(1)
+    expect(rows.get('org-new')).toBe(1)
+  })
+
+  it('rejects when the next claim would exceed the cap', async () => {
+    const { prisma } = buildPrismaDouble({ 'org-busy': 3 })
+    await expect(
+      assertAndIncrementOrgConcurrency(prisma, 'org-busy', 3),
+    ).rejects.toBeInstanceOf(ConcurrencyCapExceededError)
+  })
+
+  it('allows the claim that exactly hits the cap', async () => {
+    const { prisma, rows } = buildPrismaDouble({ 'org-edge': 4 })
+    const result = await assertAndIncrementOrgConcurrency(prisma, 'org-edge', 5)
+    expect(result.activeCount).toBe(5)
+    expect(rows.get('org-edge')).toBe(5)
+  })
+})
+
+describe('decrementOrgConcurrency', () => {
+  it('decrements an existing counter', async () => {
+    const { prisma, rows } = buildPrismaDouble({ 'org-1': 2 })
+    await decrementOrgConcurrency(prisma, 'org-1')
+    expect(rows.get('org-1')).toBe(1)
+  })
+
+  it('clamps at zero on double-decrement (idempotent close paths)', async () => {
+    const { prisma, rows } = buildPrismaDouble({ 'org-1': 0 })
+    await decrementOrgConcurrency(prisma, 'org-1')
+    await decrementOrgConcurrency(prisma, 'org-1')
+    expect(rows.get('org-1')).toBe(0)
+  })
+
+  it('is a no-op for null/undefined orgId (callers may not always have one)', async () => {
+    const { prisma } = buildPrismaDouble()
+    await expect(decrementOrgConcurrency(prisma, null)).resolves.toBeUndefined()
+    await expect(decrementOrgConcurrency(prisma, undefined)).resolves.toBeUndefined()
+    expect(prisma.$executeRawUnsafe).not.toHaveBeenCalled()
+  })
+})

--- a/src/services/concurrency/concurrencyService.ts
+++ b/src/services/concurrency/concurrencyService.ts
@@ -1,0 +1,234 @@
+/**
+ * Per-org concurrency counter service.
+ *
+ * Replaces the racy COUNT(*) check in `assertOrgConcurrency` with a
+ * row-locked counter in `OrganizationConcurrencyCounter`. The full
+ * lifecycle is:
+ *
+ *   1. Caller asks `assertAndIncrement(orgId, cap)`.
+ *      - Open transaction.
+ *      - SELECT FOR UPDATE the counter row (creating it at 0 if needed).
+ *      - If `activeCount + 1 > cap` → throw, transaction rolls back.
+ *      - Otherwise UPDATE active_count = active_count + 1, commit.
+ *
+ *   2. On every close path (success, failure, sweeper, suspension)
+ *      caller invokes `decrement(orgId)`. The counter is clamped at 0
+ *      so a double-decrement is idempotent.
+ *
+ *   3. The hourly reconciler `reconcileAll()` recomputes activeCount
+ *      from the deployments table and overwrites the counter, so
+ *      drift never accumulates past one cycle.
+ */
+
+import type { PrismaClient } from '@prisma/client'
+import { createLogger } from '../../lib/logger.js'
+
+const log = createLogger('concurrency-service')
+
+export class ConcurrencyCapExceededError extends Error {
+  constructor(
+    public readonly organizationId: string,
+    public readonly activeCount: number,
+    public readonly cap: number,
+  ) {
+    super(`Concurrency cap exceeded for org ${organizationId}: ${activeCount}/${cap}`)
+    this.name = 'ConcurrencyCapExceededError'
+  }
+}
+
+/**
+ * Reserve a concurrency slot for `organizationId`. Throws
+ * `ConcurrencyCapExceededError` if the cap would be exceeded; that
+ * sentinel lets callers translate to the appropriate user-facing error
+ * (GraphQLError CONCURRENCY_LIMIT_REACHED) without coupling this layer
+ * to GraphQL.
+ *
+ * `cap` is passed in so the caller (launchGuards) controls the tier
+ * lookup; this service only enforces the row-locked claim.
+ */
+export async function assertAndIncrementOrgConcurrency(
+  prisma: PrismaClient,
+  organizationId: string,
+  cap: number,
+): Promise<{ activeCount: number }> {
+  return prisma.$transaction(async (tx) => {
+    // Bootstrap the row if missing — happens on first deploy ever for
+    // an org. We do NOT use upsert here because we need the SELECT FOR
+    // UPDATE lock and Prisma's upsert doesn't expose row-level locking.
+    const existingRows = await tx.$queryRawUnsafe<{ active_count: number }[]>(
+      `SELECT active_count FROM organization_concurrency_counter
+       WHERE organization_id = $1
+       FOR UPDATE`,
+      organizationId,
+    )
+
+    let current: number
+    if (existingRows.length === 0) {
+      // Concurrent inserts of the same orgId can race; we let the unique
+      // PK reject the loser and re-read.
+      try {
+        await tx.organizationConcurrencyCounter.create({
+          data: { organizationId, activeCount: 0 },
+        })
+      } catch (err) {
+        if ((err as { code?: string }).code !== 'P2002') throw err
+      }
+      const reread = await tx.$queryRawUnsafe<{ active_count: number }[]>(
+        `SELECT active_count FROM organization_concurrency_counter
+         WHERE organization_id = $1
+         FOR UPDATE`,
+        organizationId,
+      )
+      current = reread[0]?.active_count ?? 0
+    } else {
+      current = existingRows[0].active_count
+    }
+
+    if (current + 1 > cap) {
+      throw new ConcurrencyCapExceededError(organizationId, current, cap)
+    }
+
+    const updated = await tx.organizationConcurrencyCounter.update({
+      where: { organizationId },
+      data: { activeCount: current + 1 },
+    })
+    return { activeCount: updated.activeCount }
+  })
+}
+
+/**
+ * Release a concurrency slot. Idempotent: clamps at 0 so a double-call
+ * (one from the resolver, one from the sweeper, etc.) is safe.
+ *
+ * If the row doesn't exist there is nothing to decrement — just no-op.
+ */
+export async function decrementOrgConcurrency(
+  prisma: PrismaClient,
+  organizationId: string | null | undefined,
+): Promise<void> {
+  if (!organizationId) return
+
+  // The clamping `GREATEST(0, …)` is what makes double-decrements safe.
+  // We use a raw query because Prisma's `decrement` doesn't have a
+  // built-in floor and a TX wrapper for one statement is overkill.
+  await prisma.$executeRawUnsafe(
+    `UPDATE organization_concurrency_counter
+     SET active_count = GREATEST(0, active_count - 1),
+         "updatedAt" = NOW()
+     WHERE organization_id = $1`,
+    organizationId,
+  )
+}
+
+/**
+ * Counts the deployments that should occupy a concurrency slot for an org.
+ * Mirrors the WHERE clause in `assertOrgConcurrency` so the reconciler
+ * stays in lock-step with the launch-time check.
+ */
+async function countActiveDeploymentsForOrg(
+  prisma: PrismaClient,
+  organizationId: string,
+): Promise<number> {
+  const [akashActive, phalaActive] = await Promise.all([
+    prisma.akashDeployment.count({
+      where: {
+        status: { in: ['CREATING', 'WAITING_BIDS', 'SELECTING_BID', 'CREATING_LEASE', 'SENDING_MANIFEST', 'DEPLOYING', 'ACTIVE'] },
+        service: { project: { organizationId } },
+      },
+    }),
+    prisma.phalaDeployment.count({
+      where: {
+        status: { in: ['CREATING', 'STARTING', 'ACTIVE'] },
+        organizationId,
+      },
+    }),
+  ])
+  return akashActive + phalaActive
+}
+
+/**
+ * Recompute the counter for a single org from the deployment tables.
+ * Used by the reconciler and by callers that need to bootstrap a row
+ * during runtime (e.g. legacy orgs that pre-date the counter).
+ */
+export async function recomputeOrgConcurrency(
+  prisma: PrismaClient,
+  organizationId: string,
+): Promise<{ activeCount: number; previous: number | null }> {
+  const actual = await countActiveDeploymentsForOrg(prisma, organizationId)
+  const upserted = await prisma.organizationConcurrencyCounter.upsert({
+    where: { organizationId },
+    update: { activeCount: actual },
+    create: { organizationId, activeCount: actual },
+  })
+  return { activeCount: upserted.activeCount, previous: null }
+}
+
+/**
+ * Hourly reconciler: walk every counter row + every org that has a
+ * counter-eligible deployment, recompute, and overwrite. Drift is
+ * logged so we can see whether a particular close path is missing a
+ * decrement.
+ *
+ * Bounded `limit` because we don't want a one-off inventory walk to
+ * pin the DB. The job re-runs hourly so anything skipped this cycle
+ * gets picked up next.
+ */
+export async function reconcileAll(
+  prisma: PrismaClient,
+  opts: { limit?: number } = {},
+): Promise<{ scanned: number; drifted: number }> {
+  const limit = opts.limit ?? 5000
+
+  // Union of (orgs with a counter row) ∪ (orgs that currently own a
+  // counter-eligible deployment). The right-hand side catches orgs
+  // that have never had a counter row yet still have live deployments
+  // (legacy data from before the counter shipped).
+  const counterOrgs = await prisma.organizationConcurrencyCounter.findMany({
+    select: { organizationId: true, activeCount: true },
+    take: limit,
+  })
+  const phalaOrgs = await prisma.phalaDeployment.findMany({
+    where: { organizationId: { not: null }, status: { in: ['CREATING', 'STARTING', 'ACTIVE'] } },
+    select: { organizationId: true },
+    distinct: ['organizationId'],
+    take: limit,
+  })
+  const akashOrgsRaw = await prisma.akashDeployment.findMany({
+    where: { status: { in: ['CREATING', 'WAITING_BIDS', 'SELECTING_BID', 'CREATING_LEASE', 'SENDING_MANIFEST', 'DEPLOYING', 'ACTIVE'] } },
+    select: { service: { select: { project: { select: { organizationId: true } } } } },
+    take: limit,
+  })
+
+  const orgIds = new Set<string>()
+  for (const c of counterOrgs) orgIds.add(c.organizationId)
+  for (const p of phalaOrgs) {
+    if (p.organizationId) orgIds.add(p.organizationId)
+  }
+  for (const a of akashOrgsRaw) {
+    const id = a.service?.project?.organizationId
+    if (id) orgIds.add(id)
+  }
+
+  const counterMap = new Map(counterOrgs.map((c) => [c.organizationId, c.activeCount]))
+
+  let drifted = 0
+  for (const orgId of orgIds) {
+    const actual = await countActiveDeploymentsForOrg(prisma, orgId)
+    const stored = counterMap.get(orgId) ?? null
+    if (stored !== actual) {
+      drifted++
+      log.warn(
+        { orgId, stored, actual },
+        'Concurrency counter drift — recomputing from deployments table',
+      )
+    }
+    await prisma.organizationConcurrencyCounter.upsert({
+      where: { organizationId: orgId },
+      update: { activeCount: actual },
+      create: { organizationId: orgId, activeCount: actual },
+    })
+  }
+
+  return { scanned: orgIds.size, drifted }
+}

--- a/src/services/leader/leaderElection.ts
+++ b/src/services/leader/leaderElection.ts
@@ -1,0 +1,321 @@
+/**
+ * Heartbeat-based leader election for singleton schedulers.
+ *
+ * The lease row in `scheduler_leader_lease` records who currently owns
+ * a given scheduler key. A pod becomes leader by INSERTing or UPDATEing
+ * the row in a single atomic statement that only succeeds if:
+ *   * no row exists yet (first start ever), OR
+ *   * the existing row has expired (previous leader crashed), OR
+ *   * we are already the leader (heartbeat renewal).
+ *
+ * The leader renews `expires_at` every `LEADER_HEARTBEAT_MS`. If the
+ * renewal fails (DB down, lost the lease, etc.) the local scheduler is
+ * stopped immediately. Standbys keep polling and one of them takes
+ * over once the previous lease expires.
+ *
+ * IMPORTANT: every scheduler wrapped by `runWithLeadership` MUST be
+ * idempotent under "skipped one tick" semantics. There is a window of
+ * up to `LEASE_TTL_MS - HEARTBEAT_MS` after a leader crash where no
+ * pod is running the scheduler.
+ */
+
+import { randomUUID } from 'node:crypto'
+import type { PrismaClient } from '@prisma/client'
+import { createLogger } from '../../lib/logger.js'
+
+const log = createLogger('leader-election')
+
+const HEARTBEAT_MS = parseInt(process.env.LEADER_HEARTBEAT_MS ?? '20000', 10)
+const LEASE_TTL_MS = parseInt(process.env.LEADER_LEASE_TTL_MS ?? '60000', 10)
+const LEADER_DISABLED = process.env.LEADER_ELECTION_DISABLED === 'true'
+
+if (LEASE_TTL_MS <= HEARTBEAT_MS * 2) {
+  // Misconfiguration that would cause flapping (renewal fails to land
+  // before expiry under any DB latency). Loud at boot, never silent.
+  log.warn(
+    { HEARTBEAT_MS, LEASE_TTL_MS },
+    'LEADER_LEASE_TTL_MS should be at least 2x LEADER_HEARTBEAT_MS to tolerate transient DB latency',
+  )
+}
+
+const PROCESS_LEADER_ID = `${process.env.HOSTNAME ?? 'unknown'}:${randomUUID()}`
+
+export interface LeaderHandle {
+  readonly schedulerKey: string
+  readonly leaderId: string
+  /** Released by the lifecycle manager — callers should not invoke directly. */
+  stop(): Promise<void>
+  /** True while we still believe we own the lease. */
+  isLeader(): boolean
+}
+
+export interface RunWithLeadershipOptions {
+  /** Override the global heartbeat interval for this scheduler. */
+  heartbeatMs?: number
+  /** Override the global lease TTL for this scheduler. */
+  leaseTtlMs?: number
+  /**
+   * Called when leadership is lost (renewal failure, race, etc). The
+   * caller must stop the scheduler. Re-acquisition is handled by the
+   * outer poll loop and `onAcquire` will fire again.
+   */
+  onLost?: (reason: string) => void | Promise<void>
+}
+
+interface SchedulerLifecycle {
+  /** Called once when this pod becomes leader. Start the work. */
+  onAcquire: (handle: LeaderHandle) => void | Promise<void>
+  /** Called when leadership is lost. Stop the work. */
+  onRelease: () => void | Promise<void>
+}
+
+interface RunningLease {
+  schedulerKey: string
+  leaderId: string
+  heartbeatMs: number
+  leaseTtlMs: number
+  intervalHandle: ReturnType<typeof setInterval> | null
+  pollHandle: ReturnType<typeof setInterval> | null
+  isLeader: boolean
+  stopped: boolean
+  lifecycle: SchedulerLifecycle
+  options: RunWithLeadershipOptions
+}
+
+const running = new Map<string, RunningLease>()
+
+async function tryAcquire(
+  prisma: PrismaClient,
+  schedulerKey: string,
+  leaderId: string,
+  leaseTtlMs: number,
+): Promise<boolean> {
+  // Atomic acquire-or-renew. Postgres UPSERT semantics:
+  //   * row missing → INSERT, rows[0].leader_id = us → success
+  //   * row exists with our id → UPDATE (renewal), success
+  //   * row exists, different id, expired → UPDATE (steal), success
+  //   * row exists, different id, NOT expired → no rows updated, fail
+  //
+  // We compare leader_id in a CTE so that the WHERE clause runs against
+  // the ROW that was there pre-update; otherwise the freshly-written
+  // value would always equal `leaderId` and we'd think every collision
+  // succeeded.
+  const rows = await prisma.$queryRawUnsafe<{ leader_id: string }[]>(
+    `INSERT INTO scheduler_leader_lease (scheduler_key, leader_id, acquired_at, expires_at, "updatedAt")
+     VALUES ($1, $2, NOW(), NOW() + ($3 || ' milliseconds')::interval, NOW())
+     ON CONFLICT (scheduler_key) DO UPDATE
+       SET leader_id = EXCLUDED.leader_id,
+           acquired_at = CASE WHEN scheduler_leader_lease.leader_id = EXCLUDED.leader_id
+                              THEN scheduler_leader_lease.acquired_at
+                              ELSE EXCLUDED.acquired_at END,
+           expires_at = EXCLUDED.expires_at,
+           "updatedAt" = NOW()
+       WHERE scheduler_leader_lease.expires_at < NOW()
+          OR scheduler_leader_lease.leader_id = EXCLUDED.leader_id
+     RETURNING leader_id`,
+    schedulerKey,
+    leaderId,
+    String(leaseTtlMs),
+  )
+  return rows.length > 0 && rows[0].leader_id === leaderId
+}
+
+async function releaseLease(
+  prisma: PrismaClient,
+  schedulerKey: string,
+  leaderId: string,
+): Promise<void> {
+  // Only release if we still hold the lease — guards against accidental
+  // delete after a steal.
+  await prisma
+    .$executeRawUnsafe(
+      `DELETE FROM scheduler_leader_lease
+       WHERE scheduler_key = $1 AND leader_id = $2`,
+      schedulerKey,
+      leaderId,
+    )
+    .catch((err) => {
+      log.warn({ err, schedulerKey }, 'Failed to release leader lease (will expire naturally)')
+    })
+}
+
+async function onLost(state: RunningLease, reason: string): Promise<void> {
+  if (!state.isLeader) return
+  state.isLeader = false
+  log.warn({ schedulerKey: state.schedulerKey, reason }, 'Leadership lost')
+  try {
+    await state.lifecycle.onRelease()
+  } catch (err) {
+    log.error({ err, schedulerKey: state.schedulerKey }, 'onRelease threw — scheduler may be in a torn state')
+  }
+  if (state.options.onLost) {
+    try {
+      await state.options.onLost(reason)
+    } catch (err) {
+      log.warn({ err, schedulerKey: state.schedulerKey }, 'onLost callback threw')
+    }
+  }
+}
+
+async function attemptAcquireAndStart(
+  prisma: PrismaClient,
+  state: RunningLease,
+): Promise<void> {
+  if (state.isLeader || state.stopped) return
+  let won = false
+  try {
+    won = await tryAcquire(prisma, state.schedulerKey, state.leaderId, state.leaseTtlMs)
+  } catch (err) {
+    log.warn({ err, schedulerKey: state.schedulerKey }, 'Lease acquire failed (will retry)')
+    return
+  }
+  if (!won) return
+
+  state.isLeader = true
+  log.info(
+    { schedulerKey: state.schedulerKey, leaderId: state.leaderId },
+    'Acquired leader lease — starting scheduler',
+  )
+
+  // Start heartbeat first so a slow `onAcquire` doesn't lose us the
+  // lease while we boot.
+  state.intervalHandle = setInterval(() => {
+    void (async () => {
+      if (state.stopped) return
+      try {
+        const ok = await tryAcquire(prisma, state.schedulerKey, state.leaderId, state.leaseTtlMs)
+        if (!ok) {
+          await onLost(state, 'heartbeat-renewal-rejected')
+        }
+      } catch (err) {
+        log.error({ err, schedulerKey: state.schedulerKey }, 'Heartbeat threw — relinquishing leadership')
+        await onLost(state, 'heartbeat-threw')
+      }
+    })()
+  }, state.heartbeatMs)
+
+  try {
+    const handle: LeaderHandle = {
+      schedulerKey: state.schedulerKey,
+      leaderId: state.leaderId,
+      isLeader: () => state.isLeader,
+      stop: () => stopLifecycle(prisma, state),
+    }
+    await state.lifecycle.onAcquire(handle)
+  } catch (err) {
+    log.error({ err, schedulerKey: state.schedulerKey }, 'onAcquire threw — releasing lease')
+    await onLost(state, 'on-acquire-threw')
+    if (state.intervalHandle) clearInterval(state.intervalHandle)
+    state.intervalHandle = null
+    await releaseLease(prisma, state.schedulerKey, state.leaderId)
+  }
+}
+
+async function stopLifecycle(prisma: PrismaClient, state: RunningLease): Promise<void> {
+  if (state.stopped) return
+  state.stopped = true
+  if (state.intervalHandle) clearInterval(state.intervalHandle)
+  state.intervalHandle = null
+  if (state.pollHandle) clearInterval(state.pollHandle)
+  state.pollHandle = null
+  if (state.isLeader) {
+    state.isLeader = false
+    try {
+      await state.lifecycle.onRelease()
+    } catch (err) {
+      log.error({ err, schedulerKey: state.schedulerKey }, 'onRelease threw during shutdown')
+    }
+    await releaseLease(prisma, state.schedulerKey, state.leaderId)
+  }
+  running.delete(state.schedulerKey)
+}
+
+/**
+ * Run a singleton scheduler under a leader lease. Multiple replicas
+ * can call this concurrently — only one will be elected. The others
+ * keep polling so they can take over within `leaseTtlMs` if the
+ * current leader crashes.
+ *
+ * The returned handle is idempotent: calling `stop()` multiple times
+ * is safe.
+ *
+ * Setting `LEADER_ELECTION_DISABLED=true` in the env runs the
+ * scheduler immediately without any election, for local dev with one
+ * replica or for emergencies where the lease table itself is
+ * unavailable.
+ */
+export async function runWithLeadership(
+  prisma: PrismaClient,
+  schedulerKey: string,
+  lifecycle: SchedulerLifecycle,
+  options: RunWithLeadershipOptions = {},
+): Promise<LeaderHandle> {
+  const heartbeatMs = options.heartbeatMs ?? HEARTBEAT_MS
+  const leaseTtlMs = options.leaseTtlMs ?? LEASE_TTL_MS
+
+  if (LEADER_DISABLED) {
+    log.warn(
+      { schedulerKey },
+      'LEADER_ELECTION_DISABLED=true — running scheduler without lease (single-replica mode)',
+    )
+    const handle: LeaderHandle = {
+      schedulerKey,
+      leaderId: PROCESS_LEADER_ID,
+      isLeader: () => true,
+      stop: async () => {
+        try {
+          await lifecycle.onRelease()
+        } catch (err) {
+          log.error({ err, schedulerKey }, 'onRelease threw during disabled-mode shutdown')
+        }
+      },
+    }
+    await lifecycle.onAcquire(handle)
+    return handle
+  }
+
+  if (running.has(schedulerKey)) {
+    throw new Error(`Scheduler ${schedulerKey} already registered with leader election`)
+  }
+
+  const state: RunningLease = {
+    schedulerKey,
+    leaderId: PROCESS_LEADER_ID,
+    heartbeatMs,
+    leaseTtlMs,
+    intervalHandle: null,
+    pollHandle: null,
+    isLeader: false,
+    stopped: false,
+    lifecycle,
+    options,
+  }
+  running.set(schedulerKey, state)
+
+  // Try once eagerly so a single-replica deploy doesn't wait the full
+  // poll interval before starting the scheduler.
+  await attemptAcquireAndStart(prisma, state)
+
+  // Poll for the lease at twice the heartbeat rate. Followers check
+  // often enough that takeover happens within ~1 heartbeat of crash.
+  state.pollHandle = setInterval(() => {
+    void attemptAcquireAndStart(prisma, state)
+  }, Math.max(1000, Math.floor(heartbeatMs / 2)))
+
+  return {
+    schedulerKey,
+    leaderId: PROCESS_LEADER_ID,
+    isLeader: () => state.isLeader,
+    stop: () => stopLifecycle(prisma, state),
+  }
+}
+
+/**
+ * Stop every leader-managed scheduler in this process. Used during
+ * graceful shutdown so we release leases promptly (otherwise standbys
+ * wait for `LEASE_TTL_MS` before taking over).
+ */
+export async function stopAllLeaderSchedulers(prisma: PrismaClient): Promise<void> {
+  const states = Array.from(running.values())
+  await Promise.all(states.map((s) => stopLifecycle(prisma, s)))
+}

--- a/src/services/queue/staleDeploymentSweeper.ts
+++ b/src/services/queue/staleDeploymentSweeper.ts
@@ -31,6 +31,7 @@ import {
 const log = createLogger('stale-sweeper')
 
 const STALE_THRESHOLD_MS = 25 * 60 * 1000 // 25 minutes
+const STALE_THRESHOLD_MIN = STALE_THRESHOLD_MS / 60_000
 const SWEEP_INTERVAL_MS = 5 * 60 * 1000   // 5 minutes
 const LIVENESS_MIN_AGE_MS = 10 * 60 * 1000 // only check deployments ACTIVE for >10 min
 
@@ -48,7 +49,7 @@ let activeSweep: Promise<void> | null = null
 async function sweepStaleDeployments(prisma: PrismaClient): Promise<void> {
   const cutoff = new Date(Date.now() - STALE_THRESHOLD_MS)
 
-  // Akash: find deployments stuck in intermediate states for >15 min
+  // Akash: find deployments stuck in intermediate states past the threshold
   try {
     const staleAkash = await prisma.akashDeployment.findMany({
       where: {
@@ -73,7 +74,7 @@ async function sweepStaleDeployments(prisma: PrismaClient): Promise<void> {
         where: { id: dep.id, status: dep.status },
         data: {
           status: 'FAILED',
-          errorMessage: `Stale deployment detected: stuck in ${dep.status} for >15 minutes (swept at ${new Date().toISOString()})`,
+          errorMessage: `Stale deployment detected: stuck in ${dep.status} for >${STALE_THRESHOLD_MIN} minutes (swept at ${new Date().toISOString()})`,
         },
       })
     }
@@ -85,7 +86,7 @@ async function sweepStaleDeployments(prisma: PrismaClient): Promise<void> {
     log.error(err as Error, 'Error sweeping Akash deployments')
   }
 
-  // Phala: find deployments stuck in intermediate states for >15 min
+  // Phala: find deployments stuck in intermediate states past the threshold
   try {
     const stalePhala = await prisma.phalaDeployment.findMany({
       where: {
@@ -110,7 +111,7 @@ async function sweepStaleDeployments(prisma: PrismaClient): Promise<void> {
         where: { id: dep.id, status: dep.status },
         data: {
           status: 'FAILED',
-          errorMessage: `Stale deployment detected: stuck in ${dep.status} for >15 minutes (swept at ${new Date().toISOString()})`,
+          errorMessage: `Stale deployment detected: stuck in ${dep.status} for >${STALE_THRESHOLD_MIN} minutes (swept at ${new Date().toISOString()})`,
         },
       })
     }

--- a/src/services/queue/staleDeploymentSweeper.ts
+++ b/src/services/queue/staleDeploymentSweeper.ts
@@ -18,6 +18,7 @@ import { getPhalaOrchestrator } from '../phala/index.js'
 import { settleAkashEscrowToTime } from '../billing/deploymentSettlement.js'
 import { getEscrowService } from '../billing/escrowService.js'
 import { getAvailableProviders } from '../providers/registry.js'
+import { decrementOrgConcurrency } from '../concurrency/concurrencyService.js'
 import { createLogger } from '../../lib/logger.js'
 import { audit } from '../../lib/audit.js'
 import { randomUUID } from 'node:crypto'
@@ -56,27 +57,65 @@ async function sweepStaleDeployments(prisma: PrismaClient): Promise<void> {
         status: { in: [...AKASH_INTERMEDIATE_STATES] },
         updatedAt: { lt: cutoff },
       },
-      select: { id: true, status: true, updatedAt: true, retryCount: true, dseq: true },
+      select: {
+        id: true,
+        status: true,
+        updatedAt: true,
+        retryCount: true,
+        dseq: true,
+        service: { select: { project: { select: { organizationId: true } } } },
+      },
     })
 
     for (const dep of staleAkash) {
       log.warn(`Akash deployment ${dep.id} stuck in ${dep.status} since ${dep.updatedAt.toISOString()} — marking FAILED`)
+
+      // Switch on the structured close result so a
+      // failed on-chain close doesn't get masked as success. A
+      // FAILED close means the lease is potentially still live and
+      // draining escrow; we mark CLOSE_FAILED so the next sweeper
+      // pass / operator knows to retry.
+      let closeStatus: 'CLOSED' | 'ALREADY_CLOSED' | 'FAILED' | 'NO_DSEQ' = 'NO_DSEQ'
+      let closeError: string | undefined
       if (dep.dseq && Number(dep.dseq) > 0) {
-        try {
-          const orchestrator = getAkashOrchestrator(prisma)
-          await orchestrator.closeDeployment(Number(dep.dseq))
-          log.info(`Closed on-chain deployment dseq=${dep.dseq} during stale sweep`)
-        } catch (closeErr) {
-          log.warn({ dseq: String(dep.dseq), err: closeErr }, 'Failed to close on-chain deployment during sweep — may still be leaking')
+        const orchestrator = getAkashOrchestrator(prisma)
+        const result = await orchestrator.closeDeployment(Number(dep.dseq))
+        closeStatus = result.chainStatus
+        if (result.chainStatus === 'CLOSED' || result.chainStatus === 'ALREADY_CLOSED') {
+          log.info(
+            { dseq: String(dep.dseq), chainStatus: result.chainStatus },
+            'On-chain deployment closed during stale sweep',
+          )
+        } else {
+          closeError = result.error
+          log.warn(
+            { dseq: String(dep.dseq), chainStatus: result.chainStatus, error: closeError },
+            'On-chain close FAILED during sweep — marking CLOSE_FAILED for retry',
+          )
         }
       }
-      await prisma.akashDeployment.updateMany({
+
+      const finalStatus = closeStatus === 'FAILED' ? 'CLOSE_FAILED' : 'FAILED'
+      const errorMessage =
+        closeStatus === 'FAILED'
+          ? `Stale deployment swept but on-chain close failed: ${closeError ?? 'unknown'} (swept at ${new Date().toISOString()})`
+          : `Stale deployment detected: stuck in ${dep.status} for >${STALE_THRESHOLD_MIN} minutes (swept at ${new Date().toISOString()})`
+
+      const result = await prisma.akashDeployment.updateMany({
         where: { id: dep.id, status: dep.status },
         data: {
-          status: 'FAILED',
-          errorMessage: `Stale deployment detected: stuck in ${dep.status} for >${STALE_THRESHOLD_MIN} minutes (swept at ${new Date().toISOString()})`,
+          status: finalStatus,
+          errorMessage,
         },
       })
+
+      // Only release a slot if we actually transitioned the row this
+      // pass — `updateMany` returns count=0 when another worker beat us
+      // to it (in which case THEY decremented, not us).
+      if (result.count > 0) {
+        await decrementOrgConcurrency(prisma, dep.service?.project?.organizationId)
+          .catch((err) => log.warn({ err, deploymentId: dep.id }, 'Concurrency decrement failed (stale Akash)'))
+      }
     }
 
     if (staleAkash.length > 0) {
@@ -93,7 +132,7 @@ async function sweepStaleDeployments(prisma: PrismaClient): Promise<void> {
         status: { in: [...PHALA_INTERMEDIATE_STATES] },
         updatedAt: { lt: cutoff },
       },
-      select: { id: true, status: true, updatedAt: true, retryCount: true, appId: true },
+      select: { id: true, status: true, updatedAt: true, retryCount: true, appId: true, organizationId: true },
     })
 
     for (const dep of stalePhala) {
@@ -107,13 +146,17 @@ async function sweepStaleDeployments(prisma: PrismaClient): Promise<void> {
           log.warn({ appId: dep.appId, err: delErr }, 'Failed to delete CVM during sweep')
         }
       }
-      await prisma.phalaDeployment.updateMany({
+      const result = await prisma.phalaDeployment.updateMany({
         where: { id: dep.id, status: dep.status },
         data: {
           status: 'FAILED',
           errorMessage: `Stale deployment detected: stuck in ${dep.status} for >${STALE_THRESHOLD_MIN} minutes (swept at ${new Date().toISOString()})`,
         },
       })
+      if (result.count > 0) {
+        await decrementOrgConcurrency(prisma, dep.organizationId)
+          .catch((err) => log.warn({ err, deploymentId: dep.id }, 'Concurrency decrement failed (stale Phala)'))
+      }
     }
 
     if (stalePhala.length > 0) {


### PR DESCRIPTION
§3.10 — assertSubscriptionActive now blocks deployments for SUSPENDED,
PAST_DUE, CANCELED, and TRIAL_EXPIRED-past-grace, each with a distinct
GraphQLError code so the web app can show a targeted CTA. Previously
only SUSPENDED was blocked, so canceled / past-due orgs could keep
spending Akash & Phala funds we'd never recover.

§3.18 — staleDeploymentSweeper threshold drift fixed: STALE_THRESHOLD_MS
and the log copy used to disagree (25 min vs "15 min"); both now read
from a single STALE_THRESHOLD_MIN constant.

§3.23 — Disable GraphQL landing page + introspection in production.
NoSchemaIntrospectionCustomRule is added to validation rules unless
GRAPHQL_FORCE_ENABLE_INTROSPECTION=true is explicitly set (escape
hatch for staging debugging).

§3.36 — Redact PATs (af_live_/af_test_), JWTs, Bearer tokens, Stripe
keys (sk_live_/pk_live_), and OpenAI/Anthropic keys (sk-…) from the
useLogging GraphQL plugin's onExecute query log via TOKEN_REDACTORS.

§3.12 — deploy-aws.yml + deploy-aws-staging.yml capture build digest
and use `IMAGE@sha256:…` for both prisma migrate jobs and
kubectl set image, removing the mutable-tag race.

§3.11 — REPLICAS:2 enabler:
- src/index.ts wires every singleton scheduler through
  runWithLeadership() (storage-snapshot, invoice, compute-billing,
  escrow-health, provider-registry, audit-export, provider-verification,
  stale-deployment-sweeper). Per-pod-safe schedulers (usageAggregator,
  telemetryIngestionService) remain unconditional.
- setWalletMutexPrisma(prisma) is invoked at boot so withChainAdvisoryLock
  can serialize Akash chain TXs across replicas via pg_advisory_xact_lock,
  preventing Cosmos account-sequence collisions.
- gracefulShutdown now calls stopAllLeaderSchedulers(prisma) so leases
  are released promptly on SIGTERM (otherwise standbys wait LEASE_TTL_MS).
§3.32 — supply-chain hardening:
- .github/workflows/deploy-aws.yml: cosign keyless sign, syft SBOM
  (CycloneDX + SPDX), cosign attest, trivy CRITICAL-blocking scan
  with HIGH report and SARIF code-scanning upload. Adds id-token
  and security-events permissions. Honors SUPPLY_CHAIN_DISABLED and
  SUPPLY_CHAIN_TRIVY_BLOCK escape hatches.
  
669/669 vitest tests pass; tsc --noEmit clean.