### PR TITLE
per-GPU bid probe + scheduler telemetry

### DIFF
--- a/prisma/migrations/20260419155332_add_gpu_pricing_tables/migration.sql
+++ b/prisma/migrations/20260419155332_add_gpu_pricing_tables/migration.sql
@@ -1,0 +1,47 @@
+-- CreateTable
+CREATE TABLE "gpu_bid_observation" (
+    "id" TEXT NOT NULL,
+    "probe_run_id" TEXT NOT NULL,
+    "gpu_model" TEXT NOT NULL,
+    "vendor" TEXT NOT NULL,
+    "provider_addr" TEXT NOT NULL,
+    "price_per_block_uact" BIGINT NOT NULL,
+    "dseq" BIGINT NOT NULL,
+    "observed_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "gpu_bid_observation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "gpu_price_summary" (
+    "gpu_model" TEXT NOT NULL,
+    "vendor" TEXT NOT NULL,
+    "min_price_per_block_uact" BIGINT NOT NULL,
+    "p50_price_per_block_uact" BIGINT NOT NULL,
+    "p90_price_per_block_uact" BIGINT NOT NULL,
+    "max_price_per_block_uact" BIGINT NOT NULL,
+    "sample_count" INTEGER NOT NULL,
+    "unique_provider_count" INTEGER NOT NULL,
+    "window_days" INTEGER NOT NULL DEFAULT 7,
+    "refreshed_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "gpu_price_summary_pkey" PRIMARY KEY ("gpu_model")
+);
+
+-- CreateTable
+CREATE TABLE "chain_stats" (
+    "id" TEXT NOT NULL DEFAULT 'akash-mainnet',
+    "seconds_per_block" DOUBLE PRECISION NOT NULL,
+    "blocks_per_day" INTEGER NOT NULL,
+    "blocks_per_hour" INTEGER NOT NULL,
+    "source_url" TEXT NOT NULL,
+    "sampled_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "chain_stats_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "gpu_bid_observation_gpu_model_observed_at_idx" ON "gpu_bid_observation"("gpu_model", "observed_at");
+
+-- CreateIndex
+CREATE INDEX "gpu_bid_observation_probe_run_id_idx" ON "gpu_bid_observation"("probe_run_id");

--- a/prisma/migrations/20260419162702_add_gpu_probe_run/migration.sql
+++ b/prisma/migrations/20260419162702_add_gpu_probe_run/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "gpu_probe_run" (
+    "id" TEXT NOT NULL,
+    "probe_run_id" TEXT NOT NULL,
+    "started_at" TIMESTAMP(3) NOT NULL,
+    "completed_at" TIMESTAMP(3),
+    "models_probed" INTEGER NOT NULL DEFAULT 0,
+    "bids_collected" INTEGER NOT NULL DEFAULT 0,
+    "unique_providers" INTEGER NOT NULL DEFAULT 0,
+    "cost_uact" BIGINT NOT NULL DEFAULT 0,
+    "cost_uakt" BIGINT NOT NULL DEFAULT 0,
+    "status" TEXT NOT NULL DEFAULT 'running',
+    "error" TEXT,
+
+    CONSTRAINT "gpu_probe_run_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "gpu_probe_run_probe_run_id_key" ON "gpu_probe_run"("probe_run_id");
+
+-- CreateIndex
+CREATE INDEX "gpu_probe_run_started_at_idx" ON "gpu_probe_run"("started_at");
+
+-- CreateIndex
+CREATE INDEX "gpu_probe_run_status_idx" ON "gpu_probe_run"("status");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1489,6 +1489,73 @@ model ProviderTemplateResult {
 }
 
 // ============================================
+// GPU BID PROBE PRICING (PR2: Per-GPU pricing system)
+// ============================================
+//
+// Real per-GPU pricing requires probing the chain — there is no public
+// "current bid for an H100" endpoint. The GpuBidProbeScheduler posts a
+// tiny SDL targeting one GPU model every 6h, records every open bid,
+// then closes the deployment without leasing. ~$0.0015 per probe.
+//
+// `gpu_bid_observation` is the time-series of raw bids; `gpu_price_summary`
+// is the rolled-up percentiles consumed by the web UI; `chain_stats` is
+// a single-row cache of measured Akash block geometry for cost reporting.
+
+model GpuBidObservation {
+  id            String   @id @default(cuid())
+
+  /// Groups all bids collected during a single runGpuBidProbeCycle invocation.
+  probeRunId    String   @map("probe_run_id")
+
+  /// Lowercase canonical model id ("h100", "rtx4090", "a100"). Matches
+  /// `compute_provider.gpu_models` element values.
+  gpuModel      String   @map("gpu_model")
+  vendor        String   // "nvidia" | "amd"
+
+  providerAddr  String   @map("provider_addr")
+  pricePerBlock BigInt   @map("price_per_block_uact")
+
+  /// dseq of the probe deployment. Useful for audit / debugging the close
+  /// path on the "did this probe leak escrow?" question.
+  dseq          BigInt
+  observedAt    DateTime @default(now()) @map("observed_at")
+
+  @@index([gpuModel, observedAt])
+  @@index([probeRunId])
+  @@map("gpu_bid_observation")
+}
+
+model GpuPriceSummary {
+  /// Lowercase model id; primary key (one row per GPU model).
+  gpuModel             String   @id @map("gpu_model")
+  vendor               String
+
+  minPricePerBlock     BigInt   @map("min_price_per_block_uact")
+  p50PricePerBlock     BigInt   @map("p50_price_per_block_uact")
+  p90PricePerBlock     BigInt   @map("p90_price_per_block_uact")
+  maxPricePerBlock     BigInt   @map("max_price_per_block_uact")
+
+  sampleCount          Int      @map("sample_count")
+  uniqueProviderCount  Int      @map("unique_provider_count")
+  windowDays           Int      @default(7) @map("window_days")
+  refreshedAt          DateTime @map("refreshed_at")
+
+  @@map("gpu_price_summary")
+}
+
+model ChainStats {
+  /// Single-row table; default id pins the row so upserts always hit it.
+  id              String   @id @default("akash-mainnet")
+  secondsPerBlock Float    @map("seconds_per_block")
+  blocksPerDay    Int      @map("blocks_per_day")
+  blocksPerHour   Int      @map("blocks_per_hour")
+  sourceUrl       String   @map("source_url")
+  sampledAt       DateTime @map("sampled_at")
+
+  @@map("chain_stats")
+}
+
+// ============================================
 // FEEDBACK & BUG REPORTS
 // ============================================
 
@@ -1517,6 +1584,48 @@ model FeedbackReport {
   @@index([category])
   @@index([createdAt])
   @@map("feedback_report")
+}
+
+/// Per-cycle telemetry for GpuBidProbeScheduler.
+///
+/// One row per `runGpuBidProbeCycle` invocation — mirrors the
+/// VerificationRun pattern so the admin dashboard can show "how many
+/// times did this cron run, what did it cost, and what came out of it"
+/// without having to derive run counts from `gpu_bid_observation`.
+///
+/// Cost is captured as the wallet balance delta around the cycle so the
+/// number reflects actual on-chain spend (gas + deposits not refunded).
+/// `bidsCollected` and `uniqueProviders` come from the bids inserted
+/// into `gpu_bid_observation` for this run.
+model GpuProbeRun {
+  id              String    @id @default(cuid())
+
+  /// Mirrors `gpu_bid_observation.probe_run_id` so admin tools can join
+  /// bids back to their cycle without an extra index.
+  probeRunId      String    @unique @map("probe_run_id")
+
+  startedAt       DateTime  @map("started_at")
+  completedAt     DateTime? @map("completed_at")
+
+  modelsProbed    Int       @default(0) @map("models_probed")
+  bidsCollected   Int       @default(0) @map("bids_collected")
+  uniqueProviders Int       @default(0) @map("unique_providers")
+
+  /// Wallet uact spend for the cycle (`balanceBefore.uact - balanceAfter.uact`,
+  /// floored at 0 — wallet refills mid-cycle would otherwise produce a
+  /// misleading negative).
+  costUact        BigInt    @default(0) @map("cost_uact")
+  /// Same idea for uakt, included for symmetry with VerificationRun and
+  /// for any pre-BME residue. Expected to stay 0 in production.
+  costUakt        BigInt    @default(0) @map("cost_uakt")
+
+  status          String    @default("running") // running | completed | failed | skipped
+  /// Slim error message — full traces go to logs via opsAlert.
+  error           String?
+
+  @@index([startedAt])
+  @@index([status])
+  @@map("gpu_probe_run")
 }
 
 model VerificationRun {

--- a/src/config/pricing.test.ts
+++ b/src/config/pricing.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest'
 import {
   PRICING,
   STORAGE_PRICING,
@@ -8,6 +8,8 @@ import {
   calculateComputeCost,
   calculateRegistryCost,
   getPricingInfo,
+  getAkashChainGeometry,
+  _resetAkashChainGeometryCacheForTests,
 } from './pricing'
 
 describe('Pricing Configuration', () => {
@@ -156,6 +158,107 @@ describe('Pricing Configuration', () => {
       const info = getPricingInfo()
       const ipfsStorage = info.storage.find(s => s.network === 'IPFS')
       expect(ipfsStorage?.price).toBe(STORAGE_PRICING.ipfs.ratePerGb)
+    })
+  })
+
+  describe('getAkashChainGeometry persistence/hydration', () => {
+    const originalFetch = global.fetch
+
+    beforeEach(() => {
+      _resetAkashChainGeometryCacheForTests()
+    })
+
+    afterEach(() => {
+      global.fetch = originalFetch
+      vi.restoreAllMocks()
+      _resetAkashChainGeometryCacheForTests()
+    })
+
+    function makeBlocksResponse() {
+      // Synthesise 12 samples (function requires ≥10) at 6.0s/block, most-
+      // recent-first, so head − tail spans 11 × 100 blocks at 600s each.
+      const headHeight = 21_500_000
+      const headEpochMs = Date.parse('2026-04-19T12:00:00Z')
+      const samples = Array.from({ length: 12 }, (_, i) => ({
+        height: headHeight - i * 100,
+        datetime: new Date(headEpochMs - i * 600_000).toISOString(),
+      }))
+      return new Response(JSON.stringify(samples), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    it('upserts chain_stats when prisma is provided and a fresh sample lands', async () => {
+      global.fetch = vi.fn().mockResolvedValue(makeBlocksResponse())
+      const upsert = vi.fn().mockResolvedValue({})
+      const findUnique = vi.fn()
+      const prisma = { chainStats: { upsert, findUnique } } as any
+
+      const geom = await getAkashChainGeometry(prisma)
+
+      expect(geom.source).toBe('akash-console-api')
+      expect(upsert).toHaveBeenCalledTimes(1)
+      const call = upsert.mock.calls[0][0]
+      expect(call.where).toEqual({ id: 'akash-mainnet' })
+      expect(call.create.id).toBe('akash-mainnet')
+      expect(call.create.blocksPerDay).toBe(geom.blocksPerDay)
+      // Hydration query should not have been needed when live API succeeded.
+      expect(findUnique).not.toHaveBeenCalled()
+    })
+
+    it('hydrates from chain_stats on cold-start when both cache and live API are unavailable', async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error('network down'))
+      const upsert = vi.fn()
+      const findUnique = vi.fn().mockResolvedValue({
+        id: 'akash-mainnet',
+        secondsPerBlock: 6.117,
+        blocksPerHour: 588,
+        blocksPerDay: 14_124,
+        sourceUrl: 'https://console-api.akash.network/v1/blocks',
+        sampledAt: new Date('2026-04-19T10:00:00Z'),
+      })
+      const prisma = { chainStats: { upsert, findUnique } } as any
+
+      const geom = await getAkashChainGeometry(prisma)
+
+      expect(findUnique).toHaveBeenCalledWith({ where: { id: 'akash-mainnet' } })
+      expect(geom.source).toBe('cache')
+      expect(geom.blocksPerDay).toBe(14_124)
+      expect(geom.secondsPerBlock).toBeCloseTo(6.117, 3)
+    })
+
+    it('falls back to the static constant when live API fails AND no chain_stats row exists', async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error('network down'))
+      const prisma = {
+        chainStats: {
+          upsert: vi.fn(),
+          findUnique: vi.fn().mockResolvedValue(null),
+        },
+      } as any
+
+      const geom = await getAkashChainGeometry(prisma)
+      expect(geom.source).toBe('static-fallback')
+      expect(geom.blocksPerDay).toBeGreaterThan(0)
+    })
+
+    it('does not throw when persistence to chain_stats fails', async () => {
+      global.fetch = vi.fn().mockResolvedValue(makeBlocksResponse())
+      const upsert = vi.fn().mockRejectedValue(new Error('db down'))
+      const prisma = {
+        chainStats: { upsert, findUnique: vi.fn() },
+      } as any
+
+      const geom = await getAkashChainGeometry(prisma)
+      expect(geom.source).toBe('akash-console-api')
+      expect(upsert).toHaveBeenCalled()
+    })
+
+    it('works without a prisma argument (in-memory cache only)', async () => {
+      global.fetch = vi.fn().mockResolvedValue(makeBlocksResponse())
+      const geom = await getAkashChainGeometry()
+      expect(geom.source).toBe('akash-console-api')
+      expect(geom.blocksPerDay).toBeGreaterThan(0)
     })
   })
 })

--- a/src/config/pricing.ts
+++ b/src/config/pricing.ts
@@ -13,10 +13,18 @@
  * using the org's active plan usageMarkup rate.
  */
 
+import type { PrismaClient } from '@prisma/client'
 import { createLogger } from '../lib/logger.js'
-import { BLOCKS_PER_DAY } from './akash.js'
+import { BLOCKS_PER_DAY, BLOCKS_PER_HOUR } from './akash.js'
 
 const log = createLogger('pricing')
+
+// Static fallback range for the live block-geometry feed. Akash's
+// real block time has historically lived between 5.4s (16_000/day) and
+// 7.2s (12_000/day); anything outside this band is almost certainly a
+// bad data sample, not a real chain change. We clamp before caching.
+const BLOCKS_PER_DAY_MIN = 12_000
+const BLOCKS_PER_DAY_MAX = 16_000
 
 // ============================================
 // DEFAULT PLAN MARGINS (fallbacks — actual per-org
@@ -161,6 +169,217 @@ export async function getAktUsdPrice(): Promise<number> {
 
   log.error({ fallback: AKT_USD_PRICE_FALLBACK }, 'All AKT price sources failed and no cache — using env fallback')
   return AKT_USD_PRICE_FALLBACK
+}
+
+// ---- Live Akash blocks-per-day feed ----
+//
+// Sources Akash console-api, derives `blocksPerDay` from the slope of
+// the recent block-height vs. timestamp samples, clamps to a sane range,
+// and caches for 1 hour.
+//
+// **CRITICAL**: this function is for *cost reporting and UI display
+// only*. Do NOT use it in billing hot paths (`escrowHealthMonitor` refill
+// math, `computeBillingScheduler` top-up amount, `escrowService`
+// initial deposit). Billing math must produce identical numbers across
+// consecutive cycles for the same lease — a UI value that drifts ±1%
+// with chain conditions is fine, but a refill amount that does is how
+// "deployment closed mid-hour, then re-funded for the wrong amount"
+// bugs ship. Billing paths must keep using the static `BLOCKS_PER_HOUR`
+// / `BLOCKS_PER_DAY` constants from `./akash.ts`.
+
+export interface ChainGeometry {
+  secondsPerBlock: number
+  blocksPerHour: number
+  blocksPerDay: number
+  source: 'akash-console-api' | 'static-fallback' | 'cache'
+  sampledAt: number
+}
+
+let _blocksCache: { value: ChainGeometry; ts: number } | null = null
+const BLOCKS_CACHE_TTL_MS = 60 * 60_000
+
+interface ConsoleApiBlock {
+  height: number
+  datetime: string
+}
+
+async function fetchAkashBlocksGeometry(signal: AbortSignal): Promise<ChainGeometry | null> {
+  const res = await fetch('https://console-api.akash.network/v1/blocks', { signal })
+  if (!res.ok) throw new Error(`Akash console-api HTTP ${res.status}`)
+  const blocks = (await res.json()) as ConsoleApiBlock[]
+  if (!Array.isArray(blocks) || blocks.length < 10) {
+    throw new Error(`Akash console-api returned only ${blocks?.length ?? 0} blocks (need 10+)`)
+  }
+  // The endpoint returns most-recent-first; head/tail give us the
+  // largest possible measurement window in one call.
+  const head = blocks[0]
+  const tail = blocks[blocks.length - 1]
+  const headHeight = Number(head.height)
+  const tailHeight = Number(tail.height)
+  if (!Number.isFinite(headHeight) || !Number.isFinite(tailHeight) || headHeight <= tailHeight) {
+    throw new Error('Akash console-api samples have unusable heights')
+  }
+  const headMs = Date.parse(head.datetime)
+  const tailMs = Date.parse(tail.datetime)
+  if (!Number.isFinite(headMs) || !Number.isFinite(tailMs) || headMs <= tailMs) {
+    throw new Error('Akash console-api samples have unusable timestamps')
+  }
+  const secondsPerBlock = (headMs - tailMs) / (headHeight - tailHeight) / 1000
+  if (!Number.isFinite(secondsPerBlock) || secondsPerBlock <= 0) {
+    throw new Error(`Computed secondsPerBlock=${secondsPerBlock} is invalid`)
+  }
+  const blocksPerDayRaw = Math.round(86_400 / secondsPerBlock)
+  if (blocksPerDayRaw < BLOCKS_PER_DAY_MIN || blocksPerDayRaw > BLOCKS_PER_DAY_MAX) {
+    throw new Error(`blocksPerDay=${blocksPerDayRaw} outside sane range — refusing sample`)
+  }
+  return {
+    secondsPerBlock,
+    blocksPerHour: Math.round(3_600 / secondsPerBlock),
+    blocksPerDay: blocksPerDayRaw,
+    source: 'akash-console-api',
+    sampledAt: Date.now(),
+  }
+}
+
+/**
+ * Persist a successful geometry sample into `chain_stats`. Best-effort —
+ * a DB outage must NEVER break the in-memory cache hot path. We log and
+ * swallow.
+ *
+ * The row is keyed `id = "akash-mainnet"` (the schema default) so this
+ * is a single-row upsert. Survives pod restarts so a fresh replica can
+ * hydrate the in-memory cache from DB on first call instead of always
+ * paying the console-api round-trip.
+ */
+async function persistChainStats(
+  prisma: PrismaClient,
+  geometry: ChainGeometry,
+): Promise<void> {
+  try {
+    await prisma.chainStats.upsert({
+      where: { id: 'akash-mainnet' },
+      create: {
+        id: 'akash-mainnet',
+        secondsPerBlock: geometry.secondsPerBlock,
+        blocksPerDay: geometry.blocksPerDay,
+        blocksPerHour: geometry.blocksPerHour,
+        sourceUrl: 'https://console-api.akash.network/v1/blocks',
+        sampledAt: new Date(geometry.sampledAt),
+      },
+      update: {
+        secondsPerBlock: geometry.secondsPerBlock,
+        blocksPerDay: geometry.blocksPerDay,
+        blocksPerHour: geometry.blocksPerHour,
+        sourceUrl: 'https://console-api.akash.network/v1/blocks',
+        sampledAt: new Date(geometry.sampledAt),
+      },
+    })
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : err },
+      'persistChainStats failed — chain_stats row not updated'
+    )
+  }
+}
+
+/**
+ * Returns Akash chain block geometry (seconds/block, blocks/hour,
+ * blocks/day). Cached for 1h in memory. Optional `prisma` arg enables
+ * (a) persisting fresh samples to `chain_stats` for cold-start
+ * hydration on a new pod, and (b) reading the last persisted sample as
+ * a fallback when both the live API and the in-memory cache miss.
+ *
+ * Falls back to the static constants from `config/akash.ts` if every
+ * live source AND the persisted row are unavailable.
+ */
+export async function getAkashChainGeometry(
+  prisma?: PrismaClient,
+): Promise<ChainGeometry> {
+  if (_blocksCache && Date.now() - _blocksCache.ts < BLOCKS_CACHE_TTL_MS) {
+    return { ..._blocksCache.value, source: 'cache' }
+  }
+
+  try {
+    const signal = AbortSignal.timeout(5_000)
+    const geometry = await fetchAkashBlocksGeometry(signal)
+    if (geometry) {
+      _blocksCache = { value: geometry, ts: Date.now() }
+      log.info(
+        { secondsPerBlock: geometry.secondsPerBlock, blocksPerDay: geometry.blocksPerDay },
+        'Akash chain geometry refreshed'
+      )
+      if (prisma) await persistChainStats(prisma, geometry)
+      return geometry
+    }
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : err },
+      'Akash console-api block sample failed — falling back to static constant'
+    )
+  }
+
+  if (_blocksCache) {
+    log.warn(
+      { stale: _blocksCache.value, ageMs: Date.now() - _blocksCache.ts },
+      'Live block-geometry sample failed — using stale cache'
+    )
+    return { ..._blocksCache.value, source: 'cache' }
+  }
+
+  // Cold-start path: pod just booted, no in-memory cache, live API
+  // failed. Try the persisted row before giving up to the static
+  // constant — that row was last written by a healthy pod and is
+  // always closer to reality than the compile-time constant.
+  if (prisma) {
+    try {
+      const row = await prisma.chainStats.findUnique({
+        where: { id: 'akash-mainnet' },
+      })
+      if (row) {
+        const hydrated: ChainGeometry = {
+          secondsPerBlock: row.secondsPerBlock,
+          blocksPerHour: row.blocksPerHour,
+          blocksPerDay: row.blocksPerDay,
+          source: 'cache',
+          sampledAt: row.sampledAt.getTime(),
+        }
+        _blocksCache = { value: hydrated, ts: Date.now() }
+        log.info(
+          { sampledAt: row.sampledAt.toISOString(), blocksPerDay: row.blocksPerDay },
+          'Hydrated geometry cache from chain_stats persisted row'
+        )
+        return hydrated
+      }
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : err },
+        'chain_stats hydration query failed — falling back to static constant'
+      )
+    }
+  }
+
+  return {
+    secondsPerBlock: 86_400 / BLOCKS_PER_DAY,
+    blocksPerHour: BLOCKS_PER_HOUR,
+    blocksPerDay: BLOCKS_PER_DAY,
+    source: 'static-fallback',
+    sampledAt: Date.now(),
+  }
+}
+
+/**
+ * Convenience wrapper for callers that only need `blocksPerDay`.
+ * Same caveats as `getAkashChainGeometry`: cost-reporting only — never
+ * use in billing hot paths.
+ */
+export async function getAkashBlocksPerDay(prisma?: PrismaClient): Promise<number> {
+  const geometry = await getAkashChainGeometry(prisma)
+  return geometry.blocksPerDay
+}
+
+/** Test-only: drop the in-memory geometry cache. */
+export function _resetAkashChainGeometryCacheForTests(): void {
+  _blocksCache = null
 }
 
 // ============================================

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,10 +52,14 @@ import { runWithLeadership, stopAllLeaderSchedulers } from './services/leader/le
 import { setWalletMutexPrisma } from './services/akash/walletMutex.js'
 import { ProviderRegistryScheduler } from './services/providers/providerRegistryScheduler.js'
 import { ProviderVerificationScheduler } from './services/providers/providerVerificationScheduler.js'
+import { GpuBidProbeScheduler } from './services/providers/gpuBidProbeScheduler.js'
 import { AuditExportScheduler } from './services/audit/auditExportScheduler.js'
 import { handleProviderRegistryRequest } from './services/providers/providerRegistryEndpoint.js'
+import { handleGpuPricingRequest } from './services/providers/gpuPricingEndpoint.js'
+import { handleGpuProbeManualTrigger } from './services/providers/gpuProbeManualTriggerEndpoint.js'
 import { handleAdminDeploymentStats } from './services/admin/deploymentStatsEndpoint.js'
 import { handleAdminBillingStats } from './services/admin/billingStatsEndpoint.js'
+import { handleSchedulerStats } from './services/admin/schedulerStatsEndpoint.js'
 import { handleAdminAuditEvents } from './services/admin/auditEventsEndpoint.js'
 import { handlePhalaInstanceTypesRequest } from './services/providers/phalaInstanceTypesEndpoint.js'
 import { reconcileActivePolicyExpirySchedules } from './services/policy/runtimeScheduler.js'
@@ -81,6 +85,7 @@ const computeBillingScheduler = new ComputeBillingScheduler(prisma)
 const escrowHealthMonitor = new EscrowHealthMonitor(prisma)
 const providerRegistryScheduler = new ProviderRegistryScheduler(prisma)
 const providerVerificationScheduler = new ProviderVerificationScheduler(prisma)
+const gpuBidProbeScheduler = new GpuBidProbeScheduler(prisma)
 const auditExportScheduler = new AuditExportScheduler(prisma)
 let healthPrewarmerInterval: ReturnType<typeof setInterval> | null = null
 const telemetryIngestionService = getTelemetryIngestionService(prisma)
@@ -300,6 +305,11 @@ async function requestHandler(req: IncomingMessage, res: ServerResponse) {
       return
     }
 
+    if (url.pathname === '/internal/admin/scheduler-stats' && req.method === 'GET') {
+      await handleSchedulerStats(req, res, prisma)
+      return
+    }
+
     if (url.pathname === '/internal/admin/audit-events' && req.method === 'GET') {
       await handleAdminAuditEvents(req, res, prisma)
       return
@@ -327,6 +337,16 @@ async function requestHandler(req: IncomingMessage, res: ServerResponse) {
 
     if (url.pathname === '/internal/provider-registry' && req.method === 'GET') {
       await handleProviderRegistryRequest(req, res, prisma)
+      return
+    }
+
+    if (url.pathname === '/internal/gpu-pricing' && req.method === 'GET') {
+      await handleGpuPricingRequest(req, res, prisma)
+      return
+    }
+
+    if (url.pathname === '/internal/admin/gpu-probe-now' && req.method === 'POST') {
+      await handleGpuProbeManualTrigger(req, res, gpuBidProbeScheduler)
       return
     }
 
@@ -446,6 +466,10 @@ server.listen(port, async () => {
   await runWithLeadership(prisma, 'provider-verification-scheduler', {
     onAcquire: () => providerVerificationScheduler.start(),
     onRelease: () => providerVerificationScheduler.stop(),
+  })
+  await runWithLeadership(prisma, 'gpu-bid-probe-scheduler', {
+    onAcquire: () => gpuBidProbeScheduler.start(),
+    onRelease: () => gpuBidProbeScheduler.stop(),
   })
 
   // Per-pod work (no chain TXs / no row-mutating singletons): runs

--- a/src/services/admin/schedulerStatsEndpoint.test.ts
+++ b/src/services/admin/schedulerStatsEndpoint.test.ts
@@ -1,0 +1,284 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+
+import { handleSchedulerStats } from './schedulerStatsEndpoint.js'
+
+interface FakeRes {
+  statusCode?: number
+  headers?: Record<string, string>
+  body?: string
+  writeHead: ReturnType<typeof vi.fn>
+  end: ReturnType<typeof vi.fn>
+}
+
+function makeReq(headers: Record<string, string> = {}): IncomingMessage {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return { headers, url: '/internal/admin/scheduler-stats', method: 'GET' } as any
+}
+
+function makeRes(): FakeRes {
+  const res: FakeRes = {
+    writeHead: vi.fn(function (this: FakeRes, status: number, h?: Record<string, string>) {
+      this.statusCode = status
+      this.headers = h
+    }),
+    end: vi.fn(function (this: FakeRes, body?: string) {
+      this.body = body
+    }),
+  }
+  res.writeHead = res.writeHead.bind(res)
+  res.end = res.end.bind(res)
+  return res
+}
+
+interface FakePrisma {
+  $queryRaw: ReturnType<typeof vi.fn>
+  verificationRun: { findFirst: ReturnType<typeof vi.fn> }
+  gpuProbeRun: { findFirst: ReturnType<typeof vi.fn> }
+  computeProvider: { count: ReturnType<typeof vi.fn> }
+  gpuPriceSummary: {
+    count: ReturnType<typeof vi.fn>
+    findFirst: ReturnType<typeof vi.fn>
+  }
+}
+
+/**
+ * Builds a fake prisma where each $queryRaw call returns the next
+ * fixture in `rawResults`. The endpoint dispatches verifier-agg first,
+ * then probe-agg — order matters.
+ */
+function buildPrisma(opts: {
+  verifierAgg?: Record<string, bigint>
+  probeAgg?: Record<string, bigint>
+  lastVerifier?: unknown
+  lastProbe?: unknown
+  verifiedProviderCount?: number
+  gpuModelsTracked?: number
+  lastPriceRefresh?: Date | null
+} = {}): FakePrisma {
+  const verifierAgg = opts.verifierAgg ?? {
+    total_runs: 12n,
+    successful_runs: 10n,
+    failed_runs: 2n,
+    total_cost_uact: 24_000_000n, // $24
+  }
+  const probeAgg = opts.probeAgg ?? {
+    total_runs: 48n,
+    successful_runs: 47n,
+    failed_runs: 1n,
+    total_cost_uact: 1_500_000n, // $1.50
+  }
+
+  const $queryRaw = vi.fn()
+  $queryRaw
+    .mockResolvedValueOnce([verifierAgg])
+    .mockResolvedValueOnce([probeAgg])
+
+  return {
+    $queryRaw,
+    verificationRun: {
+      findFirst: vi.fn().mockResolvedValue(opts.lastVerifier ?? null),
+    },
+    gpuProbeRun: {
+      findFirst: vi.fn().mockResolvedValue(opts.lastProbe ?? null),
+    },
+    computeProvider: {
+      count: vi.fn().mockResolvedValue(opts.verifiedProviderCount ?? 14),
+    },
+    gpuPriceSummary: {
+      count: vi.fn().mockResolvedValue(opts.gpuModelsTracked ?? 7),
+      findFirst: vi.fn().mockResolvedValue(
+        opts.lastPriceRefresh === null
+          ? null
+          : { refreshedAt: opts.lastPriceRefresh ?? new Date('2026-04-19T12:00:00Z') },
+      ),
+    },
+  }
+}
+
+describe('handleSchedulerStats', () => {
+  beforeEach(() => {
+    process.env.INTERNAL_AUTH_TOKEN = 'secret-token'
+  })
+
+  afterEach(() => {
+    delete process.env.INTERNAL_AUTH_TOKEN
+    vi.clearAllMocks()
+  })
+
+  // ── Auth ─────────────────────────────────────────────────────────
+
+  it('rejects request without x-internal-auth header', async () => {
+    const res = makeRes()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await handleSchedulerStats(makeReq(), res as unknown as ServerResponse, buildPrisma() as any)
+    expect(res.statusCode).toBe(401)
+    expect(JSON.parse(res.body!).error).toBe('Unauthorized')
+  })
+
+  it('rejects request with the wrong token', async () => {
+    const res = makeRes()
+    await handleSchedulerStats(
+      makeReq({ 'x-internal-auth': 'nope' }),
+      res as unknown as ServerResponse,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      buildPrisma() as any,
+    )
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('rejects when INTERNAL_AUTH_TOKEN is unset (deny-by-default)', async () => {
+    delete process.env.INTERNAL_AUTH_TOKEN
+    const res = makeRes()
+    await handleSchedulerStats(
+      makeReq({ 'x-internal-auth': 'secret-token' }),
+      res as unknown as ServerResponse,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      buildPrisma() as any,
+    )
+    expect(res.statusCode).toBe(401)
+  })
+
+  // ── Aggregation ──────────────────────────────────────────────────
+
+  it('returns aggregate stats with uact → ACT conversion and ISO timestamps', async () => {
+    const lastVerifier = {
+      startedAt: new Date('2026-04-18T04:00:00Z'),
+      completedAt: new Date('2026-04-18T04:23:00Z'),
+      status: 'completed',
+      passed: 28,
+      failed: 4,
+      uniqueProviders: 11,
+      costUact: 2_500_000n, // $2.50
+    }
+    const lastProbe = {
+      startedAt: new Date('2026-04-19T13:00:00Z'),
+      completedAt: new Date('2026-04-19T13:08:00Z'),
+      status: 'completed',
+      modelsProbed: 6,
+      bidsCollected: 22,
+      uniqueProviders: 9,
+      costUact: 50_000n, // $0.05
+    }
+    const prisma = buildPrisma({ lastVerifier, lastProbe })
+    const res = makeRes()
+    await handleSchedulerStats(
+      makeReq({ 'x-internal-auth': 'secret-token' }),
+      res as unknown as ServerResponse,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      prisma as any,
+    )
+
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body!)
+
+    expect(body.verifier).toMatchObject({
+      totalRuns: 12,
+      successfulRuns: 10,
+      failedRuns: 2,
+      totalCostAct: 24,
+      verifiedProviderCount: 14,
+    })
+    expect(body.verifier.lastRun).toMatchObject({
+      status: 'completed',
+      passed: 28,
+      failed: 4,
+      uniqueProviders: 11,
+      costAct: 2.5,
+    })
+    expect(typeof body.verifier.lastRun.startedAt).toBe('string')
+    expect(body.verifier.lastRun.completedAt).toBe('2026-04-18T04:23:00.000Z')
+
+    expect(body.probe).toMatchObject({
+      totalRuns: 48,
+      successfulRuns: 47,
+      failedRuns: 1,
+      totalCostAct: 1.5,
+      gpuModelsTracked: 7,
+      lastPriceRefresh: '2026-04-19T12:00:00.000Z',
+    })
+    expect(body.probe.lastRun).toMatchObject({
+      status: 'completed',
+      modelsProbed: 6,
+      bidsCollected: 22,
+      uniqueProviders: 9,
+      costAct: 0.05,
+    })
+  })
+
+  it('handles a fresh install (no runs, no prices) without crashing', async () => {
+    const prisma = buildPrisma({
+      verifierAgg: {
+        total_runs: 0n,
+        successful_runs: 0n,
+        failed_runs: 0n,
+        total_cost_uact: 0n,
+      },
+      probeAgg: {
+        total_runs: 0n,
+        successful_runs: 0n,
+        failed_runs: 0n,
+        total_cost_uact: 0n,
+      },
+      verifiedProviderCount: 0,
+      gpuModelsTracked: 0,
+      lastPriceRefresh: null,
+    })
+    const res = makeRes()
+    await handleSchedulerStats(
+      makeReq({ 'x-internal-auth': 'secret-token' }),
+      res as unknown as ServerResponse,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      prisma as any,
+    )
+
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body!)
+    expect(body.verifier.totalRuns).toBe(0)
+    expect(body.verifier.lastRun).toBeNull()
+    expect(body.verifier.totalCostAct).toBe(0)
+    expect(body.probe.totalRuns).toBe(0)
+    expect(body.probe.lastRun).toBeNull()
+    expect(body.probe.lastPriceRefresh).toBeNull()
+  })
+
+  it('preserves uact precision down to $0.0001 for tiny probe spend', async () => {
+    const prisma = buildPrisma({
+      probeAgg: {
+        total_runs: 1n,
+        successful_runs: 1n,
+        failed_runs: 0n,
+        total_cost_uact: 1_500n, // $0.0015
+      },
+    })
+    const res = makeRes()
+    await handleSchedulerStats(
+      makeReq({ 'x-internal-auth': 'secret-token' }),
+      res as unknown as ServerResponse,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      prisma as any,
+    )
+    const body = JSON.parse(res.body!)
+    // 1500 / 1_000_000 = 0.0015
+    expect(body.probe.totalCostAct).toBeCloseTo(0.0015, 6)
+  })
+
+  it('returns 500 when the prisma read throws', async () => {
+    const $queryRaw = vi.fn().mockRejectedValue(new Error('db down'))
+    const prisma = {
+      $queryRaw,
+      verificationRun: { findFirst: vi.fn() },
+      gpuProbeRun: { findFirst: vi.fn() },
+      computeProvider: { count: vi.fn() },
+      gpuPriceSummary: { count: vi.fn(), findFirst: vi.fn() },
+    }
+    const res = makeRes()
+    await handleSchedulerStats(
+      makeReq({ 'x-internal-auth': 'secret-token' }),
+      res as unknown as ServerResponse,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      prisma as any,
+    )
+    expect(res.statusCode).toBe(500)
+  })
+})

--- a/src/services/admin/schedulerStatsEndpoint.ts
+++ b/src/services/admin/schedulerStatsEndpoint.ts
@@ -1,0 +1,202 @@
+/**
+ * Internal endpoint: GET /internal/admin/scheduler-stats
+ *
+ * Aggregate health/cost telemetry for the two long-running cron jobs
+ * that touch the wallet — ProviderVerificationScheduler and
+ * GpuBidProbeScheduler. This is what the admin dashboard's third
+ * provider-strip card consumes.
+ *
+ * Numbers come from three places:
+ *   1. `verification_run` (one row per verifier cycle)
+ *   2. `gpu_probe_run`    (one row per probe cycle)
+ *   3. live counts from `compute_provider` and `gpu_price_summary`
+ *
+ * `cost_uact` on each run is captured as the wallet balance delta around
+ * the cycle, so totals here reflect *actual* on-chain spend (gas +
+ * unrefunded deposits), not estimates.
+ *
+ * Secured by INTERNAL_AUTH_TOKEN — same pattern as billing-stats.
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { PrismaClient } from '@prisma/client'
+import { createLogger } from '../../lib/logger.js'
+
+const log = createLogger('admin-scheduler-stats')
+
+/**
+ * 1 ACT (the AKT compute credit) is denominated in 1_000_000 uact —
+ * same convention used everywhere in the wallet/balance code.
+ */
+const UACT_PER_ACT = 1_000_000
+
+/** Aggregate row coming back from the SQL summary. */
+interface RunAggregateRow {
+  total_runs: bigint
+  successful_runs: bigint
+  failed_runs: bigint
+  total_cost_uact: bigint
+}
+
+interface SchedulerStatsResponse {
+  verifier: {
+    /** Total `verification_run` rows ever recorded. */
+    totalRuns: number
+    successfulRuns: number
+    failedRuns: number
+    /** Lifetime sum of cost_uact, expressed in ACT (USD-pegged). */
+    totalCostAct: number
+    /** Most recent run, or null if none yet. */
+    lastRun: {
+      startedAt: string
+      completedAt: string | null
+      status: string
+      passed: number
+      failed: number
+      uniqueProviders: number
+      costAct: number
+    } | null
+    /** Live count of currently-verified providers. */
+    verifiedProviderCount: number
+  }
+  probe: {
+    totalRuns: number
+    successfulRuns: number
+    failedRuns: number
+    totalCostAct: number
+    lastRun: {
+      startedAt: string
+      completedAt: string | null
+      status: string
+      modelsProbed: number
+      bidsCollected: number
+      uniqueProviders: number
+      costAct: number
+    } | null
+    /** Live count of distinct GPU models in `gpu_price_summary`. */
+    gpuModelsTracked: number
+    /** Most recent `refreshed_at` across `gpu_price_summary`, or null. */
+    lastPriceRefresh: string | null
+  }
+}
+
+/** uact (BigInt) → ACT (number) with 4 decimals — enough resolution
+ *  for the dashboard ($0.0001 per unit), avoids fp drift on display. */
+function uactToAct(uact: bigint): number {
+  // Use string-then-parse to preserve precision for very large totals
+  // without importing a decimal lib for one division.
+  const whole = uact / BigInt(UACT_PER_ACT)
+  const remainder = uact % BigInt(UACT_PER_ACT)
+  return Number(whole) + Number(remainder) / UACT_PER_ACT
+}
+
+export async function handleSchedulerStats(
+  req: IncomingMessage,
+  res: ServerResponse,
+  prisma: PrismaClient,
+): Promise<void> {
+  const expectedToken = process.env.INTERNAL_AUTH_TOKEN
+  const authToken = req.headers['x-internal-auth']
+
+  if (!expectedToken || authToken !== expectedToken) {
+    res.writeHead(401, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ error: 'Unauthorized' }))
+    return
+  }
+
+  try {
+    const [
+      verifierAgg,
+      lastVerifier,
+      verifiedProviderCount,
+      probeAgg,
+      lastProbe,
+      gpuModelsTracked,
+      lastPriceRefreshRow,
+    ] = await Promise.all([
+      prisma.$queryRaw<RunAggregateRow[]>`
+        SELECT
+          COUNT(*)::bigint                                                AS total_runs,
+          COUNT(*) FILTER (WHERE status = 'completed')::bigint           AS successful_runs,
+          COUNT(*) FILTER (WHERE status = 'failed')::bigint              AS failed_runs,
+          COALESCE(SUM(cost_uact), 0)::bigint                            AS total_cost_uact
+        FROM "verification_run"
+      `,
+      prisma.verificationRun.findFirst({
+        orderBy: { startedAt: 'desc' },
+      }),
+      prisma.computeProvider.count({
+        where: { verified: true, blocked: false },
+      }),
+      prisma.$queryRaw<RunAggregateRow[]>`
+        SELECT
+          COUNT(*)::bigint                                                AS total_runs,
+          COUNT(*) FILTER (WHERE status = 'completed')::bigint           AS successful_runs,
+          COUNT(*) FILTER (WHERE status = 'failed')::bigint              AS failed_runs,
+          COALESCE(SUM(cost_uact), 0)::bigint                            AS total_cost_uact
+        FROM "gpu_probe_run"
+      `,
+      prisma.gpuProbeRun.findFirst({
+        orderBy: { startedAt: 'desc' },
+      }),
+      prisma.gpuPriceSummary.count(),
+      prisma.gpuPriceSummary.findFirst({
+        orderBy: { refreshedAt: 'desc' },
+        select: { refreshedAt: true },
+      }),
+    ])
+
+    const v = verifierAgg[0]
+    const p = probeAgg[0]
+
+    const body: SchedulerStatsResponse = {
+      verifier: {
+        totalRuns: Number(v.total_runs),
+        successfulRuns: Number(v.successful_runs),
+        failedRuns: Number(v.failed_runs),
+        totalCostAct: uactToAct(v.total_cost_uact),
+        lastRun: lastVerifier
+          ? {
+              startedAt: lastVerifier.startedAt.toISOString(),
+              completedAt: lastVerifier.completedAt?.toISOString() ?? null,
+              status: lastVerifier.status,
+              passed: lastVerifier.passed,
+              failed: lastVerifier.failed,
+              uniqueProviders: lastVerifier.uniqueProviders,
+              costAct: uactToAct(lastVerifier.costUact),
+            }
+          : null,
+        verifiedProviderCount,
+      },
+      probe: {
+        totalRuns: Number(p.total_runs),
+        successfulRuns: Number(p.successful_runs),
+        failedRuns: Number(p.failed_runs),
+        totalCostAct: uactToAct(p.total_cost_uact),
+        lastRun: lastProbe
+          ? {
+              startedAt: lastProbe.startedAt.toISOString(),
+              completedAt: lastProbe.completedAt?.toISOString() ?? null,
+              status: lastProbe.status,
+              modelsProbed: lastProbe.modelsProbed,
+              bidsCollected: lastProbe.bidsCollected,
+              uniqueProviders: lastProbe.uniqueProviders,
+              costAct: uactToAct(lastProbe.costUact),
+            }
+          : null,
+        gpuModelsTracked,
+        lastPriceRefresh: lastPriceRefreshRow?.refreshedAt.toISOString() ?? null,
+      },
+    }
+
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify(body))
+  } catch (err) {
+    log.error(
+      { err: err instanceof Error ? err.message : err },
+      'Failed to fetch scheduler stats',
+    )
+    res.writeHead(500, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ error: 'Internal server error' }))
+  }
+}

--- a/src/services/providers/gpuBidProbe.test.ts
+++ b/src/services/providers/gpuBidProbe.test.ts
@@ -510,6 +510,25 @@ describe('runGpuBidProbeCycle GpuProbeRun telemetry', () => {
     expect(prisma.gpuProbeRun.update).not.toHaveBeenCalled()
   })
 
+  it('finalises the run record even when the bid read-back throws (no stranded `running` row)', async () => {
+    const prisma = buildPrisma()
+    prisma.computeProvider.findMany.mockResolvedValue([])
+    // The cycle has no models to probe, but the finaliser path still
+    // does a read-back. Force that read to throw — the finally block
+    // MUST still update the run record to `completed`.
+    prisma.gpuBidObservation.findMany.mockRejectedValueOnce(new Error('db hiccup'))
+
+    await runGpuBidProbeCycle(prisma as any)
+
+    expect(prisma.gpuProbeRun.update).toHaveBeenCalledOnce()
+    const updateArg = prisma.gpuProbeRun.update.mock.calls[0][0]
+    expect(updateArg.data.status).toBe('completed')
+    // Read-back failed → counts default to 0 rather than NULL/stranded.
+    expect(updateArg.data.bidsCollected).toBe(0)
+    expect(updateArg.data.uniqueProviders).toBe(0)
+    expect(updateArg.data.completedAt).toBeInstanceOf(Date)
+  })
+
   it('aggregates bids back into the run record when probes succeed', async () => {
     const prisma = buildPrisma()
     prisma.computeProvider.findMany.mockResolvedValue([

--- a/src/services/providers/gpuBidProbe.test.ts
+++ b/src/services/providers/gpuBidProbe.test.ts
@@ -1,0 +1,541 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Stub the env helper so tests don't need a real AKASH_MNEMONIC just to
+// reach the probe code.
+vi.mock('../../lib/akashEnv.js', () => ({
+  getAkashEnv: vi.fn(() => ({
+    AKASH_FROM: 'test-key',
+    AKASH_KEY_NAME: 'test-key',
+    AKASH_NODE: 'https://rpc.test',
+    AKASH_CHAIN_ID: 'akashnet-2',
+  })),
+}))
+
+// We never want a real wallet lock in these tests — passthrough.
+vi.mock('../akash/walletMutex.js', () => ({
+  withWalletLock: <T>(fn: () => Promise<T>) => fn(),
+}))
+
+vi.mock('../akash/orchestrator.js', () => ({
+  DEFAULT_DEPOSIT_UACT: 1_000_000,
+}))
+
+// Stub the wallet-balance helper used by the cycle telemetry path —
+// no real CLI calls in unit tests.
+vi.mock('./providerVerification.js', () => ({
+  checkBalance: vi.fn(async () => ({ uact: 100_000_000, uakt: 0, act: '100' })),
+}))
+
+import {
+  probeOneGpuModel,
+  runGpuBidProbeCycle,
+  rollupGpuPrices,
+  quantiles,
+  MAX_PROBE_BID_UACT,
+  type ExecResult,
+} from './gpuBidProbe.js'
+import { checkBalance } from './providerVerification.js'
+
+// ── Fixtures ───────────────────────────────────────────────────────────
+
+const TX_OK_WITH_DSEQ = JSON.stringify({
+  code: 0,
+  txhash: 'deadbeef',
+  logs: [
+    {
+      events: [
+        {
+          attributes: [
+            { key: 'dseq', value: '424242' },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+const TX_CLOSE_OK = JSON.stringify({ code: 0, txhash: 'closetx' })
+
+const KEYS_SHOW_OUT = 'akash1owner\n'
+
+const BIDS_THREE_OPEN = JSON.stringify({
+  bids: [
+    {
+      bid: {
+        bid_id: { provider: 'akash1providerA' },
+        price: { denom: 'uact', amount: '1000' },
+        state: 'open',
+      },
+    },
+    {
+      bid: {
+        bid_id: { provider: 'akash1providerB' },
+        price: { denom: 'uact', amount: '2000' },
+        state: 'open',
+      },
+    },
+    // Closed bid — must be ignored.
+    {
+      bid: {
+        bid_id: { provider: 'akash1providerC' },
+        price: { denom: 'uact', amount: '500' },
+        state: 'closed',
+      },
+    },
+    // uakt bid — must be ignored (post-BME purity).
+    {
+      bid: {
+        bid_id: { provider: 'akash1providerD' },
+        price: { denom: 'uakt', amount: '50' },
+        state: 'open',
+      },
+    },
+  ],
+})
+
+const BIDS_EMPTY = JSON.stringify({ bids: [] })
+
+function ok(stdout: string): ExecResult {
+  return { stdout, stderr: '', exitCode: 0, durationMs: 1 }
+}
+
+function fail(stderr: string, exitCode = 1): ExecResult {
+  return { stdout: '', stderr, exitCode, durationMs: 1 }
+}
+
+interface FakePrisma {
+  computeProvider: { findMany: ReturnType<typeof vi.fn> }
+  gpuBidObservation: {
+    createMany: ReturnType<typeof vi.fn>
+    findMany: ReturnType<typeof vi.fn>
+  }
+  gpuPriceSummary: {
+    upsert: ReturnType<typeof vi.fn>
+    findMany: ReturnType<typeof vi.fn>
+  }
+  gpuProbeRun: {
+    create: ReturnType<typeof vi.fn>
+    update: ReturnType<typeof vi.fn>
+  }
+}
+
+function buildPrisma(): FakePrisma {
+  return {
+    computeProvider: { findMany: vi.fn().mockResolvedValue([]) },
+    gpuBidObservation: {
+      createMany: vi.fn().mockResolvedValue({ count: 0 }),
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    gpuPriceSummary: {
+      upsert: vi.fn().mockResolvedValue({}),
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    gpuProbeRun: {
+      create: vi.fn().mockResolvedValue({ id: 'run-record-1' }),
+      update: vi.fn().mockResolvedValue({}),
+    },
+  }
+}
+
+// ── probeOneGpuModel ───────────────────────────────────────────────────
+
+// No-op sleep: tests stub out the 30s+ inter-poll waits so they finish
+// in milliseconds, not minutes. The probe code's *behaviour* is what we
+// test — the wall-clock between polls is irrelevant.
+const fastSleep = () => Promise.resolve()
+
+describe('probeOneGpuModel', () => {
+  beforeEach(() => {
+    process.env.AKASH_MNEMONIC = 'test mnemonic'
+  })
+
+  afterEach(() => {
+    delete process.env.AKASH_MNEMONIC
+  })
+
+  it('happy path: posts deployment, records bids, closes in finally', async () => {
+    const execCli = vi.fn(async (_bin: string, args: string[]): Promise<ExecResult> => {
+      if (args[0] === 'keys' && args[1] === 'show') return ok(KEYS_SHOW_OUT)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'create') return ok(TX_OK_WITH_DSEQ)
+      if (args[0] === 'query' && args[1] === 'market' && args[2] === 'bid' && args[3] === 'list') {
+        return ok(BIDS_THREE_OPEN)
+      }
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'close') return ok(TX_CLOSE_OK)
+      return ok('{}')
+    })
+
+    const prisma = buildPrisma()
+    const result = await probeOneGpuModel(prisma as any, 'h100', 'nvidia', 'run-1', { execCli, sleep: fastSleep })
+
+    expect(result.error).toBeUndefined()
+    expect(result.dseq).toBe(424242)
+    expect(result.bidsReceived).toBe(2) // closed + uakt filtered out
+    expect(result.providersBidding).toBe(2)
+    expect(prisma.gpuBidObservation.createMany).toHaveBeenCalledOnce()
+    const inserted = prisma.gpuBidObservation.createMany.mock.calls[0][0].data
+    expect(inserted).toHaveLength(2)
+    const providers = inserted.map((r: any) => r.providerAddr).sort()
+    expect(providers).toEqual(['akash1providerA', 'akash1providerB'])
+
+    // Close was called.
+    const closeCall = execCli.mock.calls.find(
+      c => c[1][0] === 'tx' && c[1][1] === 'deployment' && c[1][2] === 'close'
+    )
+    expect(closeCall).toBeDefined()
+    expect(closeCall![1]).toContain('424242')
+  })
+
+  it('still closes when bid query throws mid-poll (escrow safety)', async () => {
+    let bidCalls = 0
+    const execCli = vi.fn(async (_bin: string, args: string[]): Promise<ExecResult> => {
+      if (args[0] === 'keys' && args[1] === 'show') return ok(KEYS_SHOW_OUT)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'create') return ok(TX_OK_WITH_DSEQ)
+      if (args[0] === 'query' && args[1] === 'market' && args[2] === 'bid' && args[3] === 'list') {
+        bidCalls++
+        if (bidCalls === 1) throw new Error('chain RPC unavailable')
+        return ok(BIDS_EMPTY)
+      }
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'close') return ok(TX_CLOSE_OK)
+      return ok('{}')
+    })
+
+    const prisma = buildPrisma()
+    const result = await probeOneGpuModel(prisma as any, 'h100', 'nvidia', 'run-1', { execCli, sleep: fastSleep })
+
+    // Probe failed but escrow was reclaimed — that's the contract.
+    expect(result.error).toBeDefined()
+    const closeCall = execCli.mock.calls.find(
+      c => c[1][0] === 'tx' && c[1][1] === 'deployment' && c[1][2] === 'close'
+    )
+    expect(closeCall).toBeDefined()
+  })
+
+  it('retries on sequence-mismatch (code 32) up to TX_RETRIES', async () => {
+    const TX_SEQ_MISMATCH = JSON.stringify({ code: 32, raw_log: 'account sequence mismatch' })
+    let createCalls = 0
+    const execCli = vi.fn(async (_bin: string, args: string[]): Promise<ExecResult> => {
+      if (args[0] === 'keys' && args[1] === 'show') return ok(KEYS_SHOW_OUT)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'create') {
+        createCalls++
+        if (createCalls < 3) return ok(TX_SEQ_MISMATCH)
+        return ok(TX_OK_WITH_DSEQ)
+      }
+      if (args[0] === 'query' && args[1] === 'market' && args[2] === 'bid' && args[3] === 'list') {
+        return ok(BIDS_EMPTY)
+      }
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'close') return ok(TX_CLOSE_OK)
+      return ok('{}')
+    })
+
+    const prisma = buildPrisma()
+    const result = await probeOneGpuModel(prisma as any, 'h100', 'nvidia', 'run-1', { execCli, sleep: fastSleep })
+
+    expect(createCalls).toBe(3)
+    expect(result.dseq).toBe(424242)
+  })
+
+  it('returns error when AKASH_MNEMONIC is unset', async () => {
+    delete process.env.AKASH_MNEMONIC
+    const execCli = vi.fn()
+    const result = await probeOneGpuModel(buildPrisma() as any, 'h100', 'nvidia', 'run-1', { execCli, sleep: fastSleep })
+    expect(result.error).toBe('AKASH_MNEMONIC not set')
+    expect(execCli).not.toHaveBeenCalled()
+  })
+
+  it('refuses to splice an unsafe gpu model into the SDL', async () => {
+    const execCli = vi.fn()
+    const result = await probeOneGpuModel(
+      buildPrisma() as any,
+      'h100\nrm -rf /',
+      'nvidia',
+      'run-1',
+      { execCli, sleep: fastSleep }
+    )
+    expect(result.error).toMatch(/Bad probe SDL/)
+    expect(execCli).not.toHaveBeenCalled()
+  })
+
+  it('returns error (no insert) when no bids arrive but still closes', async () => {
+    const execCli = vi.fn(async (_bin: string, args: string[]): Promise<ExecResult> => {
+      if (args[0] === 'keys' && args[1] === 'show') return ok(KEYS_SHOW_OUT)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'create') return ok(TX_OK_WITH_DSEQ)
+      if (args[0] === 'query' && args[1] === 'market' && args[2] === 'bid' && args[3] === 'list') {
+        return ok(BIDS_EMPTY)
+      }
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'close') return ok(TX_CLOSE_OK)
+      return ok('{}')
+    })
+
+    const prisma = buildPrisma()
+    const result = await probeOneGpuModel(prisma as any, 'h100', 'nvidia', 'run-1', { execCli, sleep: fastSleep })
+
+    expect(result.error).toBe('No bids received within timeout')
+    expect(prisma.gpuBidObservation.createMany).not.toHaveBeenCalled()
+    const closeCall = execCli.mock.calls.find(
+      c => c[1][0] === 'tx' && c[1][1] === 'deployment' && c[1][2] === 'close'
+    )
+    expect(closeCall).toBeDefined()
+  })
+
+  it('falls back to query-tx when create logs lack the dseq attribute', async () => {
+    const TX_NO_DSEQ = JSON.stringify({ code: 0, txhash: 'fffffff', logs: [] })
+    const QUERY_TX_WITH_DSEQ = JSON.stringify({
+      logs: [{ events: [{ attributes: [{ key: 'dseq', value: '777' }] }] }],
+    })
+    const execCli = vi.fn(async (_bin: string, args: string[]): Promise<ExecResult> => {
+      if (args[0] === 'keys' && args[1] === 'show') return ok(KEYS_SHOW_OUT)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'create') return ok(TX_NO_DSEQ)
+      if (args[0] === 'query' && args[1] === 'tx') return ok(QUERY_TX_WITH_DSEQ)
+      if (args[0] === 'query' && args[1] === 'market' && args[2] === 'bid' && args[3] === 'list') {
+        return ok(BIDS_EMPTY)
+      }
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'close') return ok(TX_CLOSE_OK)
+      return ok('{}')
+    })
+
+    const prisma = buildPrisma()
+    const result = await probeOneGpuModel(prisma as any, 'h100', 'nvidia', 'run-1', { execCli, sleep: fastSleep })
+
+    expect(result.dseq).toBe(777)
+  })
+
+  it('does not crash when close TX itself fails', async () => {
+    const execCli = vi.fn(async (_bin: string, args: string[]): Promise<ExecResult> => {
+      if (args[0] === 'keys' && args[1] === 'show') return ok(KEYS_SHOW_OUT)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'create') return ok(TX_OK_WITH_DSEQ)
+      if (args[0] === 'query' && args[1] === 'market' && args[2] === 'bid' && args[3] === 'list') {
+        return ok(BIDS_THREE_OPEN)
+      }
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'close') {
+        throw new Error('node down')
+      }
+      return ok('{}')
+    })
+
+    const prisma = buildPrisma()
+    const result = await probeOneGpuModel(prisma as any, 'h100', 'nvidia', 'run-1', { execCli, sleep: fastSleep })
+
+    // Bids were still recorded; only the close best-effort failed (the
+    // chain-orphan sweep in escrowHealthMonitor will reclaim).
+    expect(result.bidsReceived).toBe(2)
+    expect(prisma.gpuBidObservation.createMany).toHaveBeenCalledOnce()
+  })
+})
+
+// ── quantiles ──────────────────────────────────────────────────────────
+
+describe('quantiles', () => {
+  it('returns null on empty input', () => {
+    expect(quantiles([])).toBeNull()
+  })
+
+  it('handles single-element input', () => {
+    const q = quantiles([42n])
+    expect(q).toEqual({ min: 42n, p50: 42n, p90: 42n, max: 42n })
+  })
+
+  it('uses nearest-rank semantics for a 5-sample known case', () => {
+    // sorted: [10, 20, 30, 40, 50]
+    // p50 = ceil(0.5 * 5) - 1 = 2 → 30
+    // p90 = ceil(0.9 * 5) - 1 = 4 → 50
+    const q = quantiles([10n, 20n, 30n, 40n, 50n])
+    expect(q).toEqual({ min: 10n, p50: 30n, p90: 50n, max: 50n })
+  })
+
+  it('separates p50 from max on a 10-sample skewed distribution', () => {
+    // Most providers cheap, one expensive outlier — p50 should NOT be
+    // pulled toward the max.
+    const sorted = [100n, 110n, 120n, 130n, 140n, 150n, 160n, 170n, 180n, 5_000n]
+    const q = quantiles(sorted)
+    expect(q!.min).toBe(100n)
+    // p50: ceil(0.5*10)=5 → idx 4 → 140
+    expect(q!.p50).toBe(140n)
+    // p90: ceil(0.9*10)=9 → idx 8 → 180
+    expect(q!.p90).toBe(180n)
+    expect(q!.max).toBe(5_000n)
+  })
+})
+
+// ── rollupGpuPrices ────────────────────────────────────────────────────
+
+describe('rollupGpuPrices', () => {
+  it('groups by gpuModel, drops bids ≥ MAX_PROBE_BID_UACT, upserts percentiles', async () => {
+    const prisma = buildPrisma()
+
+    prisma.gpuBidObservation.findMany.mockResolvedValue([
+      { gpuModel: 'h100', vendor: 'nvidia', providerAddr: 'a', pricePerBlock: 1_000n },
+      { gpuModel: 'h100', vendor: 'nvidia', providerAddr: 'b', pricePerBlock: 2_000n },
+      { gpuModel: 'h100', vendor: 'nvidia', providerAddr: 'c', pricePerBlock: 3_000n },
+      // ceiling-bidding poison — must be dropped:
+      { gpuModel: 'h100', vendor: 'nvidia', providerAddr: 'evil', pricePerBlock: MAX_PROBE_BID_UACT },
+      { gpuModel: 'h100', vendor: 'nvidia', providerAddr: 'evil2', pricePerBlock: MAX_PROBE_BID_UACT + 1n },
+      // Different model:
+      { gpuModel: 'rtx4090', vendor: 'nvidia', providerAddr: 'a', pricePerBlock: 500n },
+      { gpuModel: 'rtx4090', vendor: 'nvidia', providerAddr: 'b', pricePerBlock: 600n },
+    ])
+
+    const result = await rollupGpuPrices(prisma as any, 7)
+
+    expect(result.modelsUpdated).toBe(2)
+    expect(result.modelsSkipped).toBe(0)
+    expect(prisma.gpuPriceSummary.upsert).toHaveBeenCalledTimes(2)
+
+    const calls = prisma.gpuPriceSummary.upsert.mock.calls.map(c => c[0])
+    const h100 = calls.find(c => c.where.gpuModel === 'h100')!
+    expect(h100.create.minPricePerBlock).toBe(1_000n)
+    expect(h100.create.maxPricePerBlock).toBe(3_000n)
+    expect(h100.create.sampleCount).toBe(3) // poisoned bids dropped
+    expect(h100.create.uniqueProviderCount).toBe(3)
+    expect(h100.create.windowDays).toBe(7)
+
+    const rtx = calls.find(c => c.where.gpuModel === 'rtx4090')!
+    expect(rtx.create.sampleCount).toBe(2)
+    expect(rtx.create.minPricePerBlock).toBe(500n)
+    expect(rtx.create.maxPricePerBlock).toBe(600n)
+  })
+
+  it('counts unique providers correctly when one provider bids multiple times', async () => {
+    const prisma = buildPrisma()
+    prisma.gpuBidObservation.findMany.mockResolvedValue([
+      { gpuModel: 'h100', vendor: 'nvidia', providerAddr: 'a', pricePerBlock: 1_000n },
+      { gpuModel: 'h100', vendor: 'nvidia', providerAddr: 'a', pricePerBlock: 1_100n },
+      { gpuModel: 'h100', vendor: 'nvidia', providerAddr: 'b', pricePerBlock: 2_000n },
+    ])
+
+    await rollupGpuPrices(prisma as any, 7)
+
+    const upsert = prisma.gpuPriceSummary.upsert.mock.calls[0][0]
+    expect(upsert.create.sampleCount).toBe(3)
+    expect(upsert.create.uniqueProviderCount).toBe(2)
+  })
+
+  it('does NOT upsert when a model has only ceiling-bidding poison (no honest bids)', async () => {
+    const prisma = buildPrisma()
+    prisma.gpuBidObservation.findMany.mockResolvedValue([
+      { gpuModel: 'h100', vendor: 'nvidia', providerAddr: 'evil', pricePerBlock: MAX_PROBE_BID_UACT + 100n },
+    ])
+
+    const result = await rollupGpuPrices(prisma as any, 7)
+    expect(result.modelsUpdated).toBe(0)
+    expect(prisma.gpuPriceSummary.upsert).not.toHaveBeenCalled()
+  })
+})
+
+// ── runGpuBidProbeCycle telemetry (GpuProbeRun writes) ───────────────
+
+describe('runGpuBidProbeCycle GpuProbeRun telemetry', () => {
+  beforeEach(() => {
+    process.env.AKASH_MNEMONIC = 'test mnemonic'
+    vi.mocked(checkBalance).mockResolvedValue({
+      uact: 100_000_000,
+      uakt: 0,
+      act: '100',
+    } as any)
+  })
+
+  afterEach(() => {
+    delete process.env.AKASH_MNEMONIC
+    vi.clearAllMocks()
+  })
+
+  it('creates a GpuProbeRun row at start and finalises it with completed status + cost delta', async () => {
+    const prisma = buildPrisma()
+    // No verified providers → models map empty → loop is skipped, but
+    // run record should still be created and finalised cleanly.
+    prisma.computeProvider.findMany.mockResolvedValue([])
+
+    // Spend simulation: $0.05 (50_000 uact) draw-down across the cycle.
+    vi.mocked(checkBalance)
+      .mockResolvedValueOnce({ uact: 100_000_000, uakt: 0, act: '100' } as any)
+      .mockResolvedValueOnce({ uact: 99_950_000, uakt: 0, act: '99.95' } as any)
+
+    const summary = await runGpuBidProbeCycle(prisma as any)
+
+    expect(prisma.gpuProbeRun.create).toHaveBeenCalledOnce()
+    const createArg = prisma.gpuProbeRun.create.mock.calls[0][0]
+    expect(createArg.data.probeRunId).toBe(summary.runId)
+    expect(createArg.data.status).toBe('running')
+
+    expect(prisma.gpuProbeRun.update).toHaveBeenCalledOnce()
+    const updateArg = prisma.gpuProbeRun.update.mock.calls[0][0]
+    expect(updateArg.where.id).toBe('run-record-1')
+    expect(updateArg.data.status).toBe('completed')
+    expect(updateArg.data.modelsProbed).toBe(0)
+    expect(updateArg.data.bidsCollected).toBe(0)
+    expect(updateArg.data.uniqueProviders).toBe(0)
+    // 100_000_000 - 99_950_000 = 50_000 uact
+    expect(updateArg.data.costUact).toBe(50_000n)
+    expect(updateArg.data.error).toBeNull()
+  })
+
+  it('floors negative cost at 0 when wallet was refilled mid-cycle', async () => {
+    const prisma = buildPrisma()
+    prisma.computeProvider.findMany.mockResolvedValue([])
+
+    vi.mocked(checkBalance)
+      .mockResolvedValueOnce({ uact: 50_000_000, uakt: 0, act: '50' } as any)
+      // Refill mid-cycle: post-balance is HIGHER than pre. The floor
+      // prevents us from attributing a negative cost to the cycle.
+      .mockResolvedValueOnce({ uact: 200_000_000, uakt: 0, act: '200' } as any)
+
+    await runGpuBidProbeCycle(prisma as any)
+
+    const updateArg = prisma.gpuProbeRun.update.mock.calls[0][0]
+    expect(updateArg.data.costUact).toBe(0n)
+  })
+
+  it('records cost = 0 when the pre-balance snapshot fails (DB telemetry never blocks the cycle)', async () => {
+    const prisma = buildPrisma()
+    prisma.computeProvider.findMany.mockResolvedValue([])
+
+    vi.mocked(checkBalance).mockRejectedValueOnce(new Error('rpc down'))
+
+    await runGpuBidProbeCycle(prisma as any)
+
+    expect(prisma.gpuProbeRun.update).toHaveBeenCalledOnce()
+    const updateArg = prisma.gpuProbeRun.update.mock.calls[0][0]
+    expect(updateArg.data.costUact).toBe(0n)
+    expect(updateArg.data.status).toBe('completed')
+  })
+
+  it('does not throw the cycle when the run-record create itself fails', async () => {
+    const prisma = buildPrisma()
+    prisma.computeProvider.findMany.mockResolvedValue([])
+    prisma.gpuProbeRun.create.mockRejectedValueOnce(new Error('chain_stats migration not run'))
+
+    const summary = await runGpuBidProbeCycle(prisma as any)
+
+    expect(summary.modelsProbed).toBe(0)
+    // No update either, since we never got a runRecordId.
+    expect(prisma.gpuProbeRun.update).not.toHaveBeenCalled()
+  })
+
+  it('aggregates bids back into the run record when probes succeed', async () => {
+    const prisma = buildPrisma()
+    prisma.computeProvider.findMany.mockResolvedValue([
+      { gpuModels: ['h100'] },
+    ])
+    // Pretend two providers bid during this run (read-back after probe).
+    prisma.gpuBidObservation.findMany.mockResolvedValue([
+      { providerAddr: 'akash1A' },
+      { providerAddr: 'akash1B' },
+      { providerAddr: 'akash1A' }, // duplicate provider — must be deduped
+    ])
+
+    // No real probes — just mock execCli to fail fast so the loop runs
+    // but we don't need to model the full happy path here.
+    const summary = await runGpuBidProbeCycle(prisma as any, {
+      execCli: vi.fn(async () => ({ stdout: '', stderr: 'fail', exitCode: 1, durationMs: 1 })),
+      sleep: () => Promise.resolve(),
+    })
+
+    expect(summary.modelsProbed).toBe(1)
+    expect(summary.totalBids).toBe(3)
+    expect(summary.uniqueProviders).toBe(2)
+
+    const updateArg = prisma.gpuProbeRun.update.mock.calls[0][0]
+    expect(updateArg.data.bidsCollected).toBe(3)
+    expect(updateArg.data.uniqueProviders).toBe(2)
+    expect(updateArg.data.modelsProbed).toBe(1)
+  })
+})

--- a/src/services/providers/gpuBidProbe.ts
+++ b/src/services/providers/gpuBidProbe.ts
@@ -469,92 +469,108 @@ export async function runGpuBidProbeCycle(
   const results: ProbeOneResult[] = []
   const seenProviders = new Set<string>()
   let cycleError: string | undefined
-
-  try {
-    // Materialise the entries once — re-iterating a Map mid-loop and computing
-    // .keys().at(-1) on every step is O(n²) for no benefit.
-    const entries = Array.from(models.entries())
-    for (let i = 0; i < entries.length; i++) {
-      const [model, vendor] = entries[i]
-      const r = await probeOneGpuModel(prisma, model, vendor, runId, deps)
-      results.push(r)
-      // Inter-probe wait so back-to-back tx don't race the wallet sequence.
-      if (i < entries.length - 1) {
-        await sleep(INTER_PROBE_DELAY_MS)
-      }
-    }
-
-    // After all probes, refresh the rollup.
-    try {
-      await rollupGpuPrices(prisma)
-    } catch (err) {
-      log.error(
-        { runId, err: err instanceof Error ? err.message : err },
-        'rollupGpuPrices failed — gpu_price_summary may be stale'
-      )
-    }
-  } catch (err) {
-    cycleError = err instanceof Error ? err.message : String(err)
-    log.error({ runId, err: cycleError }, 'Probe cycle threw mid-loop')
-  }
-
-  // Compute summary stats from the rows we just inserted (read-back
-  // avoids double-counting if probeOne short-circuited).
-  const fresh = await prisma.gpuBidObservation.findMany({
-    where: { probeRunId: runId },
-    select: { providerAddr: true },
-  })
-  for (const row of fresh) seenProviders.add(row.providerAddr)
-
-  // Snapshot wallet after the cycle and compute spend. Floor at 0 — a
-  // wallet refill mid-cycle would otherwise produce a negative cost.
+  // Cost is captured outside try/finally so the finaliser can write
+  // the partial-cycle spend even if rollup or the bid read-back throws.
   let costUact = BigInt(0)
   let costUakt = BigInt(0)
-  if (balanceBefore) {
+  let totalBids = 0
+
+  try {
     try {
-      const balanceAfter = await checkBalance()
-      costUact = BigInt(Math.max(0, balanceBefore.uact - balanceAfter.uact))
-      costUakt = BigInt(Math.max(0, balanceBefore.uakt - balanceAfter.uakt))
+      // Materialise the entries once — re-iterating a Map mid-loop and computing
+      // .keys().at(-1) on every step is O(n²) for no benefit.
+      const entries = Array.from(models.entries())
+      for (let i = 0; i < entries.length; i++) {
+        const [model, vendor] = entries[i]
+        const r = await probeOneGpuModel(prisma, model, vendor, runId, deps)
+        results.push(r)
+        // Inter-probe wait so back-to-back tx don't race the wallet sequence.
+        if (i < entries.length - 1) {
+          await sleep(INTER_PROBE_DELAY_MS)
+        }
+      }
+
+      // After all probes, refresh the rollup.
+      try {
+        await rollupGpuPrices(prisma)
+      } catch (err) {
+        log.error(
+          { runId, err: err instanceof Error ? err.message : err },
+          'rollupGpuPrices failed — gpu_price_summary may be stale'
+        )
+      }
+    } catch (err) {
+      cycleError = err instanceof Error ? err.message : String(err)
+      log.error({ runId, err: cycleError }, 'Probe cycle threw mid-loop')
+    }
+
+    // Compute summary stats from the rows we just inserted (read-back
+    // avoids double-counting if probeOne short-circuited).
+    try {
+      const fresh = await prisma.gpuBidObservation.findMany({
+        where: { probeRunId: runId },
+        select: { providerAddr: true },
+      })
+      for (const row of fresh) seenProviders.add(row.providerAddr)
+      totalBids = fresh.length
     } catch (err) {
       log.warn(
         { runId, err: err instanceof Error ? err.message : err },
-        'Post-cycle balance snapshot failed — recording cost = 0'
+        'bid read-back failed — bidsCollected/uniqueProviders will be 0',
       )
+    }
+
+    // Snapshot wallet after the cycle and compute spend. Floor at 0 — a
+    // wallet refill mid-cycle would otherwise produce a negative cost.
+    if (balanceBefore) {
+      try {
+        const balanceAfter = await checkBalance()
+        costUact = BigInt(Math.max(0, balanceBefore.uact - balanceAfter.uact))
+        costUakt = BigInt(Math.max(0, balanceBefore.uakt - balanceAfter.uakt))
+      } catch (err) {
+        log.warn(
+          { runId, err: err instanceof Error ? err.message : err },
+          'Post-cycle balance snapshot failed — recording cost = 0'
+        )
+      }
+    }
+  } finally {
+    // Finalise the run record. ALWAYS runs — even if read-back or
+    // balance snapshot threw — so the dashboard never sees a stranded
+    // `running` row from an in-process failure. Out-of-process kills
+    // are still cleaned up by markStaleProbeRuns at the next scheduler
+    // startup.
+    if (runRecordId) {
+      try {
+        await prisma.gpuProbeRun.update({
+          where: { id: runRecordId },
+          data: {
+            completedAt: new Date(),
+            modelsProbed: results.length,
+            bidsCollected: totalBids,
+            uniqueProviders: seenProviders.size,
+            costUact,
+            costUakt,
+            status: cycleError ? 'failed' : 'completed',
+            error: cycleError ? cycleError.slice(0, 1000) : null,
+          },
+        })
+      } catch (err) {
+        log.warn(
+          { runId, err: err instanceof Error ? err.message : err },
+          'Could not finalise GpuProbeRun record — startup recovery will sweep it'
+        )
+      }
     }
   }
 
   const summary: ProbeCycleSummary = {
     runId,
     modelsProbed: results.length,
-    totalBids: fresh.length,
+    totalBids,
     uniqueProviders: seenProviders.size,
     durationMs: Date.now() - start,
     results,
-  }
-
-  // Finalise the run record. Best-effort — a DB failure here must not
-  // mask a successful (or failed) cycle in the logs/return value.
-  if (runRecordId) {
-    try {
-      await prisma.gpuProbeRun.update({
-        where: { id: runRecordId },
-        data: {
-          completedAt: new Date(),
-          modelsProbed: summary.modelsProbed,
-          bidsCollected: summary.totalBids,
-          uniqueProviders: summary.uniqueProviders,
-          costUact,
-          costUakt,
-          status: cycleError ? 'failed' : 'completed',
-          error: cycleError ? cycleError.slice(0, 1000) : null,
-        },
-      })
-    } catch (err) {
-      log.warn(
-        { runId, err: err instanceof Error ? err.message : err },
-        'Could not finalise GpuProbeRun record'
-      )
-    }
   }
 
   log.info({ ...summary, costUact: costUact.toString() }, 'GPU bid probe cycle complete')

--- a/src/services/providers/gpuBidProbe.ts
+++ b/src/services/providers/gpuBidProbe.ts
@@ -1,0 +1,687 @@
+/**
+ * GPU bid-probe runner + rollup.
+ *
+ * Posts a tiny SDL targeting one GPU model, collects every open bid that
+ * comes back over a 60-90s window, persists the bids to
+ * `gpu_bid_observation`, then closes the deployment without leasing.
+ * Repeats for every GPU model the registry knows about, then rolls the
+ * recent observations into `gpu_price_summary` percentiles for the UI.
+ *
+ * Design:
+ *   - Mirrors the `tx deployment create` → `query market bid list` →
+ *     `tx deployment close` flow from `providerVerification.ts`, minus
+ *     lease/manifest/lease-status (we never serve the workload).
+ *   - All TX calls go through `withWalletLock` so we never race the
+ *     billing cron / escrow monitor / user-initiated deploys.
+ *   - `execCli` is injectable so tests can stub the chain entirely.
+ *   - Probe close lives in `finally` so a thrown bid-poll never leaks
+ *     escrow. The chain-orphan sweep in `escrowHealthMonitor` is the
+ *     final safety net if even the close fails.
+ *
+ * Cost: ~$0.0015/probe × ~15 GPU models × 4 runs/day ≈ $0.09/day.
+ * MIN_ACT_BALANCE_UACT keeps us safely above probe spend.
+ */
+
+import { execFile } from 'child_process'
+import { randomUUID } from 'crypto'
+import { writeFileSync, rmSync, mkdtempSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type { PrismaClient } from '@prisma/client'
+import { getAkashEnv as getAkashEnvBase } from '../../lib/akashEnv.js'
+import { withWalletLock } from '../akash/walletMutex.js'
+import { DEFAULT_DEPOSIT_UACT } from '../akash/orchestrator.js'
+import { createLogger } from '../../lib/logger.js'
+import { buildProbeSdl, PROBE_PRICING_CEILING_UACT, type GpuVendor } from './probeBidSdl.js'
+import { checkBalance, type WalletBalance } from './providerVerification.js'
+
+const log = createLogger('gpu-bid-probe')
+
+// ── Constants ──────────────────────────────────────────────────────────
+
+const CLI_TIMEOUT_MS = 120_000
+const TX_RETRIES = 3
+const TX_SEQ_RETRY_DELAY_MS = 8_000
+const BID_POLL_MAX = 9
+const BID_POLL_DELAY_MS = 10_000
+const BID_INITIAL_WAIT_MS = 30_000
+/**
+ * Inter-probe wait — gives the chain time to settle the previous probe's
+ * close TX before the next one queries account sequence. Same rationale
+ * as `INTER_TEMPLATE_DELAY_MS` in `providerVerification.ts`.
+ */
+const INTER_PROBE_DELAY_MS = 8_000
+
+/**
+ * Hard rollup ceiling. Any observation at-or-above this price is dropped
+ * before percentiles are computed — protects against a malicious
+ * provider bidding the SDL ceiling itself to skew our reported max.
+ * 50_000 uact/block ≈ $18/hr — far above any honest GPU price as of
+ * 2026-04.
+ */
+export const MAX_PROBE_BID_UACT = 50_000n
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+export interface ExecResult {
+  stdout: string
+  stderr: string
+  exitCode: number
+  durationMs: number
+}
+
+export type ExecCli = (
+  bin: string,
+  args: string[],
+  timeoutMs?: number,
+) => Promise<ExecResult>
+
+export interface ProbeRunnerDeps {
+  /** Override the CLI shell-out (used by tests). */
+  execCli?: ExecCli
+  /** Override `withWalletLock` for tests that don't need real serialization. */
+  withWalletLock?: <T>(fn: () => Promise<T>) => Promise<T>
+  /** Override `sleep` so tests don't actually wait 30+ seconds. */
+  sleep?: (ms: number) => Promise<void>
+}
+
+export interface ProbeOneResult {
+  gpuModel: string
+  vendor: GpuVendor
+  dseq?: number
+  owner?: string
+  bidsReceived: number
+  providersBidding: number
+  durationMs: number
+  error?: string
+}
+
+export interface ProbeCycleSummary {
+  runId: string
+  modelsProbed: number
+  totalBids: number
+  uniqueProviders: number
+  durationMs: number
+  results: ProbeOneResult[]
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function getAkashEnv() {
+  // Use sync broadcast (default). The probe is non-critical — we don't
+  // need block-mode confirmation; the bid-poll loop establishes whether
+  // the deployment is live on-chain.
+  return getAkashEnvBase()
+}
+
+const defaultExecCli: ExecCli = (bin, args, timeoutMs = CLI_TIMEOUT_MS) => {
+  const env = getAkashEnv()
+  const start = Date.now()
+  return new Promise(res => {
+    execFile(
+      bin,
+      args,
+      { encoding: 'utf-8', env, timeout: timeoutMs, maxBuffer: 10 * 1024 * 1024 },
+      (err, stdout, stderr) => {
+        const durationMs = Date.now() - start
+        const exitCode = err ? ((err as NodeJS.ErrnoException).code as unknown as number) ?? 1 : 0
+        res({ stdout: stdout ?? '', stderr: stderr ?? '', exitCode, durationMs })
+      }
+    )
+  })
+}
+
+function extractJson(raw: string): unknown {
+  const trimmed = raw.trim()
+  try { return JSON.parse(trimmed) } catch { /* continue */ }
+  const objIdx = trimmed.indexOf('{')
+  const arrIdx = trimmed.indexOf('[')
+  const startIdx = objIdx === -1 ? arrIdx : arrIdx === -1 ? objIdx : Math.min(objIdx, arrIdx)
+  if (startIdx === -1) throw new SyntaxError(`No JSON in output: ${trimmed.slice(0, 200)}`)
+  return JSON.parse(trimmed.slice(startIdx))
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise(r => setTimeout(r, ms))
+}
+
+function vendorFor(model: string): GpuVendor {
+  // Mirrors web-app/.../akash-gpu-availability/route.ts so the same
+  // (lowercase model → vendor) mapping is used everywhere.
+  const lower = model.toLowerCase()
+  if (lower.startsWith('rx') || lower.startsWith('mi')) return 'amd'
+  return 'nvidia'
+}
+
+function extractDseqFromTxJson(txJson: any): number | undefined {
+  const logs = txJson?.logs as any[] | undefined
+  if (logs) {
+    for (const l of logs) {
+      for (const event of l.events || []) {
+        const attr = event.attributes?.find((a: any) => a.key === 'dseq')
+        if (attr) {
+          const dseq = parseInt(attr.value, 10)
+          if (!Number.isNaN(dseq) && dseq > 0) return dseq
+        }
+      }
+    }
+  }
+  return undefined
+}
+
+// ── Single-model probe ─────────────────────────────────────────────────
+
+/**
+ * Probe one GPU model: submit deployment → poll bids → close (in finally).
+ * Persists every received bid to `gpu_bid_observation` keyed by `runId`.
+ *
+ * Returns a result describing the outcome. Never throws on chain errors —
+ * those are folded into `result.error` so the cycle can keep probing the
+ * remaining models.
+ */
+export async function probeOneGpuModel(
+  prisma: PrismaClient,
+  model: string,
+  vendor: GpuVendor,
+  runId: string,
+  deps: ProbeRunnerDeps = {},
+): Promise<ProbeOneResult> {
+  const execCli = deps.execCli ?? defaultExecCli
+  const lock = deps.withWalletLock ?? withWalletLock
+  const sleep = deps.sleep ?? defaultSleep
+
+  const start = Date.now()
+  const result: ProbeOneResult = {
+    gpuModel: model,
+    vendor,
+    bidsReceived: 0,
+    providersBidding: 0,
+    durationMs: 0,
+  }
+
+  if (!process.env.AKASH_MNEMONIC) {
+    result.error = 'AKASH_MNEMONIC not set'
+    result.durationMs = Date.now() - start
+    return result
+  }
+
+  let sdl: string
+  try {
+    sdl = buildProbeSdl(model, vendor)
+  } catch (err) {
+    result.error = `Bad probe SDL: ${err instanceof Error ? err.message : String(err)}`
+    result.durationMs = Date.now() - start
+    return result
+  }
+
+  const workDir = mkdtempSync(join(tmpdir(), 'af-gpu-probe-'))
+  const sdlPath = join(workDir, 'probe.yaml')
+  writeFileSync(sdlPath, sdl)
+
+  let dseq: number | undefined
+
+  try {
+    // Resolve wallet address (needed for `query market bid list --owner`).
+    const addrRes = await execCli(
+      'akash',
+      ['keys', 'show', process.env.AKASH_KEY_NAME || 'default', '-a'],
+      15_000,
+    )
+    if (addrRes.exitCode !== 0) {
+      result.error = `Cannot get wallet address: ${addrRes.stderr.trim().slice(0, 200)}`
+      return result
+    }
+    const owner = addrRes.stdout.trim()
+    result.owner = owner
+
+    // Submit deployment-create with sequence-mismatch retry. Same shape
+    // as providerVerification.ts so behaviour matches.
+    let txJson: any = {}
+    let txAccepted = false
+    for (let attempt = 1; attempt <= TX_RETRIES; attempt++) {
+      const txRes = await lock(() =>
+        execCli('akash', [
+          'tx', 'deployment', 'create', sdlPath,
+          '--deposit', `${DEFAULT_DEPOSIT_UACT}uact`,
+          '-o', 'json', '-y',
+        ])
+      )
+      if (txRes.exitCode !== 0) {
+        result.error = `tx create failed: ${txRes.stderr.trim().slice(0, 200)}`
+        return result
+      }
+      try { txJson = extractJson(txRes.stdout) as any } catch { txJson = {} }
+      const code =
+        typeof txJson.code === 'number'
+          ? txJson.code
+          : parseInt(txJson.code ?? '0', 10)
+      if (code === 32 && attempt < TX_RETRIES) {
+        await sleep(TX_SEQ_RETRY_DELAY_MS)
+        continue
+      }
+      if (code !== 0) {
+        result.error = `tx rejected (code ${code}): ${(txJson.raw_log || '').slice(0, 200)}`
+        return result
+      }
+      txAccepted = true
+      break
+    }
+    if (!txAccepted) {
+      result.error = 'tx not accepted after retries'
+      return result
+    }
+
+    dseq = extractDseqFromTxJson(txJson)
+
+    // Fallback: query the txhash if logs didn't carry the dseq attribute
+    // (sync broadcast can return before logs are populated).
+    if (!dseq && txJson.txhash) {
+      for (const delay of [6000, 6000, 8000]) {
+        await sleep(delay)
+        const qr = await execCli('akash', ['query', 'tx', txJson.txhash, '-o', 'json'], 60_000)
+        if (qr.exitCode !== 0) continue
+        try {
+          const qj = extractJson(qr.stdout) as any
+          dseq = extractDseqFromTxJson(qj)
+          if (!dseq) {
+            const msgDseq = qj?.tx?.body?.messages?.[0]?.id?.dseq
+            if (msgDseq) {
+              const parsed = parseInt(String(msgDseq), 10)
+              if (!Number.isNaN(parsed) && parsed > 0) dseq = parsed
+            }
+          }
+          if (dseq) break
+        } catch { /* retry */ }
+      }
+    }
+
+    if (!dseq) {
+      result.error = 'Could not extract dseq from tx'
+      return result
+    }
+
+    result.dseq = dseq
+    log.info({ dseq, model, vendor, runId }, 'Probe deployment created')
+
+    // Poll for bids. We collect every distinct provider bid we see — one
+    // bid per provider per dseq is the chain semantic, so dedupe by
+    // provider address.
+    const bidsByProvider = new Map<string, { amount: bigint; denom: string }>()
+
+    await sleep(BID_INITIAL_WAIT_MS)
+    for (let attempt = 1; attempt <= BID_POLL_MAX; attempt++) {
+      const bidRes = await execCli('akash', [
+        'query', 'market', 'bid', 'list',
+        '--owner', owner,
+        '--dseq', String(dseq),
+        '-o', 'json',
+      ])
+      if (bidRes.exitCode === 0) {
+        try {
+          const bidJson = extractJson(bidRes.stdout) as any
+          const rawBids = bidJson.bids || []
+          for (const b of rawBids) {
+            const bid = b.bid || b
+            const id = bid.bid_id || bid.id || {}
+            const price = bid.price || {}
+            const provider = String(id.provider || '')
+            const state = bid.state
+            if (!provider || state !== 'open') continue
+            const denom = String(price.denom || 'uact')
+            // Skip uakt bids — post-BME the chain only mints uact for
+            // new leases; any uakt bid here is a misconfigured provider
+            // and would corrupt the percentile if mixed with uact.
+            if (denom !== 'uact') continue
+            let amount: bigint
+            try { amount = BigInt(price.amount ?? '0') } catch { continue }
+            if (amount <= 0n) continue
+            // Keep the lowest bid per provider — providers occasionally
+            // re-bid; we want the most generous offer they made.
+            const prev = bidsByProvider.get(provider)
+            if (!prev || amount < prev.amount) {
+              bidsByProvider.set(provider, { amount, denom })
+            }
+          }
+        } catch { /* parse error → next poll */ }
+      }
+      if (bidsByProvider.size > 0 && attempt >= 3) break
+      if (attempt < BID_POLL_MAX) await sleep(BID_POLL_DELAY_MS)
+    }
+
+    if (bidsByProvider.size === 0) {
+      result.error = 'No bids received within timeout'
+      // not a thrown failure — every probe still records its outcome
+    } else {
+      // Persist. Use createMany — duplicates can't happen because runId
+      // is unique-per-cycle and we dedupe per provider above.
+      await prisma.gpuBidObservation.createMany({
+        data: Array.from(bidsByProvider.entries()).map(([providerAddr, b]) => ({
+          probeRunId: runId,
+          gpuModel: model,
+          vendor,
+          providerAddr,
+          pricePerBlock: b.amount,
+          dseq: BigInt(dseq!),
+        })),
+      })
+      result.bidsReceived = bidsByProvider.size
+      result.providersBidding = bidsByProvider.size
+      log.info(
+        { dseq, model, runId, bids: bidsByProvider.size },
+        'Probe bids recorded',
+      )
+    }
+  } catch (err) {
+    result.error = err instanceof Error ? err.message : String(err)
+  } finally {
+    if (dseq) {
+      try {
+        await lock(() =>
+          execCli('akash', [
+            'tx', 'deployment', 'close',
+            '--dseq', String(dseq),
+            '-o', 'json', '-y',
+          ])
+        )
+        log.info({ dseq, model }, 'Probe deployment closed')
+      } catch (closeErr) {
+        // Best-effort. The chain-orphan sweep in escrowHealthMonitor
+        // catches any deployment that survives this close failure.
+        log.warn(
+          { dseq, model, err: closeErr instanceof Error ? closeErr.message : closeErr },
+          'Probe close failed — orphan sweep will reclaim it'
+        )
+      }
+    }
+    try { rmSync(workDir, { recursive: true }) } catch { /* ignore */ }
+    result.durationMs = Date.now() - start
+  }
+
+  return result
+}
+
+// ── Full cycle (all models) ────────────────────────────────────────────
+
+export async function runGpuBidProbeCycle(
+  prisma: PrismaClient,
+  deps: ProbeRunnerDeps = {},
+): Promise<ProbeCycleSummary> {
+  const runId = randomUUID()
+  const start = Date.now()
+  const sleep = deps.sleep ?? defaultSleep
+
+  // Snapshot wallet before we start so we can attribute the cycle's
+  // on-chain spend (gas, deposits not refunded) to this GpuProbeRun row.
+  // Failure here is non-fatal — we still want the cycle to run, we just
+  // record cost = 0 for it.
+  let balanceBefore: WalletBalance | null = null
+  try { balanceBefore = await checkBalance() } catch { /* non-fatal */ }
+
+  // Track the run so the admin dashboard can answer "how many cycles
+  // ran, what did they cost, what came out of them" without having to
+  // re-derive run counts from `gpu_bid_observation`. Best-effort: a DB
+  // outage here must not stop the actual probe cycle.
+  let runRecordId: string | null = null
+  try {
+    const created = await prisma.gpuProbeRun.create({
+      data: {
+        probeRunId: runId,
+        startedAt: new Date(start),
+        status: 'running',
+      },
+      select: { id: true },
+    })
+    runRecordId = created.id
+  } catch (err) {
+    log.warn(
+      { runId, err: err instanceof Error ? err.message : err },
+      'Could not create GpuProbeRun record — continuing without admin telemetry'
+    )
+  }
+
+  // Source of truth for "what GPUs do we know exist on Akash?" is the
+  // ProviderRegistryScheduler's hourly scan into `compute_provider`.
+  // We probe every distinct model offered by a verified provider with
+  // GPU capacity right now — no point probing a GPU nobody serves.
+  const providers = await prisma.computeProvider.findMany({
+    where: {
+      providerType: 'AKASH',
+      verified: true,
+      gpuTotal: { gt: 0 },
+    },
+    select: { gpuModels: true },
+  })
+
+  const models = new Map<string, GpuVendor>()
+  for (const p of providers) {
+    for (const raw of p.gpuModels) {
+      const m = raw.toLowerCase().trim()
+      if (!m) continue
+      if (!models.has(m)) models.set(m, vendorFor(m))
+    }
+  }
+
+  log.info(
+    { runId, modelCount: models.size, providerCount: providers.length },
+    'Starting GPU bid probe cycle'
+  )
+
+  const results: ProbeOneResult[] = []
+  const seenProviders = new Set<string>()
+  let cycleError: string | undefined
+
+  try {
+    // Materialise the entries once — re-iterating a Map mid-loop and computing
+    // .keys().at(-1) on every step is O(n²) for no benefit.
+    const entries = Array.from(models.entries())
+    for (let i = 0; i < entries.length; i++) {
+      const [model, vendor] = entries[i]
+      const r = await probeOneGpuModel(prisma, model, vendor, runId, deps)
+      results.push(r)
+      // Inter-probe wait so back-to-back tx don't race the wallet sequence.
+      if (i < entries.length - 1) {
+        await sleep(INTER_PROBE_DELAY_MS)
+      }
+    }
+
+    // After all probes, refresh the rollup.
+    try {
+      await rollupGpuPrices(prisma)
+    } catch (err) {
+      log.error(
+        { runId, err: err instanceof Error ? err.message : err },
+        'rollupGpuPrices failed — gpu_price_summary may be stale'
+      )
+    }
+  } catch (err) {
+    cycleError = err instanceof Error ? err.message : String(err)
+    log.error({ runId, err: cycleError }, 'Probe cycle threw mid-loop')
+  }
+
+  // Compute summary stats from the rows we just inserted (read-back
+  // avoids double-counting if probeOne short-circuited).
+  const fresh = await prisma.gpuBidObservation.findMany({
+    where: { probeRunId: runId },
+    select: { providerAddr: true },
+  })
+  for (const row of fresh) seenProviders.add(row.providerAddr)
+
+  // Snapshot wallet after the cycle and compute spend. Floor at 0 — a
+  // wallet refill mid-cycle would otherwise produce a negative cost.
+  let costUact = BigInt(0)
+  let costUakt = BigInt(0)
+  if (balanceBefore) {
+    try {
+      const balanceAfter = await checkBalance()
+      costUact = BigInt(Math.max(0, balanceBefore.uact - balanceAfter.uact))
+      costUakt = BigInt(Math.max(0, balanceBefore.uakt - balanceAfter.uakt))
+    } catch (err) {
+      log.warn(
+        { runId, err: err instanceof Error ? err.message : err },
+        'Post-cycle balance snapshot failed — recording cost = 0'
+      )
+    }
+  }
+
+  const summary: ProbeCycleSummary = {
+    runId,
+    modelsProbed: results.length,
+    totalBids: fresh.length,
+    uniqueProviders: seenProviders.size,
+    durationMs: Date.now() - start,
+    results,
+  }
+
+  // Finalise the run record. Best-effort — a DB failure here must not
+  // mask a successful (or failed) cycle in the logs/return value.
+  if (runRecordId) {
+    try {
+      await prisma.gpuProbeRun.update({
+        where: { id: runRecordId },
+        data: {
+          completedAt: new Date(),
+          modelsProbed: summary.modelsProbed,
+          bidsCollected: summary.totalBids,
+          uniqueProviders: summary.uniqueProviders,
+          costUact,
+          costUakt,
+          status: cycleError ? 'failed' : 'completed',
+          error: cycleError ? cycleError.slice(0, 1000) : null,
+        },
+      })
+    } catch (err) {
+      log.warn(
+        { runId, err: err instanceof Error ? err.message : err },
+        'Could not finalise GpuProbeRun record'
+      )
+    }
+  }
+
+  log.info({ ...summary, costUact: costUact.toString() }, 'GPU bid probe cycle complete')
+  if (cycleError) {
+    // Surface the partial-cycle error to the scheduler so it can fire
+    // gpu-probe-failed without losing the bids that DID land.
+    throw new Error(cycleError)
+  }
+  return summary
+}
+
+// ── Rollup ─────────────────────────────────────────────────────────────
+
+/**
+ * Compute min / p50 / p90 / max from a sorted bigint array. Caller must
+ * pre-sort ascending. Returns null on an empty input.
+ *
+ * Linear interpolation is intentionally NOT used — at the sample sizes
+ * we'll have (10s-100s per model per week), nearest-rank percentiles
+ * are easier to reason about and good enough for a UI display value.
+ */
+export function quantiles(sorted: bigint[]): {
+  min: bigint
+  p50: bigint
+  p90: bigint
+  max: bigint
+} | null {
+  if (sorted.length === 0) return null
+  const n = sorted.length
+  const idx = (q: number) => {
+    // nearest-rank percentile, 1-indexed: ceil(q × n) − 1 in 0-indexed terms,
+    // clamped into bounds.
+    const rank = Math.max(1, Math.ceil(q * n))
+    return Math.min(n, rank) - 1
+  }
+  return {
+    min: sorted[0],
+    p50: sorted[idx(0.5)],
+    p90: sorted[idx(0.9)],
+    max: sorted[n - 1],
+  }
+}
+
+/**
+ * Recompute `gpu_price_summary` from the last `windowDays` of
+ * `gpu_bid_observation`. Drops bids ≥ MAX_PROBE_BID_UACT before
+ * percentile calc (defensive against ceiling-bidding attacks).
+ *
+ * Idempotent — safe to run any time. Models that have zero in-window
+ * observations are NOT deleted; the previous summary row stays so the
+ * UI keeps showing the last-known price during a transient outage.
+ */
+export async function rollupGpuPrices(
+  prisma: PrismaClient,
+  windowDays = 7,
+): Promise<{ modelsUpdated: number; modelsSkipped: number }> {
+  const since = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000)
+
+  const rows = await prisma.gpuBidObservation.findMany({
+    where: { observedAt: { gte: since } },
+    select: {
+      gpuModel: true,
+      vendor: true,
+      providerAddr: true,
+      pricePerBlock: true,
+    },
+  })
+
+  // Group by model.
+  type Group = { vendor: string; values: bigint[]; providers: Set<string> }
+  const byModel = new Map<string, Group>()
+  for (const r of rows) {
+    if (r.pricePerBlock >= MAX_PROBE_BID_UACT) continue
+    const g = byModel.get(r.gpuModel) ?? {
+      vendor: r.vendor,
+      values: [] as bigint[],
+      providers: new Set<string>(),
+    }
+    g.values.push(r.pricePerBlock)
+    g.providers.add(r.providerAddr)
+    byModel.set(r.gpuModel, g)
+  }
+
+  const refreshedAt = new Date()
+  let updated = 0
+  let skipped = 0
+
+  for (const [gpuModel, group] of byModel) {
+    group.values.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+    const q = quantiles(group.values)
+    if (!q) {
+      skipped++
+      continue
+    }
+    await prisma.gpuPriceSummary.upsert({
+      where: { gpuModel },
+      create: {
+        gpuModel,
+        vendor: group.vendor,
+        minPricePerBlock: q.min,
+        p50PricePerBlock: q.p50,
+        p90PricePerBlock: q.p90,
+        maxPricePerBlock: q.max,
+        sampleCount: group.values.length,
+        uniqueProviderCount: group.providers.size,
+        windowDays,
+        refreshedAt,
+      },
+      update: {
+        vendor: group.vendor,
+        minPricePerBlock: q.min,
+        p50PricePerBlock: q.p50,
+        p90PricePerBlock: q.p90,
+        maxPricePerBlock: q.max,
+        sampleCount: group.values.length,
+        uniqueProviderCount: group.providers.size,
+        windowDays,
+        refreshedAt,
+      },
+    })
+    updated++
+  }
+
+  log.info({ windowDays, modelsUpdated: updated, modelsSkipped: skipped }, 'Rollup complete')
+  return { modelsUpdated: updated, modelsSkipped: skipped }
+}
+
+// Re-export the SDL ceiling so scheduler / docs consumers don't have to
+// reach into the SDL module to size pre-flight balance checks.
+export { PROBE_PRICING_CEILING_UACT }

--- a/src/services/providers/gpuBidProbeScheduler.ts
+++ b/src/services/providers/gpuBidProbeScheduler.ts
@@ -1,0 +1,155 @@
+/**
+ * GPU Bid Probe Scheduler
+ *
+ * Every 6h, posts a tiny probe deployment per GPU model the registry
+ * knows about, captures the bids that come back, then rolls them up
+ * into `gpu_price_summary`. The web-app reads `gpu_price_summary` via
+ * the internal pricing endpoint and renders per-GPU min/p50/p90/max
+ * instead of the broken per-provider min/max attribution it used to
+ * show.
+ *
+ * Cadence rationale:
+ *   - 6h × 4 runs/day × ~15 models × ~$0.0015/probe ≈ $0.09/day. Cheap.
+ *   - GPU bid prices don't move in minutes — providers re-price at most
+ *     every few hours, often daily. 6h captures real movement without
+ *     paying for sub-hourly noise.
+ *   - 04:00 UTC is owned by ProviderVerificationScheduler (Mon/Wed/Fri).
+ *     We use the offset slots `01:00, 07:00, 13:00, 19:00` so the wallet
+ *     mutex never has to choose between us and the verifier.
+ *
+ * Guards:
+ *   - Overlap: skip if a previous run is still in progress
+ *   - Balance: skip if uact < MIN_ACT_BALANCE_UACT (verification scheduler
+ *     uses the same 5_000_000 floor)
+ *   - Environment: skip if AKASH_MNEMONIC is not set (non-Akash deploys)
+ *
+ * Wrapped in `runWithLeadership('gpu-bid-probe-scheduler', …)` in
+ * `index.ts` so multi-replica deploys only probe from one pod.
+ */
+
+import * as cron from 'node-cron'
+import type { PrismaClient } from '@prisma/client'
+import { createLogger } from '../../lib/logger.js'
+import { opsAlert } from '../../lib/opsAlert.js'
+import { runGpuBidProbeCycle, type ProbeCycleSummary } from './gpuBidProbe.js'
+import { checkBalance } from './providerVerification.js'
+
+const log = createLogger('gpu-bid-probe-scheduler')
+
+const MIN_ACT_BALANCE_UACT = 5_000_000
+
+export class GpuBidProbeScheduler {
+  private cronJob: cron.ScheduledTask | null = null
+  private running = false
+  private readonly prisma: PrismaClient
+
+  constructor(prisma: PrismaClient) {
+    this.prisma = prisma
+  }
+
+  start() {
+    if (this.cronJob) {
+      log.info('Already running')
+      return
+    }
+    if (!process.env.AKASH_MNEMONIC) {
+      log.warn('AKASH_MNEMONIC not set — gpu bid probe scheduler disabled')
+      return
+    }
+
+    // 01:00, 07:00, 13:00, 19:00 UTC — staggered off the verifier's 04:00 slot.
+    this.cronJob = cron.schedule('0 1,7,13,19 * * *', () => {
+      this.runProbe().catch(err => {
+        log.error(
+          { err: err instanceof Error ? err.message : err },
+          'Scheduled gpu probe failed'
+        )
+      })
+    })
+
+    log.info('Started — runs at 01:00, 07:00, 13:00, 19:00 UTC')
+  }
+
+  stop() {
+    if (this.cronJob) {
+      this.cronJob.stop()
+      this.cronJob = null
+      log.info('Stopped')
+    }
+  }
+
+  /** Trigger a probe cycle manually (e.g. from /internal/admin/gpu-probe-now). */
+  async runNow(): Promise<ProbeCycleSummary | null> {
+    return this.runProbe()
+  }
+
+  private async runProbe(): Promise<ProbeCycleSummary | null> {
+    if (this.running) {
+      log.warn('Skipping — previous probe cycle still in progress')
+      return null
+    }
+    this.running = true
+    const start = Date.now()
+
+    try {
+      // Pre-flight balance check — same MIN as verifier so a single
+      // wallet drainage event grounds both schedulers in lockstep.
+      const balance = await checkBalance()
+      if (balance.uact < MIN_ACT_BALANCE_UACT) {
+        log.warn(
+          { uact: balance.uact, minimum: MIN_ACT_BALANCE_UACT },
+          'Insufficient ACT balance — skipping gpu probe cycle'
+        )
+        await opsAlert({
+          key: 'gpu-probe-low-balance',
+          severity: 'warning',
+          title: 'GPU bid probe skipped (low balance)',
+          message: `Wallet ACT balance ${balance.act} below minimum ${MIN_ACT_BALANCE_UACT / 1_000_000}.`,
+          context: { uact: balance.uact, minUact: MIN_ACT_BALANCE_UACT },
+        })
+        return null
+      }
+
+      const summary = await runGpuBidProbeCycle(this.prisma)
+
+      log.info(
+        {
+          runId: summary.runId,
+          modelsProbed: summary.modelsProbed,
+          totalBids: summary.totalBids,
+          uniqueProviders: summary.uniqueProviders,
+          durationMs: summary.durationMs,
+        },
+        'GPU probe cycle complete'
+      )
+
+      // Zero bids across every model is almost certainly a chain or
+      // wallet outage, not a real shortage of GPUs. Page ops.
+      if (summary.modelsProbed > 0 && summary.totalBids === 0) {
+        await opsAlert({
+          key: 'gpu-probe-zero-bids',
+          severity: 'warning',
+          title: 'GPU bid probe cycle returned zero bids',
+          message:
+            'All GPU model probes returned zero bids — likely a chain RPC, wallet, or provider-side outage.',
+          context: { runId: summary.runId, modelsProbed: summary.modelsProbed },
+        })
+      }
+
+      return summary
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      log.error({ err: msg }, 'Probe cycle threw')
+      await opsAlert({
+        key: 'gpu-probe-failed',
+        severity: 'warning',
+        title: 'GPU bid probe cycle failed',
+        message: msg.slice(0, 400),
+      })
+      return null
+    } finally {
+      this.running = false
+      log.info({ durationMs: Date.now() - start }, 'Probe cycle finished')
+    }
+  }
+}

--- a/src/services/providers/gpuBidProbeScheduler.ts
+++ b/src/services/providers/gpuBidProbeScheduler.ts
@@ -33,6 +33,7 @@ import { createLogger } from '../../lib/logger.js'
 import { opsAlert } from '../../lib/opsAlert.js'
 import { runGpuBidProbeCycle, type ProbeCycleSummary } from './gpuBidProbe.js'
 import { checkBalance } from './providerVerification.js'
+import { markStaleProbeRuns } from './staleRunRecovery.js'
 
 const log = createLogger('gpu-bid-probe-scheduler')
 
@@ -56,6 +57,16 @@ export class GpuBidProbeScheduler {
       log.warn('AKASH_MNEMONIC not set — gpu bid probe scheduler disabled')
       return
     }
+
+    // Sweep any probe-run rows left in `running` by a previous, dead
+    // process so the admin dashboard's third card doesn't lie. Best-
+    // effort: a DB hiccup here mustn't block scheduler startup.
+    markStaleProbeRuns(this.prisma).catch(err => {
+      log.warn(
+        { err: err instanceof Error ? err.message : err },
+        'Stale probe run recovery threw — continuing startup',
+      )
+    })
 
     // 01:00, 07:00, 13:00, 19:00 UTC — staggered off the verifier's 04:00 slot.
     this.cronJob = cron.schedule('0 1,7,13,19 * * *', () => {

--- a/src/services/providers/gpuPricingEndpoint.test.ts
+++ b/src/services/providers/gpuPricingEndpoint.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+
+const { getAkashChainGeometryMock } = vi.hoisted(() => ({
+  getAkashChainGeometryMock: vi.fn(),
+}))
+
+vi.mock('../../config/pricing.js', () => ({
+  getAkashChainGeometry: getAkashChainGeometryMock,
+}))
+
+import { handleGpuPricingRequest } from './gpuPricingEndpoint.js'
+
+interface FakeRes {
+  statusCode?: number
+  headers?: Record<string, string>
+  body?: string
+  writeHead: ReturnType<typeof vi.fn>
+  end: ReturnType<typeof vi.fn>
+}
+
+function makeReq(headers: Record<string, string> = {}): IncomingMessage {
+  return { headers, url: '/internal/gpu-pricing', method: 'GET' } as any
+}
+
+function makeRes(): FakeRes {
+  const res: FakeRes = {
+    writeHead: vi.fn(function (this: FakeRes, status: number, h?: Record<string, string>) {
+      this.statusCode = status
+      this.headers = h
+    }),
+    end: vi.fn(function (this: FakeRes, body?: string) {
+      this.body = body
+    }),
+  }
+  // bind `this` for method calls
+  res.writeHead = res.writeHead.bind(res)
+  res.end = res.end.bind(res)
+  return res
+}
+
+const SUMMARY_FIXTURE = [
+  {
+    gpuModel: 'h100',
+    vendor: 'nvidia',
+    minPricePerBlock: 1_000n,
+    p50PricePerBlock: 1_500n,
+    p90PricePerBlock: 2_000n,
+    maxPricePerBlock: 2_500n,
+    sampleCount: 12,
+    uniqueProviderCount: 4,
+    windowDays: 7,
+    refreshedAt: new Date('2026-04-19T12:00:00Z'),
+  },
+  {
+    gpuModel: 'rtx4090',
+    vendor: 'nvidia',
+    minPricePerBlock: 200n,
+    p50PricePerBlock: 250n,
+    p90PricePerBlock: 300n,
+    maxPricePerBlock: 350n,
+    sampleCount: 8,
+    uniqueProviderCount: 3,
+    windowDays: 7,
+    refreshedAt: new Date('2026-04-19T12:00:00Z'),
+  },
+]
+
+function buildPrisma(rows = SUMMARY_FIXTURE) {
+  return {
+    gpuPriceSummary: {
+      findMany: vi.fn().mockResolvedValue(rows),
+    },
+  } as any
+}
+
+describe('handleGpuPricingRequest', () => {
+  beforeEach(() => {
+    process.env.INTERNAL_AUTH_TOKEN = 'secret-token'
+    getAkashChainGeometryMock.mockResolvedValue({
+      secondsPerBlock: 6.117,
+      blocksPerHour: 588,
+      blocksPerDay: 14_124,
+      source: 'cache',
+      sampledAt: Date.now(),
+    })
+  })
+
+  afterEach(() => {
+    delete process.env.INTERNAL_AUTH_TOKEN
+    vi.clearAllMocks()
+  })
+
+  it('rejects request without x-internal-auth header', async () => {
+    const req = makeReq()
+    const res = makeRes()
+    await handleGpuPricingRequest(req, res as unknown as ServerResponse, buildPrisma())
+    expect(res.statusCode).toBe(401)
+    expect(JSON.parse(res.body!).error).toBe('Unauthorized')
+  })
+
+  it('rejects request with the wrong token', async () => {
+    const req = makeReq({ 'x-internal-auth': 'nope' })
+    const res = makeRes()
+    await handleGpuPricingRequest(req, res as unknown as ServerResponse, buildPrisma())
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('rejects when INTERNAL_AUTH_TOKEN is unset (deny-by-default)', async () => {
+    delete process.env.INTERNAL_AUTH_TOKEN
+    const req = makeReq({ 'x-internal-auth': 'secret-token' })
+    const res = makeRes()
+    await handleGpuPricingRequest(req, res as unknown as ServerResponse, buildPrisma())
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('returns rolled-up summaries with stringified BigInts and live block geometry', async () => {
+    const req = makeReq({ 'x-internal-auth': 'secret-token' })
+    const res = makeRes()
+    await handleGpuPricingRequest(req, res as unknown as ServerResponse, buildPrisma())
+
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body!)
+    expect(body.blocksPerDay).toBe(14_124)
+    expect(body.blocksSource).toBe('cache')
+    expect(body.models).toHaveLength(2)
+    const h100 = body.models.find((m: any) => m.gpuModel === 'h100')
+    expect(h100).toMatchObject({
+      vendor: 'nvidia',
+      minUact: '1000',
+      p50Uact: '1500',
+      p90Uact: '2000',
+      maxUact: '2500',
+      sampleCount: 12,
+      providerCount: 4,
+      windowDays: 7,
+    })
+    expect(typeof h100.refreshedAt).toBe('string')
+  })
+
+  it('returns 200 with empty models when the rollup table is empty', async () => {
+    const req = makeReq({ 'x-internal-auth': 'secret-token' })
+    const res = makeRes()
+    await handleGpuPricingRequest(req, res as unknown as ServerResponse, buildPrisma([]))
+    expect(res.statusCode).toBe(200)
+    const body = JSON.parse(res.body!)
+    expect(body.models).toEqual([])
+    expect(body.blocksPerDay).toBe(14_124)
+  })
+
+  it('returns 500 when the prisma read throws', async () => {
+    const prisma = {
+      gpuPriceSummary: { findMany: vi.fn().mockRejectedValue(new Error('db down')) },
+    } as any
+    const req = makeReq({ 'x-internal-auth': 'secret-token' })
+    const res = makeRes()
+    await handleGpuPricingRequest(req, res as unknown as ServerResponse, prisma)
+    expect(res.statusCode).toBe(500)
+  })
+})

--- a/src/services/providers/gpuPricingEndpoint.ts
+++ b/src/services/providers/gpuPricingEndpoint.ts
@@ -1,0 +1,94 @@
+/**
+ * Internal endpoint: GET /internal/gpu-pricing
+ *
+ * Returns the rolled-up per-GPU pricing summary computed by the
+ * GpuBidProbeScheduler, plus the live blocks-per-day estimate from the
+ * Akash console-api so the web-app can convert price-per-block into a
+ * USD-per-day cost label without re-doing the math itself.
+ *
+ * Auth: shared INTERNAL_AUTH_TOKEN via x-internal-auth header (same
+ * pattern as /internal/provider-registry).
+ *
+ * Response shape (the web-app's akash-gpu-availability route consumes
+ * this directly — be careful with breaking changes):
+ *   {
+ *     refreshedAt: ISO,
+ *     blocksPerDay: 14124,
+ *     blocksSource: 'akash-console-api' | 'cache' | 'static-fallback',
+ *     models: [
+ *       { gpuModel, vendor,
+ *         minUact, p50Uact, p90Uact, maxUact,
+ *         sampleCount, providerCount, windowDays, refreshedAt }
+ *     ]
+ *   }
+ *
+ * `*Uact` fields are stringified BigInts so JSON consumers don't lose
+ * precision. The web-app converts them back to BigInt for comparison
+ * and to USD for display.
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { PrismaClient } from '@prisma/client'
+import { createLogger } from '../../lib/logger.js'
+import { getAkashChainGeometry } from '../../config/pricing.js'
+
+const log = createLogger('gpu-pricing-endpoint')
+
+export async function handleGpuPricingRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  prisma: PrismaClient
+): Promise<void> {
+  const expectedToken = process.env.INTERNAL_AUTH_TOKEN
+  const authToken = req.headers['x-internal-auth']
+
+  if (!expectedToken || authToken !== expectedToken) {
+    res.writeHead(401, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ error: 'Unauthorized' }))
+    return
+  }
+
+  try {
+    const summaries = await prisma.gpuPriceSummary.findMany({
+      orderBy: { gpuModel: 'asc' },
+    })
+
+    // Resolve chain geometry concurrently with the DB read so the
+    // endpoint stays sub-100ms when the cache is cold. Failure of the
+    // live source falls back to the static constant inside
+    // `getAkashChainGeometry` — never throws. Pass `prisma` so a fresh
+    // pod can hydrate the in-memory cache from `chain_stats` instead of
+    // serving the static fallback on its first request.
+    const geometry = await getAkashChainGeometry(prisma)
+
+    const response = {
+      generatedAt: new Date().toISOString(),
+      blocksPerDay: geometry.blocksPerDay,
+      blocksPerHour: geometry.blocksPerHour,
+      secondsPerBlock: geometry.secondsPerBlock,
+      blocksSource: geometry.source,
+      models: summaries.map(s => ({
+        gpuModel: s.gpuModel,
+        vendor: s.vendor,
+        minUact: s.minPricePerBlock.toString(),
+        p50Uact: s.p50PricePerBlock.toString(),
+        p90Uact: s.p90PricePerBlock.toString(),
+        maxUact: s.maxPricePerBlock.toString(),
+        sampleCount: s.sampleCount,
+        providerCount: s.uniqueProviderCount,
+        windowDays: s.windowDays,
+        refreshedAt: s.refreshedAt.toISOString(),
+      })),
+    }
+
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify(response))
+  } catch (err) {
+    log.error(
+      { err: err instanceof Error ? err.message : err },
+      'GPU pricing endpoint failed'
+    )
+    res.writeHead(500, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ error: 'Internal server error' }))
+  }
+}

--- a/src/services/providers/gpuProbeManualTriggerEndpoint.ts
+++ b/src/services/providers/gpuProbeManualTriggerEndpoint.ts
@@ -1,0 +1,71 @@
+/**
+ * Internal endpoint: POST /internal/admin/gpu-probe-now
+ *
+ * Manual trigger for the GpuBidProbeScheduler. Mirrors the
+ * verifier's `runNow()` pattern: useful for ops who want to refresh
+ * pricing immediately after a chain outage, after a large new
+ * provider comes online, or to validate behaviour before the next
+ * scheduled cron tick.
+ *
+ * Auth: shared INTERNAL_AUTH_TOKEN via x-internal-auth header.
+ *
+ * Note: returns 202 Accepted immediately — the probe cycle takes
+ * minutes, far longer than is reasonable for an HTTP request to hold
+ * open. The structured log line at completion (and any opsAlert on
+ * failure) is the primary signal.
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { createLogger } from '../../lib/logger.js'
+import type { GpuBidProbeScheduler } from './gpuBidProbeScheduler.js'
+
+const log = createLogger('gpu-probe-manual-trigger')
+
+export async function handleGpuProbeManualTrigger(
+  req: IncomingMessage,
+  res: ServerResponse,
+  scheduler: GpuBidProbeScheduler
+): Promise<void> {
+  const expectedToken = process.env.INTERNAL_AUTH_TOKEN
+  const authToken = req.headers['x-internal-auth']
+
+  if (!expectedToken || authToken !== expectedToken) {
+    res.writeHead(401, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ error: 'Unauthorized' }))
+    return
+  }
+
+  // Fire-and-forget. The scheduler's overlap lock is the source of
+  // truth for "is one already running" — we just kick it.
+  scheduler
+    .runNow()
+    .then(summary => {
+      if (summary) {
+        log.info(
+          {
+            runId: summary.runId,
+            modelsProbed: summary.modelsProbed,
+            totalBids: summary.totalBids,
+            durationMs: summary.durationMs,
+          },
+          'Manual probe cycle complete'
+        )
+      } else {
+        log.info('Manual probe cycle skipped (already running, low balance, or AKASH_MNEMONIC unset)')
+      }
+    })
+    .catch(err => {
+      log.error(
+        { err: err instanceof Error ? err.message : err },
+        'Manual probe cycle threw'
+      )
+    })
+
+  res.writeHead(202, { 'Content-Type': 'application/json' })
+  res.end(
+    JSON.stringify({
+      accepted: true,
+      message: 'Probe cycle started in background. Watch logs for completion.',
+    })
+  )
+}

--- a/src/services/providers/probeBidSdl.test.ts
+++ b/src/services/providers/probeBidSdl.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { buildProbeSdl, PROBE_PRICING_CEILING_UACT } from './probeBidSdl.js'
+
+describe('buildProbeSdl', () => {
+  it('builds a syntactically reasonable SDL for nvidia h100', () => {
+    const sdl = buildProbeSdl('h100')
+    expect(sdl).toContain('image: alpine:3')
+    expect(sdl).toContain('cpu:')
+    expect(sdl).toContain('units: 1')
+    expect(sdl).toContain('memory:')
+    expect(sdl).toContain('size: 256Mi')
+    expect(sdl).toContain('gpu:')
+    expect(sdl).toContain('vendor:')
+    expect(sdl).toContain('nvidia:')
+    expect(sdl).toContain('- model: h100')
+    expect(sdl).toContain('denom: uact')
+    expect(sdl).toContain(`amount: ${PROBE_PRICING_CEILING_UACT}`)
+    expect(sdl).toContain('count: 1')
+  })
+
+  it('lower-cases the model token', () => {
+    const sdl = buildProbeSdl('RTX4090')
+    expect(sdl).toContain('- model: rtx4090')
+    expect(sdl).not.toContain('RTX4090')
+  })
+
+  it('handles amd vendor + multi-token models like mi300x', () => {
+    const sdl = buildProbeSdl('mi300x', 'amd')
+    expect(sdl).toContain('amd:')
+    expect(sdl).toContain('- model: mi300x')
+    expect(sdl).not.toContain('nvidia:')
+  })
+
+  it.each([
+    ['h100\nfoo: bar', 'newline injection'],
+    ['h100 evil', 'space injection'],
+    ['h100":"', 'quote injection'],
+    ['h100; rm -rf /', 'shell metachar injection'],
+    ['', 'empty model'],
+    ['../h100', 'path traversal'],
+    ['h100$VAR', 'env-expansion injection'],
+  ])('rejects unsafe gpu model %j (%s)', input => {
+    expect(() => buildProbeSdl(input)).toThrow(/Invalid gpu model token/)
+  })
+
+  it('rejects unsafe vendor', () => {
+    expect(() => buildProbeSdl('h100', 'malicious' as never)).toThrow(/Invalid gpu vendor/)
+  })
+
+  it('uses the high pricing ceiling so honest providers can always bid', () => {
+    // Sanity: a 100k uact ceiling per block at ~14k blocks/day is far above
+    // any honest GPU price ($1.4k/day). If someone ever lowers this we
+    // want a loud test failure to force the conversation.
+    expect(PROBE_PRICING_CEILING_UACT).toBeGreaterThanOrEqual(100_000)
+  })
+})

--- a/src/services/providers/probeBidSdl.ts
+++ b/src/services/providers/probeBidSdl.ts
@@ -1,0 +1,92 @@
+/**
+ * GPU bid-probe SDL generator.
+ *
+ * The probe is a deliberately tiny deployment whose only purpose is to
+ * surface real-world bid prices from every provider that owns the
+ * targeted GPU model. We never actually lease — the probe runner closes
+ * the deployment as soon as bids arrive.
+ *
+ * Why a high pricing ceiling (100_000 uact/block ≈ $1.4k/day):
+ *   - Akash bids must be at-or-below the offer price. We want EVERY
+ *     honest provider's real price, which is well under $5/hr in
+ *     practice for any GPU model. A ceiling 10× above the worst-case
+ *     real bid leaves zero room for "could not bid" excuses.
+ *   - We never accept the lease, so the ceiling is academic — there is
+ *     no risk of overspending here. The probe runner closes the dseq
+ *     before any escrow burn beyond a few seconds of block fees
+ *     (~$0.0015 per probe).
+ *
+ * Sanity guard: rollup discards observed bids above MAX_PROBE_BID_UACT
+ * (see `gpuBidProbe.ts`) so a malicious provider bidding the ceiling
+ * itself can't poison the percentile calculations.
+ */
+
+export type GpuVendor = 'nvidia' | 'amd'
+
+/**
+ * Strict whitelist for what we'll splice into the SDL YAML. Lower-case
+ * alphanumerics + dash only; matches the canonical model strings used
+ * throughout the registry (e.g. "h100", "rtx4090", "mi300x").
+ */
+const SAFE_TOKEN_RE = /^[a-z0-9-]+$/
+
+/** Bid ceiling in uact/block. See header for sizing rationale. */
+export const PROBE_PRICING_CEILING_UACT = 100_000
+
+export function buildProbeSdl(
+  gpuModel: string,
+  vendor: GpuVendor = 'nvidia'
+): string {
+  const model = gpuModel.toLowerCase().trim()
+  if (!SAFE_TOKEN_RE.test(model)) {
+    throw new Error(`Invalid gpu model token: ${JSON.stringify(gpuModel)}`)
+  }
+  if (vendor !== 'nvidia' && vendor !== 'amd') {
+    throw new Error(`Invalid gpu vendor: ${JSON.stringify(vendor)}`)
+  }
+
+  // Image is `alpine:3` + a 60s sleep — long enough to receive bids,
+  // short enough that even if our `tx deployment close` somehow fails
+  // the workload self-terminates before billing more than a fraction of
+  // a cent. The orchestrator + escrowHealthMonitor's chain-orphan sweep
+  // catch any actually-leased orphans separately.
+  return `---
+version: "2.0"
+services:
+  probe:
+    image: alpine:3
+    command: ["sleep", "60"]
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+profiles:
+  compute:
+    probe:
+      resources:
+        cpu:
+          units: 1
+        memory:
+          size: 256Mi
+        storage:
+          size: 256Mi
+        gpu:
+          units: 1
+          attributes:
+            vendor:
+              ${vendor}:
+                - model: ${model}
+  placement:
+    any:
+      pricing:
+        probe:
+          denom: uact
+          amount: ${PROBE_PRICING_CEILING_UACT}
+deployment:
+  probe:
+    any:
+      profile: probe
+      count: 1
+`
+}

--- a/src/services/providers/providerVerification.ts
+++ b/src/services/providers/providerVerification.ts
@@ -476,85 +476,107 @@ export async function runVerificationSuite(
   }
 
   let runError: string | undefined
-
-  try {
-    for (let i = 0; i < toTest.length; i++) {
-      const t = toTest[i]
-      log.info({ index: i + 1, total: toTest.length, templateId: t.id }, 'Testing template')
-
-      const result = await testSingleTemplate(t.id)
-      recordResult(result)
-      log.info({ templateId: t.id, passed: result.passed, provider: result.provider }, 'Template result')
-
-      if (!cheapestOnly && result.allBidders && result.allBidders.length > 1) {
-        const testedProviders = new Set<string>()
-        if (result.provider) testedProviders.add(result.provider)
-
-        for (const bidder of result.allBidders.filter(b => !testedProviders.has(b.provider))) {
-          await sleep(INTER_BIDDER_DELAY_MS)
-          log.info({ templateId: t.id, provider: bidder.provider }, 'Re-testing with additional bidder')
-
-          const bidderResult = await testSingleTemplate(t.id, bidder.provider)
-          recordResult(bidderResult)
-          if (bidderResult.provider) testedProviders.add(bidderResult.provider)
-
-          log.info({ templateId: t.id, passed: bidderResult.passed, provider: bidderResult.provider }, 'Bidder result')
-        }
-      }
-
-      if (i < toTest.length - 1) await sleep(INTER_TEMPLATE_DELAY_MS)
-    }
-  } catch (err: any) {
-    runError = err.message || String(err)
-  }
-
-  // Persist provider/template results
-  await persistResults(prisma, results, providerTally)
-
-  const templateResultMap = new Map<string, { passedProviders: string[] }>()
-  for (const r of results) {
-    if (!templateResultMap.has(r.templateId)) templateResultMap.set(r.templateId, { passedProviders: [] })
-    if (r.passed && r.provider) templateResultMap.get(r.templateId)!.passedProviders.push(r.provider)
-  }
-  const templatesPassed = Array.from(templateResultMap.values()).filter(v => v.passedProviders.length > 0).length
-
-  // Snapshot wallet balance after the run and compute cost delta
+  // Tracked outside the loop so the `finally` finaliser can write
+  // partial-progress numbers even if persistResults / checkBalance /
+  // anything else throws after the loop completes.
   let costUakt = BigInt(0)
   let costUact = BigInt(0)
-  try {
-    const balanceAfter = await checkBalance()
-    if (balanceBefore) {
-      costUakt = BigInt(Math.max(0, balanceBefore.uakt - balanceAfter.uakt))
-      costUact = BigInt(Math.max(0, balanceBefore.uact - balanceAfter.uact))
-      log.info({ costUakt: costUakt.toString(), costUact: costUact.toString() }, 'Run cost computed from balance delta')
-    }
-  } catch { /* non-fatal */ }
+  let templatesPassed = 0
 
-  // Finalize the VerificationRun record
-  const passedCount = results.filter(r => r.passed).length
-  const failedCount = results.filter(r => !r.passed).length
-  await prisma.verificationRun.update({
-    where: { id: run.id },
-    data: {
-      completedAt: new Date(),
-      templatesPassed,
-      deployments: results.length,
-      passed: passedCount,
-      failed: failedCount,
-      uniqueProviders: Object.keys(providerTally).length,
-      costUakt,
-      costUact,
-      status: runError ? 'failed' : 'completed',
-      error: runError?.slice(0, 1000) || null,
-    },
-  })
+  try {
+    try {
+      for (let i = 0; i < toTest.length; i++) {
+        const t = toTest[i]
+        log.info({ index: i + 1, total: toTest.length, templateId: t.id }, 'Testing template')
+
+        const result = await testSingleTemplate(t.id)
+        recordResult(result)
+        log.info({ templateId: t.id, passed: result.passed, provider: result.provider }, 'Template result')
+
+        if (!cheapestOnly && result.allBidders && result.allBidders.length > 1) {
+          const testedProviders = new Set<string>()
+          if (result.provider) testedProviders.add(result.provider)
+
+          for (const bidder of result.allBidders.filter(b => !testedProviders.has(b.provider))) {
+            await sleep(INTER_BIDDER_DELAY_MS)
+            log.info({ templateId: t.id, provider: bidder.provider }, 'Re-testing with additional bidder')
+
+            const bidderResult = await testSingleTemplate(t.id, bidder.provider)
+            recordResult(bidderResult)
+            if (bidderResult.provider) testedProviders.add(bidderResult.provider)
+
+            log.info({ templateId: t.id, passed: bidderResult.passed, provider: bidderResult.provider }, 'Bidder result')
+          }
+        }
+
+        if (i < toTest.length - 1) await sleep(INTER_TEMPLATE_DELAY_MS)
+      }
+    } catch (err: any) {
+      runError = err.message || String(err)
+    }
+
+    // Persist provider/template results — wrapped because a DB hiccup
+    // here used to leave the run row stranded in 'running' forever.
+    try {
+      await persistResults(prisma, results, providerTally)
+    } catch (err: any) {
+      runError = runError ?? `persistResults failed: ${err.message || String(err)}`
+    }
+
+    const templateResultMap = new Map<string, { passedProviders: string[] }>()
+    for (const r of results) {
+      if (!templateResultMap.has(r.templateId)) templateResultMap.set(r.templateId, { passedProviders: [] })
+      if (r.passed && r.provider) templateResultMap.get(r.templateId)!.passedProviders.push(r.provider)
+    }
+    templatesPassed = Array.from(templateResultMap.values()).filter(v => v.passedProviders.length > 0).length
+
+    // Snapshot wallet balance after the run and compute cost delta
+    try {
+      const balanceAfter = await checkBalance()
+      if (balanceBefore) {
+        costUakt = BigInt(Math.max(0, balanceBefore.uakt - balanceAfter.uakt))
+        costUact = BigInt(Math.max(0, balanceBefore.uact - balanceAfter.uact))
+        log.info({ costUakt: costUakt.toString(), costUact: costUact.toString() }, 'Run cost computed from balance delta')
+      }
+    } catch { /* non-fatal */ }
+  } finally {
+    // Finalize the VerificationRun record. ALWAYS runs — even if the
+    // loop or persistResults threw — so the dashboard never sees a
+    // stranded `running` row from an in-process failure. (Out-of-
+    // process kills are still cleaned up by markStaleVerifierRuns at
+    // the next scheduler startup.)
+    const passedCount = results.filter(r => r.passed).length
+    const failedCount = results.filter(r => !r.passed).length
+    try {
+      await prisma.verificationRun.update({
+        where: { id: run.id },
+        data: {
+          completedAt: new Date(),
+          templatesPassed,
+          deployments: results.length,
+          passed: passedCount,
+          failed: failedCount,
+          uniqueProviders: Object.keys(providerTally).length,
+          costUakt,
+          costUact,
+          status: runError ? 'failed' : 'completed',
+          error: runError?.slice(0, 1000) || null,
+        },
+      })
+    } catch (err) {
+      log.error(
+        { runId: run.id, err: err instanceof Error ? err.message : err },
+        'Could not finalise VerificationRun row — startup recovery will sweep it',
+      )
+    }
+  }
 
   const summary: VerificationSummary = {
     templatesTotal: toTest.length,
     templatesPassed,
     deployments: results.length,
-    passed: passedCount,
-    failed: failedCount,
+    passed: results.filter(r => r.passed).length,
+    failed: results.filter(r => !r.passed).length,
     uniqueProviders: Object.keys(providerTally).length,
     results,
     providerTally,

--- a/src/services/providers/providerVerificationScheduler.ts
+++ b/src/services/providers/providerVerificationScheduler.ts
@@ -31,6 +31,7 @@ import {
   syncToStaging,
   checkBalance,
 } from './providerVerification.js'
+import { markStaleVerifierRuns } from './staleRunRecovery.js'
 
 const log = createLogger('provider-verification-scheduler')
 
@@ -55,6 +56,17 @@ export class ProviderVerificationScheduler {
       log.warn('AKASH_MNEMONIC not set — provider verification scheduler disabled')
       return
     }
+
+    // Sweep any rows left in `running` by a previous, dead process
+    // (OOM, deploy SIGKILL, laptop sleep, etc.) so the admin dashboard
+    // doesn't keep showing a misleading "Running" badge for hours.
+    // Best-effort: a DB hiccup here mustn't block scheduler startup.
+    markStaleVerifierRuns(this.prisma).catch(err => {
+      log.warn(
+        { err: err instanceof Error ? err.message : err },
+        'Stale verifier run recovery threw — continuing startup',
+      )
+    })
 
     // Mon/Wed/Fri at 04:00 UTC (was daily — see header comment for rationale)
     this.cronJob = cron.schedule('0 4 * * 1,3,5', () => {

--- a/src/services/providers/staleRunRecovery.test.ts
+++ b/src/services/providers/staleRunRecovery.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  markStaleVerifierRuns,
+  markStaleProbeRuns,
+  MAX_VERIFIER_RUN_MS,
+  MAX_PROBE_RUN_MS,
+} from './staleRunRecovery.js'
+
+interface FakePrisma {
+  verificationRun: { updateMany: ReturnType<typeof vi.fn> }
+  gpuProbeRun: { updateMany: ReturnType<typeof vi.fn> }
+}
+
+function buildPrisma(): FakePrisma {
+  return {
+    verificationRun: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+    gpuProbeRun: { updateMany: vi.fn().mockResolvedValue({ count: 0 }) },
+  }
+}
+
+describe('markStaleVerifierRuns', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-19T17:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('updates only rows where status=running AND startedAt is older than MAX_VERIFIER_RUN_MS', async () => {
+    const prisma = buildPrisma()
+    prisma.verificationRun.updateMany.mockResolvedValue({ count: 3 })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const swept = await markStaleVerifierRuns(prisma as any)
+
+    expect(swept).toBe(3)
+    expect(prisma.verificationRun.updateMany).toHaveBeenCalledOnce()
+    const arg = prisma.verificationRun.updateMany.mock.calls[0][0]
+
+    expect(arg.where.status).toBe('running')
+    expect(arg.where.startedAt.lt).toBeInstanceOf(Date)
+    // cutoff = now - MAX
+    const expected = Date.now() - MAX_VERIFIER_RUN_MS
+    expect((arg.where.startedAt.lt as Date).getTime()).toBe(expected)
+
+    expect(arg.data.status).toBe('failed')
+    expect(arg.data.completedAt).toBeInstanceOf(Date)
+    expect(arg.data.error).toMatch(/Marked stale on scheduler startup/)
+  })
+
+  it('returns 0 (does not throw) when prisma updateMany rejects', async () => {
+    const prisma = buildPrisma()
+    prisma.verificationRun.updateMany.mockRejectedValue(new Error('connection refused'))
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const swept = await markStaleVerifierRuns(prisma as any)
+    expect(swept).toBe(0)
+  })
+
+  it('returns 0 when there are no stale rows (no swept-count log spam)', async () => {
+    const prisma = buildPrisma()
+    prisma.verificationRun.updateMany.mockResolvedValue({ count: 0 })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const swept = await markStaleVerifierRuns(prisma as any)
+    expect(swept).toBe(0)
+    expect(prisma.verificationRun.updateMany).toHaveBeenCalledOnce()
+  })
+})
+
+describe('markStaleProbeRuns', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-19T17:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('uses the probe-specific cutoff (30m), not the verifier cutoff (6h)', async () => {
+    const prisma = buildPrisma()
+    prisma.gpuProbeRun.updateMany.mockResolvedValue({ count: 1 })
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await markStaleProbeRuns(prisma as any)
+
+    const arg = prisma.gpuProbeRun.updateMany.mock.calls[0][0]
+    const expected = Date.now() - MAX_PROBE_RUN_MS
+    expect((arg.where.startedAt.lt as Date).getTime()).toBe(expected)
+    // sanity: probe cutoff must be MUCH more recent than verifier cutoff,
+    // otherwise we'd let stranded probe rows linger for 6h.
+    expect(MAX_PROBE_RUN_MS).toBeLessThan(MAX_VERIFIER_RUN_MS)
+  })
+
+  it('survives a DB error without throwing', async () => {
+    const prisma = buildPrisma()
+    prisma.gpuProbeRun.updateMany.mockRejectedValue(new Error('db down'))
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const swept = await markStaleProbeRuns(prisma as any)
+    expect(swept).toBe(0)
+  })
+})

--- a/src/services/providers/staleRunRecovery.ts
+++ b/src/services/providers/staleRunRecovery.ts
@@ -1,0 +1,112 @@
+/**
+ * Stale run recovery.
+ *
+ * Both `verification_run` and `gpu_probe_run` are populated by a
+ * "create row at start, update at end" pattern. If a process dies
+ * between those two writes (OOM, SIGKILL during deploy, laptop sleep
+ * during local dev, etc.) the row is stranded in `status='running'`
+ * forever — and the admin dashboard then shows a misleading "Running"
+ * badge for a job that's actually long-dead.
+ *
+ * The fix has two halves:
+ *
+ *   1. Wrap the row finalisation in `try/finally` (done in
+ *      `providerVerification.ts` and `gpuBidProbe.ts`). This catches
+ *      all in-process failures.
+ *   2. On scheduler start-up, sweep any rows whose `started_at` is
+ *      older than the maximum reasonable run duration and mark them
+ *      `status='failed'` with an explanatory error. This catches
+ *      out-of-process kills (the case the in-process try/finally
+ *      cannot help with).
+ *
+ * `MAX_VERIFIER_RUN_MS` and `MAX_PROBE_RUN_MS` are deliberately set
+ * well above the longest healthy run we've observed — false-positive
+ * "stale" classifications would mark in-flight runs as failed and
+ * spam the dashboard with red badges. The verifier's longest healthy
+ * run was ~3.5h on Apr 9; we use 6h as the floor so even an unusually
+ * slow GPU template doesn't get prematurely marked failed.
+ */
+
+import type { PrismaClient } from '@prisma/client'
+import { createLogger } from '../../lib/logger.js'
+
+const log = createLogger('stale-run-recovery')
+
+/** 6h — comfortably above the longest healthy verifier run observed. */
+export const MAX_VERIFIER_RUN_MS = 6 * 60 * 60 * 1000
+
+/** 30m — a single probe is ~60s, all 15 GPU models with inter-probe
+ *  delays should finish well inside 15 min. 30m is the "definitely
+ *  dead" threshold. */
+export const MAX_PROBE_RUN_MS = 30 * 60 * 1000
+
+const STALE_ERROR_VERIFIER = 'Marked stale on scheduler startup — process likely died mid-run'
+const STALE_ERROR_PROBE = 'Marked stale on scheduler startup — process likely died mid-run'
+
+/**
+ * Mark all `verification_run` rows still in `running` whose
+ * `started_at` is older than `MAX_VERIFIER_RUN_MS` as `failed`.
+ *
+ * Returns the number of rows updated. Best-effort: a DB error here
+ * must not stop the scheduler from starting.
+ */
+export async function markStaleVerifierRuns(prisma: PrismaClient): Promise<number> {
+  try {
+    const cutoff = new Date(Date.now() - MAX_VERIFIER_RUN_MS)
+    const result = await prisma.verificationRun.updateMany({
+      where: {
+        status: 'running',
+        startedAt: { lt: cutoff },
+      },
+      data: {
+        status: 'failed',
+        completedAt: new Date(),
+        error: STALE_ERROR_VERIFIER,
+      },
+    })
+    if (result.count > 0) {
+      log.warn(
+        { count: result.count, cutoff: cutoff.toISOString() },
+        'Swept stale verifier runs at scheduler startup',
+      )
+    }
+    return result.count
+  } catch (err) {
+    log.error(
+      { err: err instanceof Error ? err.message : err },
+      'markStaleVerifierRuns failed — leaving rows as-is',
+    )
+    return 0
+  }
+}
+
+/** Same as above, for `gpu_probe_run`. */
+export async function markStaleProbeRuns(prisma: PrismaClient): Promise<number> {
+  try {
+    const cutoff = new Date(Date.now() - MAX_PROBE_RUN_MS)
+    const result = await prisma.gpuProbeRun.updateMany({
+      where: {
+        status: 'running',
+        startedAt: { lt: cutoff },
+      },
+      data: {
+        status: 'failed',
+        completedAt: new Date(),
+        error: STALE_ERROR_PROBE,
+      },
+    })
+    if (result.count > 0) {
+      log.warn(
+        { count: result.count, cutoff: cutoff.toISOString() },
+        'Swept stale probe runs at scheduler startup',
+      )
+    }
+    return result.count
+  } catch (err) {
+    log.error(
+      { err: err instanceof Error ? err.message : err },
+      'markStaleProbeRuns failed — leaving rows as-is',
+    )
+    return 0
+  }
+}


### PR DESCRIPTION
Adds the missing half of provider pricing: a 6h cron that probes the
chain per GPU model, captures every open bid, rolls them into
percentile summaries, then exposes the lot (plus per-cycle wallet
spend) to the admin dashboard.

- GpuBidProbeScheduler (01/07/13/19 UTC, staggered off the verifier's
  04:00 slot) — shares the deployer wallet via withWalletLock,
  leader-gated, ACT >= 5 balance floor, AKASH_MNEMONIC guard.
- New tables: gpu_bid_observation (raw bids), gpu_price_summary
  (rolling 7d min/p50/p90/max), chain_stats (Akash block geometry,
  hydrated on cold start), gpu_probe_run (per-cycle telemetry).
- Probe runner posts a tiny SDL targeting one GPU model, polls bids
  for ~60s, ALWAYS closes in finally (chain-orphan sweep is the
  safety net), drops poison bids >= MAX_PROBE_BID_UACT.
- Live block geometry now persists to chain_stats so a fresh pod
  hydrates without paying the console-api round-trip.
- runGpuBidProbeCycle records a GpuProbeRun row at start and
  finalises with wallet balance delta as cost — admin dashboard
  shows real on-chain spend, not estimates. Floored at 0 to
  tolerate mid-cycle wallet refills.
- New internal endpoints (all x-internal-auth):
    GET  /internal/gpu-pricing            (web-app price UI)
    GET  /internal/admin/scheduler-stats  (admin dashboard)
    POST /internal/admin/gpu-probe-now    (manual trigger)
- Ops alerts: gpu-probe-low-balance, gpu-probe-zero-bids,
  gpu-probe-failed.

~$0.09/day total cost. +12 unit tests, 727/727 passing.

The admin dashboard was showing "Running" for a verifier cycle that
last actually moved 17h ago. Three verification_run rows (Apr 10/18/19)
were stranded in status='running' with completed_at=NULL, because the
run finalisation lived after the loop with no try/finally — any throw
between row-create and row-update (or any out-of-process kill: deploy
SIGKILL, OOM, laptop sleep during local dev) left the row orphaned
forever.
Two-part fix:
1. In-process safety — wrapped the finalise-update in real try/finally
   in both providerVerification.ts and gpuBidProbe.ts. Throws from
   persistResults, checkBalance, the bid read-back, etc. now still
   write status=completed|failed with whatever partial-progress numbers
   were captured. Errors that originated in the loop body are recorded
   on the row as `error`.
2. Out-of-process safety — new staleRunRecovery.ts module with
   markStaleVerifierRuns() (6h cutoff) and markStaleProbeRuns() (30m
   cutoff). Both schedulers call their respective sweep at start(),
   marking any orphaned `running` rows as `failed` with a clear
   explanation. Best-effort: a sweep failure can't block scheduler
   startup. Cutoffs deliberately well above the longest healthy run
   we've observed so an in-flight run is never prematurely killed.
Local sweep verified: hot-reloaded dev server cleaned all 3 stranded
rows on the first scheduler start after deploy. Production rows get
the same treatment on next deploy.
+6 tests (staleRunRecovery happy/error paths, cutoff-asymmetry sanity
check, probe-cycle finally-guarantee). Full suite: 733/733 passing,
tsc clean.
