### PR TITLE
scoped trivy waivers for upstream akash CVEs

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -134,10 +134,16 @@ jobs:
         if: ${{ env.SUPPLY_CHAIN_DISABLED != 'true' }}
         env:
           TRIVY_EXIT_CODE: ${{ env.SUPPLY_CHAIN_TRIVY_BLOCK == 'false' && '0' || '1' }}
+          # Scoped, expiring waivers for CVEs in third-party Go binaries
+          # (akash + provider-services) we ship in the image. Each entry
+          # has an `expired_at` so the deploy re-blocks automatically
+          # when the waiver lapses. See file header for policy.
+          TRIVY_IGNOREFILE: service-cloud-api/.trivyignore.yaml
         run: |
           trivy image \
             --severity CRITICAL \
             --ignore-unfixed \
+            --ignorefile "${TRIVY_IGNOREFILE}" \
             --exit-code "${TRIVY_EXIT_CODE}" \
             --no-progress \
             --format table \
@@ -147,6 +153,7 @@ jobs:
           trivy image \
             --severity HIGH \
             --ignore-unfixed \
+            --ignorefile "${TRIVY_IGNOREFILE}" \
             --no-progress \
             --format table \
             "${{ steps.image.outputs.ref }}" || true
@@ -155,6 +162,7 @@ jobs:
           trivy image \
             --severity HIGH,CRITICAL \
             --ignore-unfixed \
+            --ignorefile "${TRIVY_IGNOREFILE}" \
             --format sarif \
             --output trivy.sarif \
             "${{ steps.image.outputs.ref }}" || true

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,58 @@
+# Trivy vulnerability waivers — service-cloud-api image scan.
+#
+# All entries below MUST:
+#   1. Be scoped to a specific CVE ID
+#   2. Be scoped to specific binary paths inside the image
+#   3. Have an expired_at date (re-evaluation forced when it lapses)
+#   4. Carry a `statement` explaining real-world exploitability + tracking
+#
+# When a waiver expires, the deploy will start blocking again. That is the
+# point: do NOT remove the expiry date to "make the build green forever."
+# Renew the waiver only after re-confirming exploitability is still bounded.
+#
+# All waivers below are reviewed in the supply-chain section of the
+# AF_INCIDENT_RUNBOOKS.md (admin/cloud/docs).
+
+vulnerabilities:
+  - id: CVE-2026-33186
+    paths:
+      - "usr/local/bin/akash"
+      - "usr/local/bin/provider-services"
+    expired_at: 2026-05-18
+    statement: |
+      gRPC-Go authz bypass via improper HTTP/2 path validation. Bundled
+      via the upstream Akash CLI (akash v2.0.0-rc18 → grpc 1.76.0) and
+      provider-services v0.10.6 → grpc 1.75.0). Fix is upstream-only:
+      Akash needs to rebuild with grpc 1.79.3+. We don't control that
+      release cadence.
+
+      Practical exploitability: the Akash CLI only opens gRPC channels
+      to AKASH_RPC_ENDPOINT (pinned, TLS-validated). An attacker would
+      have to MITM an already-authenticated TLS channel inside our pod
+      to leverage the bypass. Combined with the rest of the attack
+      surface needed (pod RCE → AKASH_FROM private key → drain the
+      hot-wallet cap from §3.14), this is a marginal additional vector.
+
+      Tracking: open an issue against akash-network/node + provider
+      requesting a release with grpc 1.79.3, link here.
+      Re-evaluate by: 2026-05-18.
+
+  - id: CVE-2025-68121
+    paths:
+      - "usr/local/bin/akash"
+      - "usr/local/bin/provider-services"
+    expired_at: 2026-05-18
+    statement: |
+      Go stdlib (crypto/tls): incorrect certificate validation during
+      TLS session resumption. Bundled via the upstream Akash CLI binary
+      (built with Go 1.25.5; fixed in 1.25.7). Fix requires upstream
+      Akash to rebuild with patched Go.
+
+      Practical exploitability: Akash CLI only resumes TLS to
+      AKASH_RPC_ENDPOINT, which we pin and rotate. To weaponize this
+      an attacker needs (a) network position to MITM the resumed
+      handshake, AND (b) a forged cert that the resumption path
+      accepts. Same overall constraints as CVE-2026-33186 above.
+
+      Tracking: same upstream Akash release tracker as CVE-2026-33186.
+      Re-evaluate by: 2026-05-18.

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -50,7 +50,7 @@ export type { Context }
 
 // Service factory for storage tracking (billing is now handled by service-auth)
 const storageTracker = (prisma: any) => new StorageTracker(prisma)
-
+ 
 /**
  * Validate that context.projectId is owned by the authenticated user.
  * Prevents IDOR via spoofed x-project-id header.


### PR DESCRIPTION
CVE-2026-33186 (grpc-go HTTP/2 authz bypass) and CVE-2025-68121
(Go stdlib TLS resumption) live in third-party Akash binaries
(akash v2.0.0-rc18, provider-services v0.10.6) bundled into the
runtime image. Upstream fix requires Akash to rebuild with
grpc 1.79.3 + Go 1.25.7+; no such release exists yet.

Adds .trivyignore.yaml with:
- Per-CVE waivers scoped to /usr/local/bin/akash and
  /usr/local/bin/provider-services only (other paths still block)
- expired_at: 2026-05-18 — Trivy resumes blocking automatically
  when waivers lapse, forcing re-evaluation
- Statement documenting real-world exploitability bound and
  upstream tracking

Wires --ignorefile into all three trivy invocations in
deploy-aws.yml via single TRIVY_IGNOREFILE env var.