### PR TITLE
fix gpu bid probe parser dropping every cosmos Dec-formatted bid

### DIFF
--- a/src/services/providers/gpuBidProbe.test.ts
+++ b/src/services/providers/gpuBidProbe.test.ts
@@ -299,6 +299,54 @@ describe('probeOneGpuModel', () => {
     expect(result.dseq).toBe(777)
   })
 
+  it('parses cosmos SDK Dec-formatted bid prices (real chain wire format)', async () => {
+    // Regression: production cycles produced 0 bids because the chain
+    // returns `price.amount` as a fixed-point Dec string (e.g.
+    // "1957.925980000000000000"). BigInt(decimalString) throws
+    // SyntaxError, so the previous parser silently dropped every bid.
+    // We must truncate the fractional part before BigInt-ing.
+    const BIDS_DEC_FORMAT = JSON.stringify({
+      bids: [
+        {
+          bid: {
+            id: { provider: 'akash15pkdkewzarpsx42t98vzf45h42hlq6ra8w96hr' },
+            price: { denom: 'uact', amount: '1957.925980000000000000' },
+            state: 'open',
+          },
+        },
+        {
+          bid: {
+            id: { provider: 'akash17erkmem6xcugfnew2c0ujfqtet32j29ztk03jt' },
+            price: { denom: 'uact', amount: '3376.830911000000000000' },
+            state: 'open',
+          },
+        },
+      ],
+    })
+
+    const execCli = vi.fn(async (_bin: string, args: string[]): Promise<ExecResult> => {
+      if (args[0] === 'keys' && args[1] === 'show') return ok(KEYS_SHOW_OUT)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'create') return ok(TX_OK_WITH_DSEQ)
+      if (args[0] === 'query' && args[1] === 'market' && args[2] === 'bid' && args[3] === 'list') {
+        return ok(BIDS_DEC_FORMAT)
+      }
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'close') return ok(TX_CLOSE_OK)
+      return ok('{}')
+    })
+
+    const prisma = buildPrisma()
+    const result = await probeOneGpuModel(prisma as any, 'h100', 'nvidia', 'run-1', { execCli, sleep: fastSleep })
+
+    expect(result.bidsReceived).toBe(2)
+    expect(result.providersBidding).toBe(2)
+    expect(prisma.gpuBidObservation.createMany).toHaveBeenCalledTimes(1)
+    const inserted = (prisma.gpuBidObservation.createMany as any).mock.calls[0][0].data
+    expect(inserted).toHaveLength(2)
+    // Truncated to whole uact — sub-uact precision discarded by design.
+    const prices = inserted.map((r: any) => r.pricePerBlock).sort((a: bigint, b: bigint) => (a < b ? -1 : 1))
+    expect(prices).toEqual([1957n, 3376n])
+  })
+
   it('does not crash when close TX itself fails', async () => {
     const execCli = vi.fn(async (_bin: string, args: string[]): Promise<ExecResult> => {
       if (args[0] === 'keys' && args[1] === 'show') return ok(KEYS_SHOW_OUT)

--- a/src/services/providers/gpuBidProbe.ts
+++ b/src/services/providers/gpuBidProbe.ts
@@ -332,8 +332,19 @@ export async function probeOneGpuModel(
             // new leases; any uakt bid here is a misconfigured provider
             // and would corrupt the percentile if mixed with uact.
             if (denom !== 'uact') continue
+            // Bid prices come back from `query market bid list` as cosmos
+            // SDK Dec strings (fixed-point, 18 decimals — e.g.
+            // "1957.925980000000000000"). BigInt rejects the decimal
+            // point outright (SyntaxError), so we have to truncate the
+            // fractional part before parsing. Sub-uact precision is below
+            // any meaningful price granularity (uact is already 1e-6 ACT),
+            // so flooring to whole uact loses no signal.
             let amount: bigint
-            try { amount = BigInt(price.amount ?? '0') } catch { continue }
+            try {
+              const rawAmount = String(price.amount ?? '0')
+              const intPart = rawAmount.split('.')[0]
+              amount = BigInt(intPart)
+            } catch { continue }
             if (amount <= 0n) continue
             // Keep the lowest bid per provider — providers occasionally
             // re-bid; we want the most generous offer they made.


### PR DESCRIPTION
query market bid list` returns bid prices as cosmos SDK Dec strings
("1957.925980000000000000", fixed-point 18 decimals). The parser called
BigInt(price.amount) directly — BigInt rejects decimal points with
SyntaxError, the try/catch swallowed it, and 100% of bids were silently
dropped. Cycles completed cleanly with `0 bids · 0 providers` for every
GPU model and `gpu_price_summary` never populated.
Fix: split on '.' and BigInt the integer portion. Truncating sub-uact
precision is fine — uact is already 1e-6 ACT, well below any
meaningful pricing granularity.
Verified live against akashnet-2: same h100 probe pre-fix returned 0
bids in 124s (timeout); post-fix returned 2 bids (1957 + 3376
uact/block) in 61s and wrote both observations.
Regression test added using the actual chain wire format
("1957.925980000000000000"). Previous fixtures used clean integer
strings ("1000") which BigInt accepts, so no test would have caught
this.