### PR TITLE
bypass wallet-mnemonic gate for read-only `query provider get`

### DIFF
--- a/src/services/akash/orchestrator.ts
+++ b/src/services/akash/orchestrator.ts
@@ -24,6 +24,7 @@ import { getBillingApiClient } from '../billing/billingApiClient.js'
 import { createLogger } from '../../lib/logger.js'
 import { withWalletLock, isWalletTx } from './walletMutex.js'
 import type { TemplateGpu } from '../../templates/index.js'
+import { resolveSdlPricingUact } from '../../templates/sdl.js'
 
 const log = createLogger('akash-orchestrator')
 
@@ -1380,6 +1381,10 @@ export class AkashOrchestrator {
           { templateId: service.templateId, hasResourceOverrides: !!resourceOverrides },
           `Generating SDL from template '${service.templateId}' for service '${service.slug}'`
         )
+        // SDL ceiling for GPU deploys is unconditional (see
+        // `templates/sdl.ts:GPU_SDL_PRICING_CEILING_UACT`). No
+        // dynamic-pricing lookup needed — providers bid, the bid-
+        // selection layer picks the cheapest preferred bid.
         return generateSDLFromTemplate(template, {
           serviceName: service.slug,
           resourceOverrides: resourceOverrides
@@ -1415,7 +1420,7 @@ export class AkashOrchestrator {
         effectiveImage,
         port,
         resourceOverrides,
-        parsedVolumes
+        parsedVolumes,
       )
     }
 
@@ -1556,7 +1561,7 @@ export class AkashOrchestrator {
       storage?: string
       gpu?: { units: number; vendor: string; model?: string } | null
     },
-    volumes: ServiceVolume[] = []
+    volumes: ServiceVolume[] = [],
   ): string {
     const needsKeepAlive = /^(ubuntu|debian|alpine|centos|fedora|busybox|amazonlinux|rockylinux|almalinux)(:|$)/i.test(image)
 
@@ -1645,7 +1650,7 @@ ${storageProfile}${gpuBlock}
       pricing:
         ${name}:
           denom: uact
-          amount: ${gpu && gpu.units > 0 ? 10000 : 1000}
+          amount: ${resolveSdlPricingUact(!!(gpu && gpu.units > 0))}
 
 deployment:
   ${name}:

--- a/src/services/queue/akashSteps.ts
+++ b/src/services/queue/akashSteps.ts
@@ -596,14 +596,16 @@ export async function handleCheckBids(
         const gpuFilteredBids: typeof safeBids = []
         const bidderModels: Array<{ provider: string; model: string | null }> = []
         for (const bid of safeBids) {
-          const model = await resolveProviderGpuModel(
+          // Use the verified-set-aware resolver: a provider with multiple
+          // GPUs (e.g. h100+a100) should pass an a100-only filter.
+          const matched = await providerHasAcceptableGpu(
             bid.bidId.provider,
-            deployment.dseq,
+            acceptable,
             prisma,
-            deploymentId
+            deploymentId,
           )
-          bidderModels.push({ provider: bid.bidId.provider, model })
-          if (model && acceptable.has(model.toLowerCase())) {
+          bidderModels.push({ provider: bid.bidId.provider, model: matched })
+          if (matched) {
             gpuFilteredBids.push(bid)
           }
         }
@@ -717,52 +719,117 @@ export async function handleCheckBids(
   }
 }
 
-// ── Helper: resolve provider GPU model from on-chain attributes ───────
+// ── Helper: resolve provider GPU model(s) ─────────────────────────────
 
-async function resolveProviderGpuModel(
+/**
+ * Return ALL GPU models a provider exposes — verified-set first
+ * (compute_provider.gpuModels), chain-attributes second.
+ *
+ * Why "all" and not "first": providers commonly host more than one GPU
+ * (e.g. an `h100 + a100` rig). The previous `resolveProviderGpuModel`
+ * walked the chain attributes and returned only the first match, which
+ * caused the policy filter to reject perfectly valid bids — e.g. a
+ * provider with both H100 and A100 would resolve to `h100`, fail an
+ * `acceptableGpuModels=['a100']` filter, and the deployment would die
+ * even though the provider could honour the request. See
+ * 2026-04-19 incident for milady-gateway/A100.
+ *
+ * Lookup order:
+ *   1. `compute_provider.gpuModels` (populated by the verifier; the
+ *      authoritative set we've actually deployed against and confirmed).
+ *   2. SDL-pinned model (if our own SDL specified one, the chain
+ *      already enforced the filter — trust it).
+ *   3. ALL `capabilities/gpu/vendor/<v>/model/<m>` chain attributes
+ *      (provider-claimed; lowest trust but better than nothing).
+ *
+ * Returns lowercase model ids. Empty array means "unknown" — caller
+ * decides how to treat that (we currently reject as a safety default).
+ */
+export async function resolveProviderGpuModels(
   providerAddr: string,
-  dseq: bigint,
   prisma: PrismaClient,
-  deploymentId: string
-): Promise<string | null> {
+  deploymentId: string,
+): Promise<string[]> {
+  const result = new Set<string>()
+
   try {
-    // First try: if our SDL requests a specific (non-wildcard) model, use that.
-    // When a specific model is in the SDL, only providers with that GPU can bid,
-    // so we can trust the SDL value without querying the provider.
+    const verified = await prisma.computeProvider.findFirst({
+      where: { address: providerAddr },
+      select: { gpuModels: true },
+    })
+    if (verified?.gpuModels) {
+      for (const m of verified.gpuModels) {
+        if (m) result.add(m.toLowerCase())
+      }
+    }
+  } catch (err) {
+    log.warn(
+      { detail: err instanceof Error ? err.message : err, providerAddr },
+      'Failed to look up verified GPU models for provider',
+    )
+  }
+
+  if (result.size > 0) return Array.from(result)
+
+  try {
     const deployment = await prisma.akashDeployment.findUnique({
       where: { id: deploymentId },
       select: { sdlContent: true },
     })
     if (deployment?.sdlContent) {
       const modelMatch = deployment.sdlContent.match(
-        /gpu:[\s\S]*?model:\s*"?([^"\s]+)"?/m
+        /gpu:[\s\S]*?model:\s*"?([^"\s]+)"?/m,
       )
       const model = modelMatch?.[1]
       if (model && model !== 'nvidia' && model !== '*') {
-        return model
+        result.add(model.toLowerCase())
       }
     }
+  } catch {
+    // best-effort SDL inspection
+  }
 
-    // Fallback: query the provider's on-chain attributes for their actual GPU model.
-    // This path is used when the SDL has model: "*" (any GPU) or no model specified.
+  if (result.size > 0) return Array.from(result)
+
+  try {
     const output = await runAkashAsync(
       ['query', 'provider', 'get', providerAddr, '-o', 'json'],
-      15_000
+      15_000,
     )
-    const result = extractJson(output) as {
+    const parsed = extractJson(output) as {
       provider?: { attributes?: Array<{ key: string; value: string }> }
       attributes?: Array<{ key: string; value: string }>
     }
-    const attrs = result.attributes || result.provider?.attributes || []
-
+    const attrs = parsed.attributes || parsed.provider?.attributes || []
     for (const attr of attrs) {
       const gpuMatch = attr.key.match(
-        /capabilities\/gpu\/vendor\/(\w+)\/model\/(\w+)/
+        /capabilities\/gpu\/vendor\/(\w+)\/model\/(\w+)/,
       )
-      if (gpuMatch?.[2]) return gpuMatch[2]
+      if (gpuMatch?.[2]) result.add(gpuMatch[2].toLowerCase())
     }
   } catch (err) {
-    log.warn({ detail: err instanceof Error ? err.message : err }, `Could not resolve GPU model for provider ${providerAddr}`)
+    log.warn(
+      { detail: err instanceof Error ? err.message : err },
+      `Could not resolve GPU models for provider ${providerAddr} from chain`,
+    )
+  }
+
+  return Array.from(result)
+}
+
+/**
+ * Returns the matched acceptable model (lowercase) if the provider
+ * exposes any GPU in `acceptable`, else `null`.
+ */
+export async function providerHasAcceptableGpu(
+  providerAddr: string,
+  acceptable: Set<string>,
+  prisma: PrismaClient,
+  deploymentId: string,
+): Promise<string | null> {
+  const models = await resolveProviderGpuModels(providerAddr, prisma, deploymentId)
+  for (const m of models) {
+    if (acceptable.has(m)) return m
   }
   return null
 }
@@ -844,12 +911,19 @@ export async function handleCreateLease(
       }
     }
 
-    const gpuModel = await resolveProviderGpuModel(
+    // Persist the provider's GPU model on the deployment row for later
+    // billing/UX surfaces. The new helper returns the FULL set the
+    // provider exposes (verified DB → SDL pin → chain attrs); we pin
+    // the first match so the deployment row stays single-valued. If
+    // none of the lookup sources had data, leave the column null and
+    // the SEND_MANIFEST step proceeds — the policy filter already
+    // rejected mismatched providers upstream.
+    const providerGpuModels = await resolveProviderGpuModels(
       provider,
-      deployment.dseq,
       prisma,
-      deploymentId
+      deploymentId,
     )
+    const gpuModel = providerGpuModels[0] ?? null
 
     await prisma.akashDeployment.update({
       where: { id: deploymentId },
@@ -1215,12 +1289,16 @@ export async function finalizeDeployment(
   if (!deployment.gpuModel && deployment.provider && deployment.sdlContent) {
     const hasGpu = /gpu:/m.test(deployment.sdlContent)
     if (hasGpu) {
-      const resolved = await resolveProviderGpuModel(
+      // Backfill `gpuModel` for deployments that reached ACTIVE without
+      // one persisted (pre-SEND_MANIFEST resolver miss, legacy rows,
+      // sidebar redeploys mid-rollout). Same helper as CREATE_LEASE;
+      // pick the first model from the provider's full set.
+      const resolvedModels = await resolveProviderGpuModels(
         deployment.provider,
-        deployment.dseq,
         prisma,
-        deployment.id
+        deployment.id,
       )
+      const resolved = resolvedModels[0] ?? null
       if (resolved) gpuModelUpdate = resolved
     }
   }

--- a/src/services/queue/akashSteps.ts
+++ b/src/services/queue/akashSteps.ts
@@ -792,9 +792,17 @@ export async function resolveProviderGpuModels(
   if (result.size > 0) return Array.from(result)
 
   try {
-    const output = await runAkashAsync(
+    // `query provider get` is read-only — no signing, no wallet needed.
+    // Bypass `runAkashAsync` (which calls `getAkashEnv()` without
+    // `skipMnemonicCheck`, throwing in any environment lacking
+    // `AKASH_MNEMONIC` — including CI). Bypassing also keeps this off
+    // the wallet mutex since there's no tx to serialize.
+    const env = getAkashEnv({ skipMnemonicCheck: true })
+    log.info(`Running: akash query provider get ${providerAddr} -o json`)
+    const output = await execAsync(
+      'akash',
       ['query', 'provider', 'get', providerAddr, '-o', 'json'],
-      15_000,
+      { env, timeout: 15_000 },
     )
     const parsed = extractJson(output) as {
       provider?: { attributes?: Array<{ key: string; value: string }> }

--- a/src/services/queue/providerGpuFilter.test.ts
+++ b/src/services/queue/providerGpuFilter.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// `akashSteps.ts` pulls in heavy deps (qstash, billing, escrow). Mock
+// the narrow surface needed for the helpers under test.
+const { execAsyncMock } = vi.hoisted(() => ({ execAsyncMock: vi.fn() }))
+
+vi.mock('./asyncExec.js', () => ({ execAsync: execAsyncMock }))
+vi.mock('./qstashClient.js', () => ({
+  isQStashEnabled: () => false,
+  publishJob: vi.fn(),
+}))
+vi.mock('../billing/escrowService.js', () => ({
+  getEscrowService: () => ({ createEscrow: vi.fn() }),
+}))
+vi.mock('../billing/billingApiClient.js', () => ({
+  getBillingApiClient: () => ({ getOrgBilling: vi.fn(), getOrgMarkup: vi.fn() }),
+}))
+
+import {
+  providerHasAcceptableGpu,
+  resolveProviderGpuModels,
+} from './akashSteps.js'
+
+interface FakePrisma {
+  computeProvider: { findFirst: ReturnType<typeof vi.fn> }
+  akashDeployment: { findUnique: ReturnType<typeof vi.fn> }
+}
+
+function buildPrisma(opts: {
+  verifiedGpuModels?: string[] | null
+  sdlContent?: string | null
+}): FakePrisma {
+  return {
+    computeProvider: {
+      findFirst: vi.fn().mockResolvedValue(
+        opts.verifiedGpuModels === undefined
+          ? null
+          : { gpuModels: opts.verifiedGpuModels ?? [] },
+      ),
+    },
+    akashDeployment: {
+      findUnique: vi.fn().mockResolvedValue(
+        opts.sdlContent === undefined ? null : { sdlContent: opts.sdlContent ?? '' },
+      ),
+    },
+  }
+}
+
+beforeEach(() => {
+  execAsyncMock.mockReset()
+})
+
+describe('resolveProviderGpuModels', () => {
+  it('returns the verified set from compute_provider when present (multiple models)', async () => {
+    // Real-world case: provider exposes both H100 and A100. The old
+    // resolver returned only the first chain attribute (h100), causing
+    // an a100-only policy to reject this provider's bid.
+    const prisma = buildPrisma({ verifiedGpuModels: ['h100', 'a100'] })
+    const models = await resolveProviderGpuModels(
+      'akash1...',
+      prisma as never,
+      'dep-1',
+    )
+    expect(models.sort()).toEqual(['a100', 'h100'])
+    expect(prisma.akashDeployment.findUnique).not.toHaveBeenCalled()
+    expect(execAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('lowercases verified-set entries', async () => {
+    const prisma = buildPrisma({ verifiedGpuModels: ['H100', 'A100'] })
+    const models = await resolveProviderGpuModels(
+      'akash1...',
+      prisma as never,
+      'dep-1',
+    )
+    expect(models.sort()).toEqual(['a100', 'h100'])
+  })
+
+  it('falls through to SDL parsing when verified set is empty', async () => {
+    const prisma = buildPrisma({
+      verifiedGpuModels: [],
+      sdlContent: 'profiles:\n  compute:\n    svc:\n      resources:\n        gpu:\n          units: 1\n          attributes:\n            vendor:\n              nvidia:\n                - model: a100\n',
+    })
+    const models = await resolveProviderGpuModels(
+      'akash1...',
+      prisma as never,
+      'dep-1',
+    )
+    expect(models).toEqual(['a100'])
+    expect(execAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('ignores SDL when model is wildcard or vendor-only', async () => {
+    const prisma = buildPrisma({
+      verifiedGpuModels: [],
+      sdlContent: 'gpu:\n  attributes:\n    vendor:\n      nvidia:\n',
+    })
+    execAsyncMock.mockResolvedValueOnce(
+      JSON.stringify({
+        attributes: [
+          { key: 'capabilities/gpu/vendor/nvidia/model/h100', value: 'true' },
+        ],
+      }),
+    )
+    const models = await resolveProviderGpuModels(
+      'akash1...',
+      prisma as never,
+      'dep-1',
+    )
+    expect(models).toEqual(['h100'])
+  })
+
+  it('extracts ALL chain GPU attributes (multi-GPU rig)', async () => {
+    const prisma = buildPrisma({ verifiedGpuModels: [], sdlContent: null })
+    execAsyncMock.mockResolvedValueOnce(
+      JSON.stringify({
+        provider: {
+          attributes: [
+            { key: 'region', value: 'us-west' },
+            { key: 'capabilities/gpu/vendor/nvidia/model/h100', value: 'true' },
+            { key: 'capabilities/gpu/vendor/nvidia/model/a100', value: 'true' },
+            { key: 'capabilities/gpu/vendor/nvidia/model/rtx5090', value: 'true' },
+          ],
+        },
+      }),
+    )
+    const models = await resolveProviderGpuModels(
+      'akash1...',
+      prisma as never,
+      'dep-1',
+    )
+    expect(models.sort()).toEqual(['a100', 'h100', 'rtx5090'])
+  })
+
+  it('returns empty array when chain query fails', async () => {
+    const prisma = buildPrisma({ verifiedGpuModels: [], sdlContent: null })
+    execAsyncMock.mockRejectedValueOnce(new Error('chain unreachable'))
+    const models = await resolveProviderGpuModels(
+      'akash1...',
+      prisma as never,
+      'dep-1',
+    )
+    expect(models).toEqual([])
+  })
+})
+
+describe('providerHasAcceptableGpu', () => {
+  it('returns the matched model when verified set intersects acceptable (the milady-A100 case)', async () => {
+    // Provider exposes both H100 and A100; user's policy demands A100.
+    // Before the fix this returned null; now it returns 'a100'.
+    const prisma = buildPrisma({ verifiedGpuModels: ['h100', 'a100'] })
+    const matched = await providerHasAcceptableGpu(
+      'akash1...',
+      new Set(['a100']),
+      prisma as never,
+      'dep-1',
+    )
+    expect(matched).toBe('a100')
+  })
+
+  it('returns null when none of the provider GPUs are acceptable', async () => {
+    const prisma = buildPrisma({ verifiedGpuModels: ['rtx4090', 'rtx5090'] })
+    const matched = await providerHasAcceptableGpu(
+      'akash1...',
+      new Set(['a100', 'h200']),
+      prisma as never,
+      'dep-1',
+    )
+    expect(matched).toBeNull()
+  })
+
+  it('matches when policy contains multiple acceptable models and provider has any of them', async () => {
+    const prisma = buildPrisma({ verifiedGpuModels: ['rtx5090'] })
+    const matched = await providerHasAcceptableGpu(
+      'akash1...',
+      new Set(['a100', 'h200', 'rtx5090']),
+      prisma as never,
+      'dep-1',
+    )
+    expect(matched).toBe('rtx5090')
+  })
+})

--- a/src/templates/sdl-ceiling.test.ts
+++ b/src/templates/sdl-ceiling.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  GPU_SDL_PRICING_CEILING_UACT,
+  NON_GPU_SDL_PRICING_CEILING_UACT,
+  generateCompositeSDL,
+  generateSDLFromTemplate,
+  resolveSdlPricingUact,
+} from './sdl.js'
+import type { ResolvedComponent } from './sdl.js'
+import type { Template } from './schema.js'
+
+const baseTemplate: Template = {
+  id: 'gpu-test',
+  name: 'GPU Test',
+  description: 'fixture',
+  category: 'AI_ML',
+  tags: [],
+  icon: '',
+  repoUrl: '',
+  dockerImage: 'ghcr.io/test/gpu:1',
+  serviceType: 'VM',
+  envVars: [],
+  resources: {
+    cpu: 1,
+    memory: '1Gi',
+    storage: '1Gi',
+    gpu: { units: 1, vendor: 'nvidia', model: 'a100' },
+  },
+  ports: [{ port: 80, as: 80, global: true }],
+  pricingUakt: 2000,
+}
+
+describe('resolveSdlPricingUact', () => {
+  it('returns GPU_SDL_PRICING_CEILING_UACT for GPU deploys regardless of template default', () => {
+    expect(resolveSdlPricingUact(true, 2000)).toBe(GPU_SDL_PRICING_CEILING_UACT)
+    expect(resolveSdlPricingUact(true, undefined)).toBe(GPU_SDL_PRICING_CEILING_UACT)
+    expect(resolveSdlPricingUact(true, 100)).toBe(GPU_SDL_PRICING_CEILING_UACT)
+  })
+
+  it('returns the template default for non-GPU deploys', () => {
+    expect(resolveSdlPricingUact(false, 1500)).toBe(1500)
+  })
+
+  it('falls back to 1000 when template has no pricingUakt and no GPU', () => {
+    expect(resolveSdlPricingUact(false, undefined)).toBe(NON_GPU_SDL_PRICING_CEILING_UACT)
+    expect(resolveSdlPricingUact(false, 0)).toBe(NON_GPU_SDL_PRICING_CEILING_UACT)
+  })
+})
+
+describe('generateSDLFromTemplate — pricing ceiling', () => {
+  it('emits GPU_SDL_PRICING_CEILING_UACT for GPU templates regardless of template.pricingUakt', () => {
+    const sdl = generateSDLFromTemplate(baseTemplate, { serviceName: 'svc' })
+    expect(sdl).toContain(`amount: ${GPU_SDL_PRICING_CEILING_UACT}`)
+    expect(sdl).not.toContain('amount: 2000')
+  })
+
+  it('respects template.pricingUakt when GPU is explicitly disabled via override', () => {
+    const sdl = generateSDLFromTemplate(baseTemplate, {
+      serviceName: 'svc',
+      resourceOverrides: { gpu: null },
+    })
+    expect(sdl).toContain('amount: 2000')
+    expect(sdl).not.toContain(`amount: ${GPU_SDL_PRICING_CEILING_UACT}`)
+  })
+
+  it('uses GPU ceiling when GPU is added via override on a non-GPU template', () => {
+    const noGpuTemplate: Template = {
+      ...baseTemplate,
+      resources: { cpu: 1, memory: '1Gi', storage: '1Gi' },
+      pricingUakt: 500,
+    }
+    const sdl = generateSDLFromTemplate(noGpuTemplate, {
+      serviceName: 'svc',
+      resourceOverrides: {
+        gpu: { units: 1, vendor: 'nvidia', model: 'h200' },
+      },
+    })
+    expect(sdl).toContain(`amount: ${GPU_SDL_PRICING_CEILING_UACT}`)
+  })
+
+  it('falls back to 1000 for plain non-GPU template with no pricingUakt', () => {
+    const minimalTemplate: Template = {
+      ...baseTemplate,
+      resources: { cpu: 1, memory: '1Gi', storage: '1Gi' },
+      pricingUakt: undefined,
+    }
+    const sdl = generateSDLFromTemplate(minimalTemplate, { serviceName: 'svc' })
+    expect(sdl).toContain('amount: 1000')
+  })
+})
+
+describe('generateCompositeSDL — per-component pricing ceiling', () => {
+  it('uses GPU ceiling for GPU components and template pricing for non-GPU components', () => {
+    const components: ResolvedComponent[] = [
+      {
+        id: 'gpu-svc',
+        sdlServiceName: 'gpu-svc',
+        dockerImage: 'ghcr.io/test/gpu:1',
+        resources: {
+          cpu: 1,
+          memory: '1Gi',
+          storage: '1Gi',
+          gpu: { units: 1, vendor: 'nvidia', model: 'a100' },
+        },
+        ports: [{ port: 80, as: 80, global: true }],
+        envVars: [],
+        persistentStorage: [],
+        pricingUakt: 2000,
+        internalOnly: false,
+        resolvedEnv: {},
+      },
+      {
+        id: 'db-svc',
+        sdlServiceName: 'db-svc',
+        dockerImage: 'postgres:16',
+        resources: { cpu: 1, memory: '512Mi', storage: '1Gi' },
+        ports: [{ port: 5432, as: 5432, global: false }],
+        envVars: [],
+        persistentStorage: [],
+        pricingUakt: 800,
+        internalOnly: true,
+        resolvedEnv: {},
+      },
+    ]
+    const sdl = generateCompositeSDL(components)
+    expect(sdl).toContain(`gpu-svc:\n          denom: uact\n          amount: ${GPU_SDL_PRICING_CEILING_UACT}`)
+    expect(sdl).toContain(`db-svc:\n          denom: uact\n          amount: 800`)
+  })
+})

--- a/src/templates/sdl.ts
+++ b/src/templates/sdl.ts
@@ -30,6 +30,51 @@ function generateBase64Secret(len = 32): string {
 }
 
 /**
+ * Hard-coded SDL pricing ceiling (uact/block) used unconditionally for
+ * any deployment that requests a GPU. We deliberately do NOT cap the
+ * GPU SDL ceiling against historical bid data — premium GPUs (A100,
+ * H200, PRO6000SE, B200, etc.) routinely bid above static template
+ * defaults, and capping the SDL is the difference between "providers
+ * bid and we pick the cheapest" vs "deployment dies in WAITING_BIDS
+ * with no money owed and a confused user".
+ *
+ * Why 1_000_000 (≈ 1 ACT/block):
+ *   - The bid-probe rollup discards any observation ≥ 50_000 uact
+ *     (`MAX_PROBE_BID_UACT` in `gpuBidProbe.ts`), so percentile data
+ *     is never poisoned by ceiling-bidders against this offer.
+ *   - 1 ACT/block is ~$14k/day raw — well above any sane GPU price,
+ *     small enough that even a worst-case provider colluding to bid
+ *     the ceiling can't drain more than the per-deploy deposit before
+ *     the post-lease top-up loop notices.
+ *   - The bid-selection logic in `akashSteps.handleCheckBids` only
+ *     accepts bids from preferred (verified) providers, and the per-
+ *     org `assertOrgHourlyCost` guard caps daily spend regardless of
+ *     bid price. So this ceiling is safety-belt, not the seat belt.
+ *
+ * Non-GPU deploys keep their template-level `pricingUakt` (or 1000)
+ * because non-GPU bid prices are tightly clustered and a high ceiling
+ * adds no value while making cost predictability worse.
+ */
+export const GPU_SDL_PRICING_CEILING_UACT = 1_000_000
+
+/** Default SDL ceiling for non-GPU deploys (uact/block). */
+export const NON_GPU_SDL_PRICING_CEILING_UACT = 1_000
+
+/**
+ * Resolve the SDL `pricing.amount` for a deployment. GPU deploys get
+ * the unconditional `GPU_SDL_PRICING_CEILING_UACT`; non-GPU deploys
+ * fall through to the template's intent (or 1000).
+ */
+export function resolveSdlPricingUact(
+  hasGpu: boolean,
+  templatePricingUakt?: number,
+): number {
+  if (hasGpu) return GPU_SDL_PRICING_CEILING_UACT
+  if (templatePricingUakt && templatePricingUakt > 0) return templatePricingUakt
+  return NON_GPU_SDL_PRICING_CEILING_UACT
+}
+
+/**
  * Generate an Akash SDL from a template + user configuration overrides.
  * If the template has a `customSdl`, uses it directly (with placeholder
  * replacement and env overrides) instead of auto-generating.
@@ -43,8 +88,6 @@ export function generateSDLFromTemplate(
   if (template.customSdl) {
     return resolveCustomSdl(template, config, serviceName)
   }
-
-  const pricingUakt = template.pricingUakt || 1000
 
   // ── Merge env vars: template defaults + user overrides ──────
   const envLines = buildEnvLines(template, config?.envOverrides)
@@ -60,6 +103,13 @@ export function generateSDLFromTemplate(
     config?.resourceOverrides?.gpu === null
       ? undefined
       : (config?.resourceOverrides?.gpu ?? template.resources.gpu)
+
+  // SDL pricing ceiling: GPU deploys get the unconditional high cap so
+  // every honest provider can bid (the bid-selection layer picks the
+  // cheapest preferred bid). Non-GPU deploys keep `template.pricingUakt`.
+  // The historical `Uakt` field name is a misnomer post-BME (denom is
+  // `uact`), kept for backward compatibility with template definitions.
+  const pricingUakt = resolveSdlPricingUact(!!gpu, template.pricingUakt)
 
   // ── Ports / expose ──────────────────────────────────────────
   const exposeBlock = template.ports
@@ -488,11 +538,16 @@ ${storageLines.join('\n')}`
     .join('\n\n')
 
   // ── Placement / pricing ───────────────────────────────────────
+  // Each component picks its own ceiling: GPU components get the
+  // unconditional high cap (same rationale as `generateSDLFromTemplate`)
+  // so multi-service deployments with one GPU service don't get
+  // bid-killed by a stale per-component `pricingUakt`. Non-GPU
+  // components keep their template default.
   const pricingLines = components
-    .map(
-      c =>
-        `        ${c.sdlServiceName}:\n          denom: uact\n          amount: ${c.pricingUakt}`
-    )
+    .map(c => {
+      const amount = resolveSdlPricingUact(!!c.resources.gpu, c.pricingUakt)
+      return `        ${c.sdlServiceName}:\n          denom: uact\n          amount: ${amount}`
+    })
     .join('\n')
 
   // Multi-service deployments (especially with persistent storage) already


### PR DESCRIPTION
CI run on PR #199 surfaced two test failures in
`providerGpuFilter.test.ts`:

  resolveProviderGpuModels > ignores SDL when model is wildcard or vendor-only
  resolveProviderGpuModels > extracts ALL chain GPU attributes (multi-GPU rig)

Both failed because `resolveProviderGpuModels` reaches the chain-
query branch via `runAkashAsync`, which calls `getAkashEnv()`
without `skipMnemonicCheck` and throws `AKASH_MNEMONIC is not set`
in any environment lacking the mnemonic (CI, fresh dev shells).
The test mocked `execAsync` correctly but never reached it — the
env helper threw first, the catch block returned an empty array,
and tests asserted `['h100']` / `['a100','h100','rtx5090']` got
`[]`.

`query provider get` is a read-only chain query — no signing, no
wallet, no tx serialization needed. Bypass `runAkashAsync` for
this one