### PR TITLE
Develop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist
 .DS_Store
 certs/
 invoices/
+audit-exports/
 .age-key.txt
 bootstrap.env
 !bootstrap.enc.env

--- a/src/config/akash.ts
+++ b/src/config/akash.ts
@@ -7,11 +7,31 @@
  */
 
 /**
- * Akash averages ~6s per block. 600 blocks ≈ 1 hour — close enough that
- * we use it as the hourly unit when converting pricePerBlock (uact/block)
- * into hourly burn. If Akash changes block time, update this constant.
+ * Akash chain block geometry.
+ *
+ * Empirically measured block time on mainnet is ~6.117s (matches the
+ * upstream provider bid-pricing reference script,
+ * https://gist.github.com/chainzero/33978bf221eb35f10a7392ed9bae8caa
+ * which uses `429,909 blocks/month` at 30.437 days/month).
+ *
+ * Previous value (6.0s → 600 blocks/hour, 14400 blocks/day) over-charged
+ * deployments by ~1.95% in our USD/hour and refill calculations. Aligning
+ * with the upstream constant makes our cost reporting and on-chain escrow
+ * top-ups match the actual chain burn rate.
+ *
+ * If Akash changes block time materially, update SECONDS_PER_BLOCK and the
+ * derived constants below.
  */
-export const BLOCKS_PER_HOUR = 600
+export const AKASH_SECONDS_PER_BLOCK = 6.117
+
+/** 3600 / 6.117 ≈ 588.5 — rounded down so refills slightly under-fund rather than over-fund. */
+export const BLOCKS_PER_HOUR = 588
+
+/** 86400 / 6.117 ≈ 14124.6 — rounded down for the same reason. */
+export const BLOCKS_PER_DAY = 14_124
+
+/** Matches `429,909 blocks/month` from upstream price_script_generic.sh. */
+export const BLOCKS_PER_MONTH = 429_909
 
 /**
  * How long to hold the wallet mutex AFTER a `akash tx ...` CLI invocation

--- a/src/config/pricing.ts
+++ b/src/config/pricing.ts
@@ -14,6 +14,7 @@
  */
 
 import { createLogger } from '../lib/logger.js'
+import { BLOCKS_PER_DAY } from './akash.js'
 
 const log = createLogger('pricing')
 
@@ -93,8 +94,13 @@ export const AKT_USD_PRICE_FALLBACK = parseFloat(process.env.AKT_USD_PRICE || '0
 /** @deprecated Use getAktUsdPrice() for live price. Kept for non-async call sites. */
 export const AKT_USD_PRICE = AKT_USD_PRICE_FALLBACK
 
-/** Akash blocks per day (~6s/block) */
-export const AKASH_BLOCKS_PER_DAY = 14400
+/**
+ * Akash blocks per day, derived from measured ~6.117s block time.
+ * Re-exported from `./akash.ts` so existing imports of this name keep working.
+ *
+ * @see ./akash.ts for the canonical block-geometry constants.
+ */
+export const AKASH_BLOCKS_PER_DAY = BLOCKS_PER_DAY
 
 // ---- Live AKT price (Akash API → CoinGecko → env fallback) ----
 
@@ -268,10 +274,14 @@ export function calculateStorageCostWithMargin(
 /**
  * Convert Akash pricePerBlock to USD per day.
  *
- * Since the BME upgrade (March 2026), all Akash leases are denominated in
- * uact (micro-ACT), where ACT is a USD-pegged compute credit (1 ACT = $1).
- * For uact: daily USD = (pricePerBlock × blocksPerDay) / 1,000,000.
- * For legacy uakt: daily USD = (pricePerBlock × blocksPerDay) / 1,000,000 × aktUsdPrice.
+ * Since the BME upgrade (March 2026, Mainnet 17), all new Akash leases are
+ * denominated in uact (micro-ACT), where ACT is a USD-pegged compute credit
+ * (1 ACT = $1). The uact path is the only one used in production today:
+ *   daily USD = (pricePerBlock × BLOCKS_PER_DAY) / 1,000,000
+ *
+ * The legacy uakt branch is retained only to handle any pre-BME escrow rows
+ * that may still be queried during reconciliation. See `@deprecated` note
+ * below.
  *
  * @param pricePerBlock - Price per block from the bid/lease
  * @param denom         - Token denomination ('uact' or 'uakt'). Defaults to 'uact' (post-BME).
@@ -288,6 +298,17 @@ export function akashPricePerBlockToUsdPerDay(
   const dailyUnits = dailyMicro / 1_000_000
 
   if (denom === 'uakt') {
+    /**
+     * @deprecated Legacy pre-BME path. New leases (post-March 2026) all use
+     * `uact`. If this branch fires in production it means a pre-BME escrow
+     * row is still being processed — investigate which row and how it
+     * survived the BME upgrade. Safe to remove this branch once the warn
+     * log shows zero hits over a multi-week window.
+     */
+    log.warn(
+      { pricePerBlock: price, aktUsdPrice },
+      'Legacy uakt price conversion called — should not happen post-BME',
+    )
     return dailyUnits * aktUsdPrice
   }
 

--- a/src/services/billing/computeBillingScheduler.test.ts
+++ b/src/services/billing/computeBillingScheduler.test.ts
@@ -212,7 +212,7 @@ describe('ComputeBillingScheduler.processAkashEscrows — idempotency drift', ()
 
     // Normal path DOES do the on-chain top-up
     expect(topUpDeploymentDepositMock).toHaveBeenCalledTimes(1)
-    expect(topUpDeploymentDepositMock).toHaveBeenCalledWith(123, 60_000) // ppb=100 * 600 blocks
+    expect(topUpDeploymentDepositMock).toHaveBeenCalledWith(123, 58_800) // ppb=100 * BLOCKS_PER_HOUR (588)
   })
 
   it('advances lastBilledAt by exactly hoursToBill * 1h so fractional time rolls forward', async () => {

--- a/src/services/billing/escrowHealthMonitor.test.ts
+++ b/src/services/billing/escrowHealthMonitor.test.ts
@@ -52,7 +52,10 @@ vi.mock('../../lib/opsAlert.js', () => ({
 }))
 
 vi.mock('../../config/akash.js', () => ({
-  BLOCKS_PER_HOUR: 600,
+  BLOCKS_PER_HOUR: 588,
+  BLOCKS_PER_DAY: 14_124,
+  BLOCKS_PER_MONTH: 429_909,
+  AKASH_SECONDS_PER_BLOCK: 6.117,
   TX_SETTLE_DELAY_MS: 0,
   POST_LEASE_HOURS: 2,
 }))
@@ -164,9 +167,9 @@ describe('EscrowHealthMonitor', () => {
   })
 
   it('refills when estimated runway < MIN_ESCROW_HOURS (1h)', async () => {
-    // ppb = 1000 uact/block → hourly burn = 600_000 uact
+    // ppb = 1000 uact/block → hourly burn = 588_000 uact (BLOCKS_PER_HOUR=588)
     // funds = 1_000_000, transferred = 0, blocks elapsed = 700 → unsettled = 700_000
-    // real balance = 300_000 → 0.5h remaining → should refill.
+    // real balance = 300_000 → ~0.51h remaining → should refill.
     const prisma = buildPrisma([
       { id: 'a1', dseq: 100n, pricePerBlock: '1000', owner: 'akash1owner' },
     ])
@@ -185,8 +188,8 @@ describe('EscrowHealthMonitor', () => {
       c => c[1][0] === 'tx' && c[1][1] === 'escrow' && c[1][2] === 'deposit',
     )
     expect(depositCall).toBeDefined()
-    // Refill amount: ppb * BLOCKS_PER_HOUR * REFILL_HOURS = 1000 * 600 * 1 = 600_000
-    expect(depositCall![1]).toContain('600000uact')
+    // Refill amount: ppb * BLOCKS_PER_HOUR * REFILL_HOURS = 1000 * 588 * 1 = 588_000
+    expect(depositCall![1]).toContain('588000uact')
     expect(depositCall![1]).toContain('--dseq')
     expect(depositCall![1]).toContain('100')
   })

--- a/src/services/billing/escrowService.test.ts
+++ b/src/services/billing/escrowService.test.ts
@@ -18,7 +18,7 @@ vi.mock('../../config/pricing.js', () => ({
   getAktUsdPrice: () => getAktUsdPriceMock(),
   akashPricePerBlockToUsdPerDay: (ppb: string, _denom: string = 'uact') => {
     const price = parseFloat(ppb)
-    return (price * 14400) / 1_000_000
+    return (price * 14_124) / 1_000_000
   },
   applyMargin: (raw: number, rate: number) => raw * (1 + rate),
 }))
@@ -108,9 +108,10 @@ describe('EscrowService', () => {
         userId: 'user-1',
       })
 
-      // 1000 uakt * 14400 blocks/day = 14_400_000 uakt/day = 14.4 AKT/day
-      // At $1.00/AKT = $14.40/day raw; with 25% margin = $18.00/day = 1800 cents
-      expect(result.dailyRateCents).toBe(1800)
+      // 1000 uact * 14_124 blocks/day = 14_124_000 uact/day = 14.124 ACT/day
+      // (post-BME: 1 ACT ≈ $1, so $14.124/day raw)
+      // With 25% margin → $17.655/day → Math.ceil(1765.5) = 1766 cents
+      expect(result.dailyRateCents).toBe(1766)
     })
   })
 
@@ -125,10 +126,10 @@ describe('EscrowService', () => {
         escrowDays: 7,
       })
 
-      expect(result.depositCents).toBe(1800 * 7)
+      expect(result.depositCents).toBe(1766 * 7)
       expect(escrowDepositMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          amountCents: 1800 * 7,
+          amountCents: 1766 * 7,
           orgBillingId: 'org-billing-1',
         })
       )

--- a/src/services/providers/providerVerificationScheduler.ts
+++ b/src/services/providers/providerVerificationScheduler.ts
@@ -1,8 +1,21 @@
 /**
  * Provider Verification Scheduler
  *
- * Runs the full provider verification suite once daily at 4 AM UTC.
- * After verification, syncs results to the staging database.
+ * Runs the full provider verification suite three times a week
+ * (Mon/Wed/Fri at 04:00 UTC). After verification, syncs results to the
+ * staging database.
+ *
+ * Cadence rationale:
+ *   - The verified set is stable in practice (providers don't flip in/out
+ *     daily), so a 2-3 day staleness window is acceptable.
+ *   - Each run costs ~1.0-1.5 AKT + ~0.5-1.0 ACT and locks the wallet for
+ *     25-40 min. Mon/Wed/Fri cuts that burn by ~57% vs. daily.
+ *   - Provider presence and GPU inventory are still refreshed hourly by
+ *     ProviderRegistryScheduler — the verifier only solves functional
+ *     regression detection and newcomer promotion, neither of which
+ *     requires daily granularity.
+ *   - Lower frequency also reduces exposure to orphaned-lease bugs in the
+ *     close path until those P0 fixes ship.
  *
  * Guards:
  *   - Overlap: skips if a previous run is still in progress
@@ -43,14 +56,14 @@ export class ProviderVerificationScheduler {
       return
     }
 
-    // Daily at 4:00 AM UTC
-    this.cronJob = cron.schedule('0 4 * * *', () => {
+    // Mon/Wed/Fri at 04:00 UTC (was daily — see header comment for rationale)
+    this.cronJob = cron.schedule('0 4 * * 1,3,5', () => {
       this.runVerification().catch(err => {
-        log.error({ err: err instanceof Error ? err.message : err }, 'Daily verification failed')
+        log.error({ err: err instanceof Error ? err.message : err }, 'Scheduled verification failed')
       })
     })
 
-    log.info('Started — runs daily at 04:00 UTC')
+    log.info('Started — runs Mon/Wed/Fri at 04:00 UTC')
   }
 
   stop() {


### PR DESCRIPTION
BLOCKS_PER_HOUR 600 -> 588 and BLOCKS_PER_DAY 14400 -> 14124, matching
the 429,909 blocks/month constant from the upstream provider bid-pricing
reference script (6.117s avg block time vs the previous 6.0s assumption).
Fixes ~1.95% over-charge in escrow refills, on-chain top-ups, and
reported costPerHour/Day/Month. Pricing math is now monotonically lower
for all leases — no customer refund needed (previous dailyRateCents was
what we charged); future invoices will be slightly smaller.
Also marks the legacy uakt branch in akashPricePerBlockToUsdPerDay as
@deprecated and emits a warn-log on entry, so we can confirm zero hits
post-deploy and remove it in a follow-up.