### PR TITLE
fix gpu deploys: pin SDL ceiling, fix orphan resolveProviderGpuModel calls, drop dynamic resolver

### DIFF
--- a/src/services/akash/orchestrator.ts
+++ b/src/services/akash/orchestrator.ts
@@ -24,6 +24,7 @@ import { getBillingApiClient } from '../billing/billingApiClient.js'
 import { createLogger } from '../../lib/logger.js'
 import { withWalletLock, isWalletTx } from './walletMutex.js'
 import type { TemplateGpu } from '../../templates/index.js'
+import { resolveSdlPricingUact } from '../../templates/sdl.js'
 
 const log = createLogger('akash-orchestrator')
 
@@ -1380,6 +1381,10 @@ export class AkashOrchestrator {
           { templateId: service.templateId, hasResourceOverrides: !!resourceOverrides },
           `Generating SDL from template '${service.templateId}' for service '${service.slug}'`
         )
+        // SDL ceiling for GPU deploys is unconditional (see
+        // `templates/sdl.ts:GPU_SDL_PRICING_CEILING_UACT`). No
+        // dynamic-pricing lookup needed — providers bid, the bid-
+        // selection layer picks the cheapest preferred bid.
         return generateSDLFromTemplate(template, {
           serviceName: service.slug,
           resourceOverrides: resourceOverrides
@@ -1415,7 +1420,7 @@ export class AkashOrchestrator {
         effectiveImage,
         port,
         resourceOverrides,
-        parsedVolumes
+        parsedVolumes,
       )
     }
 
@@ -1556,7 +1561,7 @@ export class AkashOrchestrator {
       storage?: string
       gpu?: { units: number; vendor: string; model?: string } | null
     },
-    volumes: ServiceVolume[] = []
+    volumes: ServiceVolume[] = [],
   ): string {
     const needsKeepAlive = /^(ubuntu|debian|alpine|centos|fedora|busybox|amazonlinux|rockylinux|almalinux)(:|$)/i.test(image)
 
@@ -1645,7 +1650,7 @@ ${storageProfile}${gpuBlock}
       pricing:
         ${name}:
           denom: uact
-          amount: ${gpu && gpu.units > 0 ? 10000 : 1000}
+          amount: ${resolveSdlPricingUact(!!(gpu && gpu.units > 0))}
 
 deployment:
   ${name}:

--- a/src/services/providers/gpuBidProbe.test.ts
+++ b/src/services/providers/gpuBidProbe.test.ts
@@ -299,6 +299,54 @@ describe('probeOneGpuModel', () => {
     expect(result.dseq).toBe(777)
   })
 
+  it('parses cosmos SDK Dec-formatted bid prices (real chain wire format)', async () => {
+    // Regression: production cycles produced 0 bids because the chain
+    // returns `price.amount` as a fixed-point Dec string (e.g.
+    // "1957.925980000000000000"). BigInt(decimalString) throws
+    // SyntaxError, so the previous parser silently dropped every bid.
+    // We must truncate the fractional part before BigInt-ing.
+    const BIDS_DEC_FORMAT = JSON.stringify({
+      bids: [
+        {
+          bid: {
+            id: { provider: 'akash15pkdkewzarpsx42t98vzf45h42hlq6ra8w96hr' },
+            price: { denom: 'uact', amount: '1957.925980000000000000' },
+            state: 'open',
+          },
+        },
+        {
+          bid: {
+            id: { provider: 'akash17erkmem6xcugfnew2c0ujfqtet32j29ztk03jt' },
+            price: { denom: 'uact', amount: '3376.830911000000000000' },
+            state: 'open',
+          },
+        },
+      ],
+    })
+
+    const execCli = vi.fn(async (_bin: string, args: string[]): Promise<ExecResult> => {
+      if (args[0] === 'keys' && args[1] === 'show') return ok(KEYS_SHOW_OUT)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'create') return ok(TX_OK_WITH_DSEQ)
+      if (args[0] === 'query' && args[1] === 'market' && args[2] === 'bid' && args[3] === 'list') {
+        return ok(BIDS_DEC_FORMAT)
+      }
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'close') return ok(TX_CLOSE_OK)
+      return ok('{}')
+    })
+
+    const prisma = buildPrisma()
+    const result = await probeOneGpuModel(prisma as any, 'h100', 'nvidia', 'run-1', { execCli, sleep: fastSleep })
+
+    expect(result.bidsReceived).toBe(2)
+    expect(result.providersBidding).toBe(2)
+    expect(prisma.gpuBidObservation.createMany).toHaveBeenCalledTimes(1)
+    const inserted = (prisma.gpuBidObservation.createMany as any).mock.calls[0][0].data
+    expect(inserted).toHaveLength(2)
+    // Truncated to whole uact — sub-uact precision discarded by design.
+    const prices = inserted.map((r: any) => r.pricePerBlock).sort((a: bigint, b: bigint) => (a < b ? -1 : 1))
+    expect(prices).toEqual([1957n, 3376n])
+  })
+
   it('does not crash when close TX itself fails', async () => {
     const execCli = vi.fn(async (_bin: string, args: string[]): Promise<ExecResult> => {
       if (args[0] === 'keys' && args[1] === 'show') return ok(KEYS_SHOW_OUT)

--- a/src/services/providers/gpuBidProbe.ts
+++ b/src/services/providers/gpuBidProbe.ts
@@ -332,8 +332,19 @@ export async function probeOneGpuModel(
             // new leases; any uakt bid here is a misconfigured provider
             // and would corrupt the percentile if mixed with uact.
             if (denom !== 'uact') continue
+            // Bid prices come back from `query market bid list` as cosmos
+            // SDK Dec strings (fixed-point, 18 decimals — e.g.
+            // "1957.925980000000000000"). BigInt rejects the decimal
+            // point outright (SyntaxError), so we have to truncate the
+            // fractional part before parsing. Sub-uact precision is below
+            // any meaningful price granularity (uact is already 1e-6 ACT),
+            // so flooring to whole uact loses no signal.
             let amount: bigint
-            try { amount = BigInt(price.amount ?? '0') } catch { continue }
+            try {
+              const rawAmount = String(price.amount ?? '0')
+              const intPart = rawAmount.split('.')[0]
+              amount = BigInt(intPart)
+            } catch { continue }
             if (amount <= 0n) continue
             // Keep the lowest bid per provider — providers occasionally
             // re-bid; we want the most generous offer they made.

--- a/src/services/queue/akashSteps.ts
+++ b/src/services/queue/akashSteps.ts
@@ -596,14 +596,16 @@ export async function handleCheckBids(
         const gpuFilteredBids: typeof safeBids = []
         const bidderModels: Array<{ provider: string; model: string | null }> = []
         for (const bid of safeBids) {
-          const model = await resolveProviderGpuModel(
+          // Use the verified-set-aware resolver: a provider with multiple
+          // GPUs (e.g. h100+a100) should pass an a100-only filter.
+          const matched = await providerHasAcceptableGpu(
             bid.bidId.provider,
-            deployment.dseq,
+            acceptable,
             prisma,
-            deploymentId
+            deploymentId,
           )
-          bidderModels.push({ provider: bid.bidId.provider, model })
-          if (model && acceptable.has(model.toLowerCase())) {
+          bidderModels.push({ provider: bid.bidId.provider, model: matched })
+          if (matched) {
             gpuFilteredBids.push(bid)
           }
         }
@@ -717,52 +719,117 @@ export async function handleCheckBids(
   }
 }
 
-// ── Helper: resolve provider GPU model from on-chain attributes ───────
+// ── Helper: resolve provider GPU model(s) ─────────────────────────────
 
-async function resolveProviderGpuModel(
+/**
+ * Return ALL GPU models a provider exposes — verified-set first
+ * (compute_provider.gpuModels), chain-attributes second.
+ *
+ * Why "all" and not "first": providers commonly host more than one GPU
+ * (e.g. an `h100 + a100` rig). The previous `resolveProviderGpuModel`
+ * walked the chain attributes and returned only the first match, which
+ * caused the policy filter to reject perfectly valid bids — e.g. a
+ * provider with both H100 and A100 would resolve to `h100`, fail an
+ * `acceptableGpuModels=['a100']` filter, and the deployment would die
+ * even though the provider could honour the request. See
+ * 2026-04-19 incident for milady-gateway/A100.
+ *
+ * Lookup order:
+ *   1. `compute_provider.gpuModels` (populated by the verifier; the
+ *      authoritative set we've actually deployed against and confirmed).
+ *   2. SDL-pinned model (if our own SDL specified one, the chain
+ *      already enforced the filter — trust it).
+ *   3. ALL `capabilities/gpu/vendor/<v>/model/<m>` chain attributes
+ *      (provider-claimed; lowest trust but better than nothing).
+ *
+ * Returns lowercase model ids. Empty array means "unknown" — caller
+ * decides how to treat that (we currently reject as a safety default).
+ */
+export async function resolveProviderGpuModels(
   providerAddr: string,
-  dseq: bigint,
   prisma: PrismaClient,
-  deploymentId: string
-): Promise<string | null> {
+  deploymentId: string,
+): Promise<string[]> {
+  const result = new Set<string>()
+
   try {
-    // First try: if our SDL requests a specific (non-wildcard) model, use that.
-    // When a specific model is in the SDL, only providers with that GPU can bid,
-    // so we can trust the SDL value without querying the provider.
+    const verified = await prisma.computeProvider.findFirst({
+      where: { address: providerAddr },
+      select: { gpuModels: true },
+    })
+    if (verified?.gpuModels) {
+      for (const m of verified.gpuModels) {
+        if (m) result.add(m.toLowerCase())
+      }
+    }
+  } catch (err) {
+    log.warn(
+      { detail: err instanceof Error ? err.message : err, providerAddr },
+      'Failed to look up verified GPU models for provider',
+    )
+  }
+
+  if (result.size > 0) return Array.from(result)
+
+  try {
     const deployment = await prisma.akashDeployment.findUnique({
       where: { id: deploymentId },
       select: { sdlContent: true },
     })
     if (deployment?.sdlContent) {
       const modelMatch = deployment.sdlContent.match(
-        /gpu:[\s\S]*?model:\s*"?([^"\s]+)"?/m
+        /gpu:[\s\S]*?model:\s*"?([^"\s]+)"?/m,
       )
       const model = modelMatch?.[1]
       if (model && model !== 'nvidia' && model !== '*') {
-        return model
+        result.add(model.toLowerCase())
       }
     }
+  } catch {
+    // best-effort SDL inspection
+  }
 
-    // Fallback: query the provider's on-chain attributes for their actual GPU model.
-    // This path is used when the SDL has model: "*" (any GPU) or no model specified.
+  if (result.size > 0) return Array.from(result)
+
+  try {
     const output = await runAkashAsync(
       ['query', 'provider', 'get', providerAddr, '-o', 'json'],
-      15_000
+      15_000,
     )
-    const result = extractJson(output) as {
+    const parsed = extractJson(output) as {
       provider?: { attributes?: Array<{ key: string; value: string }> }
       attributes?: Array<{ key: string; value: string }>
     }
-    const attrs = result.attributes || result.provider?.attributes || []
-
+    const attrs = parsed.attributes || parsed.provider?.attributes || []
     for (const attr of attrs) {
       const gpuMatch = attr.key.match(
-        /capabilities\/gpu\/vendor\/(\w+)\/model\/(\w+)/
+        /capabilities\/gpu\/vendor\/(\w+)\/model\/(\w+)/,
       )
-      if (gpuMatch?.[2]) return gpuMatch[2]
+      if (gpuMatch?.[2]) result.add(gpuMatch[2].toLowerCase())
     }
   } catch (err) {
-    log.warn({ detail: err instanceof Error ? err.message : err }, `Could not resolve GPU model for provider ${providerAddr}`)
+    log.warn(
+      { detail: err instanceof Error ? err.message : err },
+      `Could not resolve GPU models for provider ${providerAddr} from chain`,
+    )
+  }
+
+  return Array.from(result)
+}
+
+/**
+ * Returns the matched acceptable model (lowercase) if the provider
+ * exposes any GPU in `acceptable`, else `null`.
+ */
+export async function providerHasAcceptableGpu(
+  providerAddr: string,
+  acceptable: Set<string>,
+  prisma: PrismaClient,
+  deploymentId: string,
+): Promise<string | null> {
+  const models = await resolveProviderGpuModels(providerAddr, prisma, deploymentId)
+  for (const m of models) {
+    if (acceptable.has(m)) return m
   }
   return null
 }
@@ -844,12 +911,19 @@ export async function handleCreateLease(
       }
     }
 
-    const gpuModel = await resolveProviderGpuModel(
+    // Persist the provider's GPU model on the deployment row for later
+    // billing/UX surfaces. The new helper returns the FULL set the
+    // provider exposes (verified DB → SDL pin → chain attrs); we pin
+    // the first match so the deployment row stays single-valued. If
+    // none of the lookup sources had data, leave the column null and
+    // the SEND_MANIFEST step proceeds — the policy filter already
+    // rejected mismatched providers upstream.
+    const providerGpuModels = await resolveProviderGpuModels(
       provider,
-      deployment.dseq,
       prisma,
-      deploymentId
+      deploymentId,
     )
+    const gpuModel = providerGpuModels[0] ?? null
 
     await prisma.akashDeployment.update({
       where: { id: deploymentId },
@@ -1215,12 +1289,16 @@ export async function finalizeDeployment(
   if (!deployment.gpuModel && deployment.provider && deployment.sdlContent) {
     const hasGpu = /gpu:/m.test(deployment.sdlContent)
     if (hasGpu) {
-      const resolved = await resolveProviderGpuModel(
+      // Backfill `gpuModel` for deployments that reached ACTIVE without
+      // one persisted (pre-SEND_MANIFEST resolver miss, legacy rows,
+      // sidebar redeploys mid-rollout). Same helper as CREATE_LEASE;
+      // pick the first model from the provider's full set.
+      const resolvedModels = await resolveProviderGpuModels(
         deployment.provider,
-        deployment.dseq,
         prisma,
-        deployment.id
+        deployment.id,
       )
+      const resolved = resolvedModels[0] ?? null
       if (resolved) gpuModelUpdate = resolved
     }
   }

--- a/src/services/queue/akashSteps.ts
+++ b/src/services/queue/akashSteps.ts
@@ -792,9 +792,17 @@ export async function resolveProviderGpuModels(
   if (result.size > 0) return Array.from(result)
 
   try {
-    const output = await runAkashAsync(
+    // `query provider get` is read-only — no signing, no wallet needed.
+    // Bypass `runAkashAsync` (which calls `getAkashEnv()` without
+    // `skipMnemonicCheck`, throwing in any environment lacking
+    // `AKASH_MNEMONIC` — including CI). Bypassing also keeps this off
+    // the wallet mutex since there's no tx to serialize.
+    const env = getAkashEnv({ skipMnemonicCheck: true })
+    log.info(`Running: akash query provider get ${providerAddr} -o json`)
+    const output = await execAsync(
+      'akash',
       ['query', 'provider', 'get', providerAddr, '-o', 'json'],
-      15_000,
+      { env, timeout: 15_000 },
     )
     const parsed = extractJson(output) as {
       provider?: { attributes?: Array<{ key: string; value: string }> }

--- a/src/services/queue/providerGpuFilter.test.ts
+++ b/src/services/queue/providerGpuFilter.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// `akashSteps.ts` pulls in heavy deps (qstash, billing, escrow). Mock
+// the narrow surface needed for the helpers under test.
+const { execAsyncMock } = vi.hoisted(() => ({ execAsyncMock: vi.fn() }))
+
+vi.mock('./asyncExec.js', () => ({ execAsync: execAsyncMock }))
+vi.mock('./qstashClient.js', () => ({
+  isQStashEnabled: () => false,
+  publishJob: vi.fn(),
+}))
+vi.mock('../billing/escrowService.js', () => ({
+  getEscrowService: () => ({ createEscrow: vi.fn() }),
+}))
+vi.mock('../billing/billingApiClient.js', () => ({
+  getBillingApiClient: () => ({ getOrgBilling: vi.fn(), getOrgMarkup: vi.fn() }),
+}))
+
+import {
+  providerHasAcceptableGpu,
+  resolveProviderGpuModels,
+} from './akashSteps.js'
+
+interface FakePrisma {
+  computeProvider: { findFirst: ReturnType<typeof vi.fn> }
+  akashDeployment: { findUnique: ReturnType<typeof vi.fn> }
+}
+
+function buildPrisma(opts: {
+  verifiedGpuModels?: string[] | null
+  sdlContent?: string | null
+}): FakePrisma {
+  return {
+    computeProvider: {
+      findFirst: vi.fn().mockResolvedValue(
+        opts.verifiedGpuModels === undefined
+          ? null
+          : { gpuModels: opts.verifiedGpuModels ?? [] },
+      ),
+    },
+    akashDeployment: {
+      findUnique: vi.fn().mockResolvedValue(
+        opts.sdlContent === undefined ? null : { sdlContent: opts.sdlContent ?? '' },
+      ),
+    },
+  }
+}
+
+beforeEach(() => {
+  execAsyncMock.mockReset()
+})
+
+describe('resolveProviderGpuModels', () => {
+  it('returns the verified set from compute_provider when present (multiple models)', async () => {
+    // Real-world case: provider exposes both H100 and A100. The old
+    // resolver returned only the first chain attribute (h100), causing
+    // an a100-only policy to reject this provider's bid.
+    const prisma = buildPrisma({ verifiedGpuModels: ['h100', 'a100'] })
+    const models = await resolveProviderGpuModels(
+      'akash1...',
+      prisma as never,
+      'dep-1',
+    )
+    expect(models.sort()).toEqual(['a100', 'h100'])
+    expect(prisma.akashDeployment.findUnique).not.toHaveBeenCalled()
+    expect(execAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('lowercases verified-set entries', async () => {
+    const prisma = buildPrisma({ verifiedGpuModels: ['H100', 'A100'] })
+    const models = await resolveProviderGpuModels(
+      'akash1...',
+      prisma as never,
+      'dep-1',
+    )
+    expect(models.sort()).toEqual(['a100', 'h100'])
+  })
+
+  it('falls through to SDL parsing when verified set is empty', async () => {
+    const prisma = buildPrisma({
+      verifiedGpuModels: [],
+      sdlContent: 'profiles:\n  compute:\n    svc:\n      resources:\n        gpu:\n          units: 1\n          attributes:\n            vendor:\n              nvidia:\n                - model: a100\n',
+    })
+    const models = await resolveProviderGpuModels(
+      'akash1...',
+      prisma as never,
+      'dep-1',
+    )
+    expect(models).toEqual(['a100'])
+    expect(execAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('ignores SDL when model is wildcard or vendor-only', async () => {
+    const prisma = buildPrisma({
+      verifiedGpuModels: [],
+      sdlContent: 'gpu:\n  attributes:\n    vendor:\n      nvidia:\n',
+    })
+    execAsyncMock.mockResolvedValueOnce(
+      JSON.stringify({
+        attributes: [
+          { key: 'capabilities/gpu/vendor/nvidia/model/h100', value: 'true' },
+        ],
+      }),
+    )
+    const models = await resolveProviderGpuModels(
+      'akash1...',
+      prisma as never,
+      'dep-1',
+    )
+    expect(models).toEqual(['h100'])
+  })
+
+  it('extracts ALL chain GPU attributes (multi-GPU rig)', async () => {
+    const prisma = buildPrisma({ verifiedGpuModels: [], sdlContent: null })
+    execAsyncMock.mockResolvedValueOnce(
+      JSON.stringify({
+        provider: {
+          attributes: [
+            { key: 'region', value: 'us-west' },
+            { key: 'capabilities/gpu/vendor/nvidia/model/h100', value: 'true' },
+            { key: 'capabilities/gpu/vendor/nvidia/model/a100', value: 'true' },
+            { key: 'capabilities/gpu/vendor/nvidia/model/rtx5090', value: 'true' },
+          ],
+        },
+      }),
+    )
+    const models = await resolveProviderGpuModels(
+      'akash1...',
+      prisma as never,
+      'dep-1',
+    )
+    expect(models.sort()).toEqual(['a100', 'h100', 'rtx5090'])
+  })
+
+  it('returns empty array when chain query fails', async () => {
+    const prisma = buildPrisma({ verifiedGpuModels: [], sdlContent: null })
+    execAsyncMock.mockRejectedValueOnce(new Error('chain unreachable'))
+    const models = await resolveProviderGpuModels(
+      'akash1...',
+      prisma as never,
+      'dep-1',
+    )
+    expect(models).toEqual([])
+  })
+})
+
+describe('providerHasAcceptableGpu', () => {
+  it('returns the matched model when verified set intersects acceptable (the milady-A100 case)', async () => {
+    // Provider exposes both H100 and A100; user's policy demands A100.
+    // Before the fix this returned null; now it returns 'a100'.
+    const prisma = buildPrisma({ verifiedGpuModels: ['h100', 'a100'] })
+    const matched = await providerHasAcceptableGpu(
+      'akash1...',
+      new Set(['a100']),
+      prisma as never,
+      'dep-1',
+    )
+    expect(matched).toBe('a100')
+  })
+
+  it('returns null when none of the provider GPUs are acceptable', async () => {
+    const prisma = buildPrisma({ verifiedGpuModels: ['rtx4090', 'rtx5090'] })
+    const matched = await providerHasAcceptableGpu(
+      'akash1...',
+      new Set(['a100', 'h200']),
+      prisma as never,
+      'dep-1',
+    )
+    expect(matched).toBeNull()
+  })
+
+  it('matches when policy contains multiple acceptable models and provider has any of them', async () => {
+    const prisma = buildPrisma({ verifiedGpuModels: ['rtx5090'] })
+    const matched = await providerHasAcceptableGpu(
+      'akash1...',
+      new Set(['a100', 'h200', 'rtx5090']),
+      prisma as never,
+      'dep-1',
+    )
+    expect(matched).toBe('rtx5090')
+  })
+})

--- a/src/templates/sdl-ceiling.test.ts
+++ b/src/templates/sdl-ceiling.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  GPU_SDL_PRICING_CEILING_UACT,
+  NON_GPU_SDL_PRICING_CEILING_UACT,
+  generateCompositeSDL,
+  generateSDLFromTemplate,
+  resolveSdlPricingUact,
+} from './sdl.js'
+import type { ResolvedComponent } from './sdl.js'
+import type { Template } from './schema.js'
+
+const baseTemplate: Template = {
+  id: 'gpu-test',
+  name: 'GPU Test',
+  description: 'fixture',
+  category: 'AI_ML',
+  tags: [],
+  icon: '',
+  repoUrl: '',
+  dockerImage: 'ghcr.io/test/gpu:1',
+  serviceType: 'VM',
+  envVars: [],
+  resources: {
+    cpu: 1,
+    memory: '1Gi',
+    storage: '1Gi',
+    gpu: { units: 1, vendor: 'nvidia', model: 'a100' },
+  },
+  ports: [{ port: 80, as: 80, global: true }],
+  pricingUakt: 2000,
+}
+
+describe('resolveSdlPricingUact', () => {
+  it('returns GPU_SDL_PRICING_CEILING_UACT for GPU deploys regardless of template default', () => {
+    expect(resolveSdlPricingUact(true, 2000)).toBe(GPU_SDL_PRICING_CEILING_UACT)
+    expect(resolveSdlPricingUact(true, undefined)).toBe(GPU_SDL_PRICING_CEILING_UACT)
+    expect(resolveSdlPricingUact(true, 100)).toBe(GPU_SDL_PRICING_CEILING_UACT)
+  })
+
+  it('returns the template default for non-GPU deploys', () => {
+    expect(resolveSdlPricingUact(false, 1500)).toBe(1500)
+  })
+
+  it('falls back to 1000 when template has no pricingUakt and no GPU', () => {
+    expect(resolveSdlPricingUact(false, undefined)).toBe(NON_GPU_SDL_PRICING_CEILING_UACT)
+    expect(resolveSdlPricingUact(false, 0)).toBe(NON_GPU_SDL_PRICING_CEILING_UACT)
+  })
+})
+
+describe('generateSDLFromTemplate — pricing ceiling', () => {
+  it('emits GPU_SDL_PRICING_CEILING_UACT for GPU templates regardless of template.pricingUakt', () => {
+    const sdl = generateSDLFromTemplate(baseTemplate, { serviceName: 'svc' })
+    expect(sdl).toContain(`amount: ${GPU_SDL_PRICING_CEILING_UACT}`)
+    expect(sdl).not.toContain('amount: 2000')
+  })
+
+  it('respects template.pricingUakt when GPU is explicitly disabled via override', () => {
+    const sdl = generateSDLFromTemplate(baseTemplate, {
+      serviceName: 'svc',
+      resourceOverrides: { gpu: null },
+    })
+    expect(sdl).toContain('amount: 2000')
+    expect(sdl).not.toContain(`amount: ${GPU_SDL_PRICING_CEILING_UACT}`)
+  })
+
+  it('uses GPU ceiling when GPU is added via override on a non-GPU template', () => {
+    const noGpuTemplate: Template = {
+      ...baseTemplate,
+      resources: { cpu: 1, memory: '1Gi', storage: '1Gi' },
+      pricingUakt: 500,
+    }
+    const sdl = generateSDLFromTemplate(noGpuTemplate, {
+      serviceName: 'svc',
+      resourceOverrides: {
+        gpu: { units: 1, vendor: 'nvidia', model: 'h200' },
+      },
+    })
+    expect(sdl).toContain(`amount: ${GPU_SDL_PRICING_CEILING_UACT}`)
+  })
+
+  it('falls back to 1000 for plain non-GPU template with no pricingUakt', () => {
+    const minimalTemplate: Template = {
+      ...baseTemplate,
+      resources: { cpu: 1, memory: '1Gi', storage: '1Gi' },
+      pricingUakt: undefined,
+    }
+    const sdl = generateSDLFromTemplate(minimalTemplate, { serviceName: 'svc' })
+    expect(sdl).toContain('amount: 1000')
+  })
+})
+
+describe('generateCompositeSDL — per-component pricing ceiling', () => {
+  it('uses GPU ceiling for GPU components and template pricing for non-GPU components', () => {
+    const components: ResolvedComponent[] = [
+      {
+        id: 'gpu-svc',
+        sdlServiceName: 'gpu-svc',
+        dockerImage: 'ghcr.io/test/gpu:1',
+        resources: {
+          cpu: 1,
+          memory: '1Gi',
+          storage: '1Gi',
+          gpu: { units: 1, vendor: 'nvidia', model: 'a100' },
+        },
+        ports: [{ port: 80, as: 80, global: true }],
+        envVars: [],
+        persistentStorage: [],
+        pricingUakt: 2000,
+        internalOnly: false,
+        resolvedEnv: {},
+      },
+      {
+        id: 'db-svc',
+        sdlServiceName: 'db-svc',
+        dockerImage: 'postgres:16',
+        resources: { cpu: 1, memory: '512Mi', storage: '1Gi' },
+        ports: [{ port: 5432, as: 5432, global: false }],
+        envVars: [],
+        persistentStorage: [],
+        pricingUakt: 800,
+        internalOnly: true,
+        resolvedEnv: {},
+      },
+    ]
+    const sdl = generateCompositeSDL(components)
+    expect(sdl).toContain(`gpu-svc:\n          denom: uact\n          amount: ${GPU_SDL_PRICING_CEILING_UACT}`)
+    expect(sdl).toContain(`db-svc:\n          denom: uact\n          amount: 800`)
+  })
+})

--- a/src/templates/sdl.ts
+++ b/src/templates/sdl.ts
@@ -30,6 +30,51 @@ function generateBase64Secret(len = 32): string {
 }
 
 /**
+ * Hard-coded SDL pricing ceiling (uact/block) used unconditionally for
+ * any deployment that requests a GPU. We deliberately do NOT cap the
+ * GPU SDL ceiling against historical bid data — premium GPUs (A100,
+ * H200, PRO6000SE, B200, etc.) routinely bid above static template
+ * defaults, and capping the SDL is the difference between "providers
+ * bid and we pick the cheapest" vs "deployment dies in WAITING_BIDS
+ * with no money owed and a confused user".
+ *
+ * Why 1_000_000 (≈ 1 ACT/block):
+ *   - The bid-probe rollup discards any observation ≥ 50_000 uact
+ *     (`MAX_PROBE_BID_UACT` in `gpuBidProbe.ts`), so percentile data
+ *     is never poisoned by ceiling-bidders against this offer.
+ *   - 1 ACT/block is ~$14k/day raw — well above any sane GPU price,
+ *     small enough that even a worst-case provider colluding to bid
+ *     the ceiling can't drain more than the per-deploy deposit before
+ *     the post-lease top-up loop notices.
+ *   - The bid-selection logic in `akashSteps.handleCheckBids` only
+ *     accepts bids from preferred (verified) providers, and the per-
+ *     org `assertOrgHourlyCost` guard caps daily spend regardless of
+ *     bid price. So this ceiling is safety-belt, not the seat belt.
+ *
+ * Non-GPU deploys keep their template-level `pricingUakt` (or 1000)
+ * because non-GPU bid prices are tightly clustered and a high ceiling
+ * adds no value while making cost predictability worse.
+ */
+export const GPU_SDL_PRICING_CEILING_UACT = 1_000_000
+
+/** Default SDL ceiling for non-GPU deploys (uact/block). */
+export const NON_GPU_SDL_PRICING_CEILING_UACT = 1_000
+
+/**
+ * Resolve the SDL `pricing.amount` for a deployment. GPU deploys get
+ * the unconditional `GPU_SDL_PRICING_CEILING_UACT`; non-GPU deploys
+ * fall through to the template's intent (or 1000).
+ */
+export function resolveSdlPricingUact(
+  hasGpu: boolean,
+  templatePricingUakt?: number,
+): number {
+  if (hasGpu) return GPU_SDL_PRICING_CEILING_UACT
+  if (templatePricingUakt && templatePricingUakt > 0) return templatePricingUakt
+  return NON_GPU_SDL_PRICING_CEILING_UACT
+}
+
+/**
  * Generate an Akash SDL from a template + user configuration overrides.
  * If the template has a `customSdl`, uses it directly (with placeholder
  * replacement and env overrides) instead of auto-generating.
@@ -43,8 +88,6 @@ export function generateSDLFromTemplate(
   if (template.customSdl) {
     return resolveCustomSdl(template, config, serviceName)
   }
-
-  const pricingUakt = template.pricingUakt || 1000
 
   // ── Merge env vars: template defaults + user overrides ──────
   const envLines = buildEnvLines(template, config?.envOverrides)
@@ -60,6 +103,13 @@ export function generateSDLFromTemplate(
     config?.resourceOverrides?.gpu === null
       ? undefined
       : (config?.resourceOverrides?.gpu ?? template.resources.gpu)
+
+  // SDL pricing ceiling: GPU deploys get the unconditional high cap so
+  // every honest provider can bid (the bid-selection layer picks the
+  // cheapest preferred bid). Non-GPU deploys keep `template.pricingUakt`.
+  // The historical `Uakt` field name is a misnomer post-BME (denom is
+  // `uact`), kept for backward compatibility with template definitions.
+  const pricingUakt = resolveSdlPricingUact(!!gpu, template.pricingUakt)
 
   // ── Ports / expose ──────────────────────────────────────────
   const exposeBlock = template.ports
@@ -488,11 +538,16 @@ ${storageLines.join('\n')}`
     .join('\n\n')
 
   // ── Placement / pricing ───────────────────────────────────────
+  // Each component picks its own ceiling: GPU components get the
+  // unconditional high cap (same rationale as `generateSDLFromTemplate`)
+  // so multi-service deployments with one GPU service don't get
+  // bid-killed by a stale per-component `pricingUakt`. Non-GPU
+  // components keep their template default.
   const pricingLines = components
-    .map(
-      c =>
-        `        ${c.sdlServiceName}:\n          denom: uact\n          amount: ${c.pricingUakt}`
-    )
+    .map(c => {
+      const amount = resolveSdlPricingUact(!!c.resources.gpu, c.pricingUakt)
+      return `        ${c.sdlServiceName}:\n          denom: uact\n          amount: ${amount}`
+    })
     .join('\n')
 
   // Multi-service deployments (especially with persistent storage) already


### PR DESCRIPTION
## Summary

Fixes the GPU-deploy bugs from the 2026-04-19 fix-pack the right way after the audit found the previous attempt was bypassed for the catalog-deploy path AND left two `tsc` compile errors that vitest hid.

### What changed

- **Drop the dynamic `resolvePricingCeilingUact`** — it was bypassed by the catalog-deploy path (`deployFromTemplate` GraphQL mutation builds SDL via `generateSDLFromTemplate` directly, never reaches the orchestrator-side resolver where the dynamic lookup lived). Replace with a hard-coded `GPU_SDL_PRICING_CEILING_UACT = 1_000_000` (1 ACT/block ≈ $14k/day raw) emitted unconditionally for any GPU-bearing SDL across all four paths: `generateSDLFromTemplate`, `generateCompositeSDL`, `orchestrator.generateCustomDockerSDL`, `providerVerification` (via `generateSDLFromTemplate`).
- **Fix B1: orphan `resolveProviderGpuModel` (singular) calls** at `akashSteps.ts:914` (`handleCreateLease`) and `:1285` (`handleSendManifest`). Both now use `resolveProviderGpuModels(...)[0] ?? null` for the persisted single-valued `AkashDeployment.gpuModel` field. The function the previous diff claimed to use was deleted in the same diff that introduced these calls — `tsc` would have caught it but vitest doesn't type-check.
- **Delete** `pricingCeilingResolver.ts` and its test (no longer needed).
- **New tests** (`src/templates/sdl-ceiling.test.ts`, 8 cases) pin GPU/non-GPU ceiling behaviour on both single + composite paths.

### Why pin a high constant instead of dynamic

Akash bid prices for premium GPUs (A100, H200, PRO6000SE, B200) routinely exceed static template defaults like `pricingUakt: 2000`. A dynamic resolver depending on `gpu_price_summary` introduces a feedback loop, needs caching, has tunable knobs (safety multiplier, window days), and was provably bypassed for the path where the bug actually lived. A hard ceiling at 1M uact/block gets out of the way completely; the per-org `assertOrgHourlyCost` guard caps actual spend regardless of bid price; the bid-selection layer picks the cheapest preferred bid. The probe rollup discards observations ≥ `MAX_PROBE_BID_UACT (50_000)` so percentile data isn't poisoned by ceiling-bidders.

### Files

| File | Change |
|------|--------|
| `src/templates/sdl.ts` | + `GPU_SDL_PRICING_CEILING_UACT`, `resolveSdlPricingUact`; both `generateSDLFromTemplate` and `generateCompositeSDL` use it |
| `src/services/akash/orchestrator.ts` | Drop dynamic resolver call; `generateCustomDockerSDL` drops `pricingCeilingUact` param |
| `src/services/queue/akashSteps.ts` | B1 fix at `handleCreateLease` + `handleSendManifest` |
| `src/services/providers/pricingCeilingResolver{.ts,.test.ts}` | Deleted |
| `src/templates/sdl-ceiling.test.ts` | New (8 cases) |
| `src/services/queue/providerGpuFilter.test.ts` | Pre-existing from prior fix-pack, retained (tests `resolveProviderGpuModels` + `providerHasAcceptableGpu`) |

## Test plan

- [x] `npx tsc --noEmit` exits 0
- [x] `npx vitest run` passes (59 files, 751 tests)
- [x] `git grep -n 'resolveProviderGpuModel\b' src` returns zero singular references
- [ ] After deploy: catalog-deploy a milady-gateway with H200 → SDL contains `amount: 1000000`, deployment reaches `ACTIVE` with model persisted
- [ ] Pair-PR: web-app `fix/gpu-deploy-range-label-and-amd`

## Operational notes

- Deploy this BEFORE the web-app PR (the SDL ceiling must be in place before the new client behaviour rolls out).
- No DB migrations, no env-var changes, no configmap changes.
- Rollback: pure code revert; non-GPU deploys are untouched throughout.

See `admin/cloud/docs/AF_HANDOFF_2026-04-19_GPU_DEPLOY_FIXES.md` for the full audit-driven rewrite of the handoff doc.

Made with [Cursor](https://cursor.com)