### PR TITLE
sweep chain-orphan deployments in escrow health monitor

### DIFF
--- a/src/services/billing/escrowHealthMonitor.test.ts
+++ b/src/services/billing/escrowHealthMonitor.test.ts
@@ -69,10 +69,32 @@ interface FakeAkashDeployment {
   owner: string
 }
 
-function buildPrisma(deployments: FakeAkashDeployment[]) {
+/**
+ * `deployments` represents the ACTIVE rows used by the refill loop.
+ * `inFlightDseqs` represents additional dseqs we've recorded in any
+ * non-ACTIVE state (CREATING, WAITING_BIDS, DEPLOYING, SUSPENDED,
+ * CLOSE_FAILED, etc.) that the orphan sweep MUST also exclude.
+ */
+function buildPrisma(
+  deployments: FakeAkashDeployment[],
+  inFlightDseqs: bigint[] = [],
+) {
   return {
     akashDeployment: {
-      findMany: vi.fn().mockResolvedValue(deployments),
+      findMany: vi.fn().mockImplementation(({ where, select }: any = {}) => {
+        // First call: ACTIVE-only with full select for refill loop.
+        if (where?.status === 'ACTIVE') return Promise.resolve(deployments)
+        // Second call: all known dseqs for orphan-sweep exclusion set.
+        // Returns ACTIVE rows + in-flight rows.
+        if (select?.dseq && !where) {
+          const all = [
+            ...deployments.map(d => ({ dseq: d.dseq })),
+            ...inFlightDseqs.map(dseq => ({ dseq })),
+          ]
+          return Promise.resolve(all)
+        }
+        return Promise.resolve([])
+      }),
       findUnique: vi.fn().mockImplementation(({ where }) => {
         const d = deployments.find(x => x.id === where.id)
         return Promise.resolve(d ? { status: 'ACTIVE' } : null)
@@ -110,9 +132,12 @@ function installAkashCli(overrides: {
       )
     }
 
-    // keys show <name> -a → wallet address
+    // keys show <name> -a → wallet address.
+    // Default to `akash1owner` so it matches the standard test fixture's
+    // AkashDeployment.owner field (the new owner-validation guard requires
+    // these to match — see "SAFETY: bails out on owner mismatch" test).
     if (args[0] === 'keys' && args[1] === 'show') {
-      return Promise.resolve(`${overrides.walletAddress ?? 'akash1mock'}\n`)
+      return Promise.resolve(`${overrides.walletAddress ?? 'akash1owner'}\n`)
     }
 
     // query bank balances → wallet ACT balance
@@ -314,7 +339,7 @@ describe('EscrowHealthMonitor', () => {
           JSON.stringify({ sync_info: { latest_block_height: '1000000' } }),
         )
       }
-      if (args[0] === 'keys') return Promise.resolve('akash1mock\n')
+      if (args[0] === 'keys') return Promise.resolve('akash1owner\n')
       if (args[0] === 'query' && args[1] === 'bank') {
         return Promise.resolve(
           JSON.stringify({ balances: [{ denom: 'uact', amount: '100000000' }] }),
@@ -327,9 +352,10 @@ describe('EscrowHealthMonitor', () => {
     const run1 = monitor.checkAndRefill()
 
     // Second call while the first is in flight → should bail out immediately.
-    // findMany should only be called once.
+    // findMany is called twice per cycle (once for ACTIVE, once for all-known
+    // dseqs in the orphan exclusion set), so a single completed cycle = 2.
     await monitor.checkAndRefill()
-    expect(prisma.akashDeployment.findMany).toHaveBeenCalledTimes(1)
+    expect(prisma.akashDeployment.findMany).toHaveBeenCalledTimes(2)
 
     // Now release the first run.
     resolveFirstList(JSON.stringify({ deployments: [] }))
@@ -413,7 +439,7 @@ describe('EscrowHealthMonitor', () => {
           JSON.stringify({ sync_info: { latest_block_height: '1000000' } }),
         )
       }
-      if (args[0] === 'keys') return Promise.resolve('akash1mock\n')
+      if (args[0] === 'keys') return Promise.resolve('akash1owner\n')
       if (args[0] === 'query' && args[1] === 'bank') {
         return Promise.resolve(
           JSON.stringify({ balances: [{ denom: 'uact', amount: '100000000' }] }),
@@ -559,6 +585,80 @@ describe('EscrowHealthMonitor', () => {
         c => (c[0]?.key ?? '').startsWith('chain-orphan-closed:'),
       )
       expect(orphanAlert).toBeUndefined()
+    })
+
+    it('SAFETY: bails out on owner mismatch (DB corruption defense)', async () => {
+      // If an ACTIVE row's `owner` differs from the deployer wallet that
+      // `keys show -a` resolves to, the entire cycle (refill + sweep) must
+      // skip — running the chain query against the wrong wallet would mean
+      // either (a) closing nothing real (chain rejects unknown signer), or
+      // (b) missing real orphans on our actual deployer wallet.
+      const prisma = buildPrisma([
+        { id: 'a1', dseq: 100n, pricePerBlock: '1000', owner: 'akash1corrupted' },
+      ])
+      installAkashCli({
+        blockHeight: 1_000_700,
+        walletAddress: 'akash1real',
+        listDeployments: [
+          { dseq: '999', fundsUact: 1_000_000, transferredUact: 0, settledAt: 1_000_000 },
+        ],
+      })
+
+      const monitor = new EscrowHealthMonitor(prisma)
+      await monitor.checkAndRefill()
+
+      expect(closeDeploymentMock).not.toHaveBeenCalled()
+
+      const mismatchAlert = opsAlertMock.mock.calls.find(
+        c => c[0]?.key === 'escrow-monitor-owner-mismatch',
+      )
+      expect(mismatchAlert).toBeDefined()
+      expect(mismatchAlert![0].severity).toBe('critical')
+      expect(mismatchAlert![0].context?.dbOwner).toBe('akash1corrupted')
+      expect(mismatchAlert![0].context?.resolvedDeployerAddress).toBe('akash1real')
+    })
+
+    it('SAFETY: never closes a chain dseq we have a non-ACTIVE row for', async () => {
+      // Regression test for a subtle bug class: the sweep exclusion set MUST
+      // include every dseq we have ever recorded, NOT just ACTIVE rows.
+      // Statuses to protect:
+      //   - WAITING_BIDS / CREATING / DEPLOYING — TX submitted, lease not yet
+      //     established; row not ACTIVE but chain has it.
+      //   - SUSPENDED — lease intentionally kept open while user tops up;
+      //     closing it would destroy a paying customer's workload.
+      //   - CLOSE_FAILED — by definition still open on-chain.
+      const prisma = buildPrisma(
+        [], // no ACTIVE rows
+        [
+          150n, // CREATING
+          151n, // WAITING_BIDS
+          152n, // DEPLOYING
+          153n, // SUSPENDED  ← user paused for low balance, must NOT touch
+          154n, // CLOSE_FAILED
+        ],
+      )
+
+      installAkashCli({
+        blockHeight: 1_000_700,
+        listDeployments: [
+          { dseq: '150', fundsUact: 1_000_000, transferredUact: 0, settledAt: 1_000_000 },
+          { dseq: '151', fundsUact: 1_000_000, transferredUact: 0, settledAt: 1_000_000 },
+          { dseq: '152', fundsUact: 1_000_000, transferredUact: 0, settledAt: 1_000_000 },
+          { dseq: '153', fundsUact: 1_000_000, transferredUact: 0, settledAt: 1_000_000 },
+          { dseq: '154', fundsUact: 1_000_000, transferredUact: 0, settledAt: 1_000_000 },
+          // The actual orphan — proves the sweep DOES still fire when it should.
+          { dseq: '999', fundsUact: 1_000_000, transferredUact: 0, settledAt: 1_000_000 },
+        ],
+      })
+
+      const monitor = new EscrowHealthMonitor(prisma)
+      await monitor.checkAndRefill()
+
+      for (const protectedDseq of [150, 151, 152, 153, 154]) {
+        expect(closeDeploymentMock).not.toHaveBeenCalledWith(protectedDseq)
+      }
+      expect(closeDeploymentMock).toHaveBeenCalledWith(999)
+      expect(closeDeploymentMock).toHaveBeenCalledTimes(1)
     })
 
     it('does not alert when on-chain close fails (will retry next cycle)', async () => {

--- a/src/services/billing/escrowHealthMonitor.test.ts
+++ b/src/services/billing/escrowHealthMonitor.test.ts
@@ -432,4 +432,156 @@ describe('EscrowHealthMonitor', () => {
     // elsewhere; here we just care that the method completes cleanly.
     await expect(monitor.checkAndRefill()).resolves.not.toThrow()
   })
+
+  describe('chain-orphan sweep', () => {
+    it('closes a chain deployment that has no DB row and is older than the age threshold', async () => {
+      // DB has dseq 100 ACTIVE; chain has 100 + 999. 999 is the orphan.
+      // settledAt = 1_000_000, blockHeight = 1_000_700 → ageBlocks = 700 > 600 threshold.
+      const prisma = buildPrisma([
+        { id: 'a1', dseq: 100n, pricePerBlock: '1000', owner: 'akash1owner' },
+      ])
+      installAkashCli({
+        blockHeight: 1_000_700,
+        listDeployments: [
+          { dseq: '100', fundsUact: 10_000_000, transferredUact: 0, settledAt: 1_000_600 },
+          { dseq: '999', fundsUact: 1_000_000, transferredUact: 0, settledAt: 1_000_000 },
+        ],
+      })
+
+      const monitor = new EscrowHealthMonitor(prisma)
+      await monitor.checkAndRefill()
+
+      // Tracked dseq 100 must NOT be closed (it's healthy and in DB).
+      expect(closeDeploymentMock).not.toHaveBeenCalledWith(100)
+      // Orphan dseq 999 must be closed.
+      expect(closeDeploymentMock).toHaveBeenCalledWith(999)
+
+      // We must NOT settle billing for an orphan — there's no DB row /
+      // user to settle against. settleAkashEscrowToTime takes a deploymentId
+      // and would fail or charge the wrong account.
+      expect(settleAkashEscrowToTimeMock).not.toHaveBeenCalled()
+      expect(refundEscrowMock).not.toHaveBeenCalled()
+
+      const orphanAlert = opsAlertMock.mock.calls.find(
+        c => c[0]?.key === 'chain-orphan-closed:999',
+      )
+      expect(orphanAlert).toBeDefined()
+      expect(orphanAlert![0].severity).toBe('warning')
+    })
+
+    it('skips chain deployments younger than the age threshold (race protection)', async () => {
+      // settledAt = 1_000_500, blockHeight = 1_000_700 → ageBlocks = 200 < 600.
+      // This is the case where a deployment was just created and the queue
+      // worker hasn't written the DB row yet (or a probe-bid is mid-flight).
+      const prisma = buildPrisma([
+        { id: 'a1', dseq: 100n, pricePerBlock: '1000', owner: 'akash1owner' },
+      ])
+      installAkashCli({
+        blockHeight: 1_000_700,
+        listDeployments: [
+          { dseq: '100', fundsUact: 10_000_000, transferredUact: 0, settledAt: 1_000_600 },
+          { dseq: '999', fundsUact: 1_000_000, transferredUact: 0, settledAt: 1_000_500 },
+        ],
+      })
+
+      const monitor = new EscrowHealthMonitor(prisma)
+      await monitor.checkAndRefill()
+
+      expect(closeDeploymentMock).not.toHaveBeenCalledWith(999)
+      const orphanAlert = opsAlertMock.mock.calls.find(
+        c => (c[0]?.key ?? '').startsWith('chain-orphan-closed:'),
+      )
+      expect(orphanAlert).toBeUndefined()
+    })
+
+    it('skips chain entries that are already closed on-chain', async () => {
+      // Orphan that's already `closed: true` on chain — nothing to do, the
+      // escrow is already being settled by the chain itself.
+      const prisma = buildPrisma([
+        { id: 'a1', dseq: 100n, pricePerBlock: '1000', owner: 'akash1owner' },
+      ])
+      installAkashCli({
+        blockHeight: 1_000_700,
+        listDeployments: [
+          { dseq: '100', fundsUact: 10_000_000, transferredUact: 0, settledAt: 1_000_600 },
+          {
+            dseq: '999',
+            fundsUact: 1_000_000,
+            transferredUact: 0,
+            settledAt: 1_000_000,
+            closed: true,
+          },
+        ],
+      })
+
+      const monitor = new EscrowHealthMonitor(prisma)
+      await monitor.checkAndRefill()
+
+      expect(closeDeploymentMock).not.toHaveBeenCalledWith(999)
+    })
+
+    it('runs the sweep even when DB has zero ACTIVE rows (orphan-only case)', async () => {
+      // This is the bug from the screenshot: production cloud-api had no
+      // ACTIVE deployments in the DB but a chain orphan still existed.
+      // The previous early-return-on-empty meant we never even queried chain.
+      const prisma = buildPrisma([])
+      installAkashCli({
+        blockHeight: 1_000_700,
+        listDeployments: [
+          { dseq: '999', fundsUact: 1_000_000, transferredUact: 0, settledAt: 1_000_000 },
+        ],
+      })
+
+      const monitor = new EscrowHealthMonitor(prisma)
+      await monitor.checkAndRefill()
+
+      expect(closeDeploymentMock).toHaveBeenCalledWith(999)
+    })
+
+    it('does not close anything when chain matches DB exactly', async () => {
+      const prisma = buildPrisma([
+        { id: 'a1', dseq: 100n, pricePerBlock: '1000', owner: 'akash1owner' },
+        { id: 'a2', dseq: 200n, pricePerBlock: '1000', owner: 'akash1owner' },
+      ])
+      installAkashCli({
+        blockHeight: 1_000_700,
+        listDeployments: [
+          { dseq: '100', fundsUact: 10_000_000, transferredUact: 0, settledAt: 1_000_600 },
+          { dseq: '200', fundsUact: 10_000_000, transferredUact: 0, settledAt: 1_000_600 },
+        ],
+      })
+
+      const monitor = new EscrowHealthMonitor(prisma)
+      await monitor.checkAndRefill()
+
+      expect(closeDeploymentMock).not.toHaveBeenCalled()
+      const orphanAlert = opsAlertMock.mock.calls.find(
+        c => (c[0]?.key ?? '').startsWith('chain-orphan-closed:'),
+      )
+      expect(orphanAlert).toBeUndefined()
+    })
+
+    it('does not alert when on-chain close fails (will retry next cycle)', async () => {
+      const prisma = buildPrisma([])
+      installAkashCli({
+        blockHeight: 1_000_700,
+        listDeployments: [
+          { dseq: '999', fundsUact: 1_000_000, transferredUact: 0, settledAt: 1_000_000 },
+        ],
+      })
+      closeDeploymentMock.mockResolvedValueOnce({
+        chainStatus: 'FAILED',
+        error: 'rpc timeout',
+      })
+
+      const monitor = new EscrowHealthMonitor(prisma)
+      await monitor.checkAndRefill()
+
+      expect(closeDeploymentMock).toHaveBeenCalledWith(999)
+      const orphanAlert = opsAlertMock.mock.calls.find(
+        c => (c[0]?.key ?? '').startsWith('chain-orphan-closed:'),
+      )
+      expect(orphanAlert).toBeUndefined()
+    })
+  })
 })

--- a/src/services/billing/escrowHealthMonitor.ts
+++ b/src/services/billing/escrowHealthMonitor.ts
@@ -71,7 +71,8 @@ const ORPHAN_MIN_AGE_BLOCKS = (() => {
  * If the wallet balance creeps above this cap (e.g. operator funded
  * too much, or treasury swept the wrong way), we fire an ops alert
  * and ask the operator to sweep the excess back to cold storage per
- * the runbook (Section L of AF_INCIDENT_RUNBOOKS.md).
+ * the runbook (Section M of AF_INCIDENT_RUNBOOKS.md — "Akash Hot-Wallet
+ * Cap Exceeded / Key Rotation"; §L is the unrelated failover-loop runbook).
  *
  * Override in production via `AKASH_HOT_WALLET_CAP_UACT` if the
  * default is too tight for current usage.
@@ -152,20 +153,81 @@ export class EscrowHealthMonitor {
         },
       })
 
-      log.info({ count: activeDeployments.length }, 'Escrow health check — active deployments found')
+      // Broader set used ONLY for orphan-sweep exclusion. We must NEVER close
+      // a chain deployment we've ever recorded — it could be a row in any
+      // non-terminal state (CREATING, WAITING_BIDS, DEPLOYING, SUSPENDED,
+      // CLOSE_FAILED, etc.) where the chain side is intentionally still open.
+      // Even CLOSED / PERMANENTLY_FAILED rows are safer to skip — close is
+      // idempotent so re-closing wastes a TX, and "leak escrow on a row we
+      // already know about" is strictly better than "wrongly close a user
+      // lease we forgot to filter out".
+      const allKnownDseqs = await this.prisma.akashDeployment.findMany({
+        select: { dseq: true },
+      })
+
+      log.info(
+        {
+          activeCount: activeDeployments.length,
+          knownDseqCount: allKnownDseqs.length,
+        },
+        'Escrow health check — DB snapshot loaded',
+      )
 
       await this.checkWalletBalance()
 
       // Single RPC call to fetch all deployment escrow accounts for our owner,
       // instead of one query per dseq. O(1) RPC calls regardless of deployment count.
-      // Owner: prefer a DB row's `owner` (skips an RPC) but fall back to
-      // `keys show` so we can still run the orphan sweep when DB has zero ACTIVE rows.
-      const owner =
-        activeDeployments[0]?.owner ?? (await this.resolveDeployerAddress())
-      if (!owner) {
-        log.warn('Could not resolve deployer wallet address — skipping cycle')
+      // Owner resolution. The `query deployment list --owner <addr>` chain
+      // call only returns dseqs *for that address*, and the orphan sweep
+      // closes everything in that returned set that has no DB row. So if
+      // we ever resolve the *wrong* owner, the sweep would either (a) close
+      // the wrong wallet's deployments (chain rejects — only the signing
+      // key can close, so this is structurally impossible) or (b) miss
+      // real orphans on our actual deployer wallet.
+      //
+      // Defense in depth: always resolve the deployer address authoritatively
+      // via `keys show -a` and assert it matches the `owner` field on any
+      // ACTIVE row we read. A mismatch implies DB corruption — bail out and
+      // alert rather than silently operating on the wrong account.
+      const resolvedDeployerAddress = await this.resolveDeployerAddress()
+      if (!resolvedDeployerAddress) {
+        log.warn('Could not resolve deployer wallet address via `keys show` — skipping cycle')
         return
       }
+      const dbOwner = activeDeployments[0]?.owner
+      if (dbOwner && dbOwner !== resolvedDeployerAddress) {
+        log.error(
+          { dbOwner, resolvedDeployerAddress },
+          'AkashDeployment.owner does not match the resolved deployer address — DB likely corrupted, refusing to sweep this cycle',
+        )
+        await opsAlert({
+          key: 'escrow-monitor-owner-mismatch',
+          severity: 'critical',
+          title: 'Escrow monitor refused to run — owner mismatch',
+          message:
+            `An ACTIVE AkashDeployment row has owner=${dbOwner} but the deployer wallet resolves to ${resolvedDeployerAddress}. ` +
+            `The cycle (refill + orphan sweep) has been skipped to avoid operating on the wrong wallet. ` +
+            `Inspect AkashDeployment rows for the corrupted owner value.`,
+          context: { dbOwner, resolvedDeployerAddress },
+          suppressMs: 60 * 60 * 1000,
+        })
+        return
+      }
+      const owner = resolvedDeployerAddress
+
+      // ─── Concurrency caveat ───
+      // PRP §3.29 (`PRODUCTION_READINESS_PLAN.md`): every replica runs this
+      // monitor with no leader election. Once horizontal scale ships, both
+      // replicas will independently call the sweep against the same chain
+      // dseqs. Mitigations already in place that make this *safe* (not
+      // *efficient*):
+      //   • orchestrator.closeDeployment is idempotent — second close lands
+      //     as ALREADY_CLOSED and is treated as success.
+      //   • `chain-orphan-closed:<dseq>` opsAlert key dedupes per-process
+      //     for 24h, so duplicate alerts collapse within each pod.
+      // The remaining cost is wasted close TXs (gas) — bounded by orphan
+      // count × replica count × cycles. Acceptable as a launch posture;
+      // proper fix is the leader election work tracked in PRP §3.11/§3.29.
 
       const [chainEscrows, currentBlockHeight] = await Promise.all([
         this.fetchAllEscrowBalances(owner),
@@ -248,7 +310,7 @@ export class EscrowHealthMonitor {
       // deployments whose try/finally close failed, any other path that
       // writes to the chain but bypasses the queue.
       const sweptOrphans = await this.sweepChainOrphans(
-        activeDeployments,
+        allKnownDseqs,
         chainEscrows,
         currentBlockHeight,
       )
@@ -301,14 +363,20 @@ export class EscrowHealthMonitor {
    * `try/finally` close failed, queue workers that crashed between the
    * deployment-create TX and the DB write — leaked $1+ of escrow forever.
    *
+   * SAFETY: `allKnownDseqs` MUST contain every dseq we have ever recorded,
+   * regardless of status. A row in WAITING_BIDS / DEPLOYING / SUSPENDED /
+   * CLOSE_FAILED is intentionally still open on-chain and closing it would
+   * destroy a real user workload. Filtering by `status: 'ACTIVE'` here would
+   * be a critical bug.
+   *
    * Returns the number of orphans we successfully closed.
    */
   private async sweepChainOrphans(
-    dbActive: Array<{ dseq: bigint }>,
+    allKnownDseqs: Array<{ dseq: bigint }>,
     chainEscrows: Map<string, ChainEscrowEntry>,
     currentBlockHeight: number,
   ): Promise<number> {
-    const dbDseqs = new Set(dbActive.map((d) => d.dseq.toString()))
+    const dbDseqs = new Set(allKnownDseqs.map((d) => d.dseq.toString()))
     let swept = 0
 
     for (const [dseq, entry] of chainEscrows) {
@@ -421,9 +489,10 @@ export class EscrowHealthMonitor {
         })
       }
 
-      // Hot-wallet cap (Section L of the incident runbook). The deployer
-      // wallet is online — keeping it lean limits blast radius if the
-      // pod / key is ever compromised.
+      // Hot-wallet cap (Section M of the incident runbook — "Akash
+      // Hot-Wallet Cap Exceeded / Key Rotation"). The deployer wallet is
+      // online — keeping it lean limits blast radius if the pod / key is
+      // ever compromised.
       if (balance > HOT_WALLET_CAP_UACT) {
         log.warn(
           { balanceUact: balance, balanceAct, capUact: HOT_WALLET_CAP_UACT },
@@ -435,7 +504,7 @@ export class EscrowHealthMonitor {
           title: 'Deployer hot wallet over cap',
           message:
             `Deployer wallet holds ${balanceAct} ACT, above the ${(HOT_WALLET_CAP_UACT / 1_000_000).toFixed(0)} ACT hot-wallet cap. ` +
-            `Sweep the excess back to cold storage per AF_INCIDENT_RUNBOOKS.md §L. ` +
+            `Sweep the excess back to cold storage per AF_INCIDENT_RUNBOOKS.md §M. ` +
             `Override the cap by setting AKASH_HOT_WALLET_CAP_UACT if usage justifies a larger float.`,
           context: {
             address,

--- a/src/services/billing/escrowHealthMonitor.ts
+++ b/src/services/billing/escrowHealthMonitor.ts
@@ -42,6 +42,24 @@ const ESCROW_CHECK_CRON = '30 * * * *'
 const LOW_WALLET_THRESHOLD_UACT = 5_000_000
 
 /**
+ * Minimum on-chain age before we consider a deployment a sweep-able orphan.
+ *
+ * 600 blocks ≈ 1 hour at 6s/block. Anything younger is probably a deployment
+ * mid-flight whose DB row hasn't been written yet (queue worker still running
+ * `handleCreateDeployment`), or a probe-bid (PR 2) inside its
+ * `try/finally` close window. Sweeping those would race the application code.
+ *
+ * Override via `AKASH_ORPHAN_SWEEP_MIN_AGE_BLOCKS` for staging tests.
+ */
+const DEFAULT_ORPHAN_MIN_AGE_BLOCKS = 600
+const ORPHAN_MIN_AGE_BLOCKS = (() => {
+  const raw = process.env.AKASH_ORPHAN_SWEEP_MIN_AGE_BLOCKS
+  if (!raw) return DEFAULT_ORPHAN_MIN_AGE_BLOCKS
+  const parsed = parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_ORPHAN_MIN_AGE_BLOCKS
+})()
+
+/**
  * Hot-wallet cap (defense-in-depth against key compromise).
  *
  * The deployer wallet is an *online* hot wallet — its key sits on the
@@ -134,15 +152,21 @@ export class EscrowHealthMonitor {
         },
       })
 
-      if (activeDeployments.length === 0) return
-
       log.info({ count: activeDeployments.length }, 'Escrow health check — active deployments found')
 
       await this.checkWalletBalance()
 
       // Single RPC call to fetch all deployment escrow accounts for our owner,
       // instead of one query per dseq. O(1) RPC calls regardless of deployment count.
-      const owner = activeDeployments[0].owner
+      // Owner: prefer a DB row's `owner` (skips an RPC) but fall back to
+      // `keys show` so we can still run the orphan sweep when DB has zero ACTIVE rows.
+      const owner =
+        activeDeployments[0]?.owner ?? (await this.resolveDeployerAddress())
+      if (!owner) {
+        log.warn('Could not resolve deployer wallet address — skipping cycle')
+        return
+      }
+
       const [chainEscrows, currentBlockHeight] = await Promise.all([
         this.fetchAllEscrowBalances(owner),
         this.fetchCurrentBlockHeight(),
@@ -219,8 +243,24 @@ export class EscrowHealthMonitor {
         }
       }
 
+      // Sweep deployments that exist on-chain but have no DB row.
+      // Catches: half-completed manual `akash` CLI runs, probe-bid (PR 2)
+      // deployments whose try/finally close failed, any other path that
+      // writes to the chain but bypasses the queue.
+      const sweptOrphans = await this.sweepChainOrphans(
+        activeDeployments,
+        chainEscrows,
+        currentBlockHeight,
+      )
+
       log.info(
-        { checked: activeDeployments.length, refilled: refillCount, closed: closedCount, errors: errorCount },
+        {
+          checked: activeDeployments.length,
+          refilled: refillCount,
+          closed: closedCount,
+          errors: errorCount,
+          orphansSwept: sweptOrphans,
+        },
         'Escrow health check complete'
       )
     } catch (err) {
@@ -228,6 +268,115 @@ export class EscrowHealthMonitor {
     } finally {
       this.running = false
     }
+  }
+
+  /**
+   * Resolve the deployer wallet address via `akash keys show` (used as the
+   * owner for the chain escrow query when the DB has no ACTIVE rows to read
+   * `owner` from — e.g. the orphan-only case).
+   */
+  private async resolveDeployerAddress(): Promise<string | null> {
+    try {
+      const keyName = process.env.AKASH_KEY_NAME || 'default'
+      const out = await runAkashCmd(['keys', 'show', keyName, '-a'])
+      const addr = out.trim()
+      return addr || null
+    } catch (err) {
+      log.warn(
+        { err: (err as Error).message },
+        'resolveDeployerAddress failed',
+      )
+      return null
+    }
+  }
+
+  /**
+   * Close every chain deployment that has no matching DB row, is not already
+   * closed on-chain, and is older than `ORPHAN_MIN_AGE_BLOCKS`.
+   *
+   * Why this exists: the rest of `checkAndRefill` walks DB → chain to detect
+   * leases that died on-chain. The reverse direction (chain has it, DB
+   * doesn't) had no sweeper, so any path that bypasses the queue — manual
+   * `akash tx deployment create`, future probe-bid runs whose
+   * `try/finally` close failed, queue workers that crashed between the
+   * deployment-create TX and the DB write — leaked $1+ of escrow forever.
+   *
+   * Returns the number of orphans we successfully closed.
+   */
+  private async sweepChainOrphans(
+    dbActive: Array<{ dseq: bigint }>,
+    chainEscrows: Map<string, ChainEscrowEntry>,
+    currentBlockHeight: number,
+  ): Promise<number> {
+    const dbDseqs = new Set(dbActive.map((d) => d.dseq.toString()))
+    let swept = 0
+
+    for (const [dseq, entry] of chainEscrows) {
+      if (dbDseqs.has(dseq)) continue
+      if (entry.closed) continue
+
+      // `settled_at` defaults to the deployment's create-block height for
+      // never-touched escrows, so it doubles as an age proxy. Skip anything
+      // younger than the threshold to avoid racing brand-new deployments
+      // mid-flow.
+      const ageBlocks = currentBlockHeight - entry.settledAtBlock
+      if (ageBlocks < ORPHAN_MIN_AGE_BLOCKS) {
+        log.info(
+          { dseq, ageBlocks, threshold: ORPHAN_MIN_AGE_BLOCKS },
+          'Chain-orphan candidate younger than threshold — skipping (likely deployment mid-flow)',
+        )
+        continue
+      }
+
+      log.warn(
+        {
+          dseq,
+          ageBlocks,
+          fundsUact: entry.fundsUact,
+          settledAtBlock: entry.settledAtBlock,
+        },
+        'Chain-orphan deployment found (no DB row) — closing to reclaim escrow',
+      )
+
+      try {
+        const orchestrator = getAkashOrchestrator(this.prisma)
+        const result = await orchestrator.closeDeployment(Number(dseq))
+        if (result.chainStatus === 'FAILED') {
+          log.error(
+            { dseq, error: result.error },
+            'Failed to close chain-orphan deployment (will retry next cycle)',
+          )
+          continue
+        }
+        swept++
+        // One alert per orphan closed — operator should know that something
+        // outside the application created a chain deployment we had to clean up.
+        await opsAlert({
+          key: `chain-orphan-closed:${dseq}`,
+          severity: 'warning',
+          title: 'Auto-closed chain-orphan deployment',
+          message:
+            `Closed dseq ${dseq} on-chain — it had no matching row in akash_deployment. ` +
+            `Likely cause: a manual akash CLI invocation, a queue worker that crashed before persisting, ` +
+            `or a probe-bid run whose try/finally close failed. Reclaimed ~${(entry.fundsUact / 1_000_000).toFixed(2)} ACT to deployer wallet.`,
+          context: {
+            dseq,
+            ageBlocks: String(ageBlocks),
+            fundsUact: String(entry.fundsUact),
+          },
+          // Per-dseq key dedupes naturally; suppress repeats anyway in case
+          // close keeps failing and the same dseq retries.
+          suppressMs: 24 * 60 * 60 * 1000,
+        })
+      } catch (err) {
+        log.error(
+          { dseq, error: (err as Error).message },
+          'Error closing chain-orphan deployment (will retry next cycle)',
+        )
+      }
+    }
+
+    return swept
   }
 
   private async checkWalletBalance(): Promise<void> {


### PR DESCRIPTION
The escrow monitor walked DB->chain to detect dead leases but had no
reverse sweep, so any path that wrote to chain without persisting a
DB row (manual akash CLI runs, queue workers crashing mid-flow,
probe-bid leases whose try/finally close failed) leaked $1+ of escrow
forever.

Adds sweepChainOrphans() with three safety layers:
  1. Exclusion set covers every recorded dseq regardless of status —
     SUSPENDED, WAITING_BIDS, DEPLOYING, CLOSE_FAILED, etc. are all
     intentionally open on-chain and must never be closed by the sweep.
  2. 1h age guard against racing in-flight deployments whose DB row
     hasn't been written yet (env-overridable for staging).
  3. Per-dseq ops alert so any false positive is surfaced immediately.

Also hardens the broader monitor:
  - Always re-resolves deployer address via `keys show -a` and validates
    against AkashDeployment.owner — mismatch fires
    escrow-monitor-owner-mismatch (critical) and skips the cycle.
  - Removes the empty-DB early-return so the sweep runs even when zero
    ACTIVE rows exist (the production case that surfaced the bug).
  - Fixes pre-existing §L vs §M runbook references (§L is failover loop,
    §M is hot-wallet cap).

Doc updates aligning code with reality:
  - AF_IMPLEMENTATION_AKASH.md: corrects stale `*/10` cron schedule
    (actual: `30 * * * *`), adds Chain-orphan sweep subsection.
  - AF_INCIDENT_RUNBOOKS.md §D: adds automated sweep to Prevention.
  - AF_INCIDENT_RUNBOOKS.md §J: rewrites alert-key table to match actual
    code (every previous key was stale).
  - AF_INCIDENT_RUNBOOKS.md §M: notes orphan reclaim can transiently
    push hot wallet above cap.
  - AF_REPORT_AKASH_BUGS.md: documents that the sweep covers the
    no-DB-row orphan class and is NOT a substitute for the PRP §3.5
    reaper for the all-leases-closed orphan class.