### PR TITLE
add Service.flavor discriminator (docker|server|function|template)

### DIFF
--- a/prisma/migrations/20260418090000_add_service_flavor/migration.sql
+++ b/prisma/migrations/20260418090000_add_service_flavor/migration.sql
@@ -1,0 +1,6 @@
+-- Phase 39: discriminator for the create-time flavor of a Service.
+-- Allowed values (validated in the resolver): 'docker' | 'server' | 'function' | 'template'.
+-- Free-form String (not Prisma enum) to keep migrations cheap and forward-compatible
+-- when new catalog flows are added. Null = legacy row; readers default to 'docker'
+-- for VM rows and 'function' for FUNCTION rows (matches today's UI fall-through).
+ALTER TABLE "Service" ADD COLUMN "flavor" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -255,6 +255,7 @@ model Service {
   projectId       String
   templateId      String?
   dockerImage     String?     // Custom Docker image (e.g. ghcr.io/org/app:v1)
+  flavor          String?     // Create-time discriminator: 'docker' | 'server' | 'function' | 'template'. Null = legacy row. Immutable post-creation. (Phase 39)
   containerPort   Int?        // Port the container listens on (default: 80). Used in SDL generation.
   volumes         Json?       // Persistent volumes for raw Docker images: Array<{ name: string; mountPath: string; size: string }>. Templates use template.persistentStorage instead. (Phase 38)
   healthProbe     Json?       // Optional application HTTP health probe: { path: string; port?: number; expectStatus?: number; intervalSec?: number; timeoutSec?: number }. (Phase 42)

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1506,7 +1506,7 @@ export const resolvers = {
       _: unknown,
       {
         input,
-      }: { input: { name: string; projectId: string; type?: string; templateId?: string; dockerImage?: string; containerPort?: number } },
+      }: { input: { name: string; projectId: string; type?: string; templateId?: string; flavor?: string | null; dockerImage?: string; containerPort?: number } },
       context: Context
     ) => {
       requireAuth(context)
@@ -1521,6 +1521,24 @@ export const resolvers = {
       const slug = generateSlug(input.name)
       const serviceType = (input.type as any) || 'FUNCTION'
 
+      // Phase 39 — validate the catalog-flow discriminator. Templates always
+      // resolve to 'template' regardless of what the caller sent (so the UI
+      // can't mis-tag a template-backed service). Anything else must be one
+      // of the known flavors or null (legacy/unspecified — readers default
+      // to 'docker' for VM, 'function' for FUNCTION).
+      const ALLOWED_FLAVORS = new Set(['docker', 'server', 'function', 'template'])
+      let flavor: string | null = null
+      if (input.templateId) {
+        flavor = 'template'
+      } else if (input.flavor != null) {
+        if (!ALLOWED_FLAVORS.has(input.flavor)) {
+          throw new GraphQLError(
+            `Invalid flavor "${input.flavor}". Must be one of: docker, server, function, template.`
+          )
+        }
+        flavor = input.flavor
+      }
+
       return context.prisma.service.create({
         data: {
           type: serviceType,
@@ -1528,6 +1546,7 @@ export const resolvers = {
           slug,
           projectId: input.projectId,
           templateId: input.templateId ?? null,
+          flavor,
           dockerImage: input.dockerImage ?? null,
           containerPort: input.containerPort ?? null,
           createdByUserId: context.userId ?? null,
@@ -1863,6 +1882,10 @@ export const resolvers = {
             name,
             slug,
             projectId: context.projectId!,
+            // Phase 39 — function services are always 'function' flavor; this
+            // is the only catalog flow that produces them, so we hardcode
+            // rather than accepting it from the caller.
+            flavor: 'function',
             createdByUserId: context.userId ?? null,
             internalHostname: generateInternalHostname(slug, project.slug),
           },

--- a/src/schema/typeDefs.ts
+++ b/src/schema/typeDefs.ts
@@ -107,6 +107,14 @@ export const typeDefs = /* GraphQL */ `
     name: String!
     slug: String!
     projectId: ID!
+    """
+    Create-time discriminator describing the catalog flow that produced
+    this service. One of 'docker' | 'server' | 'function' | 'template'.
+    Null on legacy rows; the web app falls through to 'docker' for VM
+    rows and 'function' for FUNCTION rows. Immutable after creation.
+    (Phase 39)
+    """
+    flavor: String
     templateId: ID
     dockerImage: String
     containerPort: Int
@@ -429,6 +437,12 @@ export const typeDefs = /* GraphQL */ `
     projectId: ID!
     type: ServiceType
     templateId: String
+    """
+    Catalog flow discriminator. One of 'docker' | 'server' | 'function' | 'template'.
+    Validated server-side; rejected if any other value. Immutable post-creation.
+    (Phase 39)
+    """
+    flavor: String
     dockerImage: String
     containerPort: Int
   }


### PR DESCRIPTION
Persists the create-time catalog flow on Service so the deploy UI
can route to the correct source input (Docker image / OS picker /
code editor) instead of collapsing all VM rows into one freeform
image card. Validated in createService, hardcoded to 'function'
in createAFFunction, defaults to 'template' when templateId is
present. Immutable post-creation; legacy null rows fall through
to 'docker' for VM and 'function' for FUNCTION on the client.