### PR TITLE
fix gpu probe close: parse tx code, retry on seq-mismatch, exclude in…

### DIFF
--- a/prisma/migrations/20260420130000_add_github_app_and_build_jobs/migration.sql
+++ b/prisma/migrations/20260420130000_add_github_app_and_build_jobs/migration.sql
@@ -1,0 +1,94 @@
+-- Phase: GitHub deploy (2026-04-20)
+-- Vercel-style "connect a repo, we build and ship it" flow.
+-- - GithubInstallation: one row per (org, GitHub App installation)
+-- - BuildJob: append-only history of build attempts
+-- - Service: new git-source columns (gitProvider/gitOwner/gitRepo/...)
+
+-- 1. New enum for BuildJob.status
+CREATE TYPE "BuildStatus" AS ENUM ('PENDING', 'RUNNING', 'SUCCEEDED', 'FAILED', 'CANCELED');
+
+-- 2. github_installation table
+CREATE TABLE "github_installation" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "installationId" BIGINT NOT NULL,
+    "accountLogin" TEXT NOT NULL,
+    "accountId" BIGINT NOT NULL,
+    "accountType" TEXT NOT NULL,
+    "targetType" TEXT NOT NULL,
+    "installedByUserId" TEXT,
+    "selectedRepos" JSONB,
+    "suspendedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "github_installation_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "github_installation_installationId_key" ON "github_installation"("installationId");
+CREATE INDEX "github_installation_organizationId_idx" ON "github_installation"("organizationId");
+CREATE INDEX "github_installation_accountLogin_idx" ON "github_installation"("accountLogin");
+
+ALTER TABLE "github_installation"
+    ADD CONSTRAINT "github_installation_organizationId_fkey"
+    FOREIGN KEY ("organizationId") REFERENCES "Organization"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "github_installation"
+    ADD CONSTRAINT "github_installation_installedByUserId_fkey"
+    FOREIGN KEY ("installedByUserId") REFERENCES "User"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- 3. New columns on Service for git-source deploys
+ALTER TABLE "Service"
+    ADD COLUMN "gitProvider"       TEXT,
+    ADD COLUMN "gitOwner"          TEXT,
+    ADD COLUMN "gitRepo"           TEXT,
+    ADD COLUMN "gitBranch"         TEXT,
+    ADD COLUMN "gitInstallationId" TEXT,
+    ADD COLUMN "buildCommand"      TEXT,
+    ADD COLUMN "startCommand"      TEXT,
+    ADD COLUMN "rootDirectory"     TEXT,
+    ADD COLUMN "detectedFramework" TEXT,
+    ADD COLUMN "detectedPort"      INTEGER,
+    ADD COLUMN "lastBuildSha"      TEXT,
+    ADD COLUMN "lastBuildStatus"   TEXT,
+    ADD COLUMN "lastBuildAt"       TIMESTAMP(3);
+
+CREATE INDEX "Service_gitInstallationId_idx" ON "Service"("gitInstallationId");
+CREATE INDEX "Service_gitOwner_gitRepo_idx" ON "Service"("gitOwner", "gitRepo");
+
+ALTER TABLE "Service"
+    ADD CONSTRAINT "Service_gitInstallationId_fkey"
+    FOREIGN KEY ("gitInstallationId") REFERENCES "github_installation"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- 4. build_job table
+CREATE TABLE "build_job" (
+    "id"                TEXT NOT NULL,
+    "serviceId"         TEXT NOT NULL,
+    "commitSha"         TEXT NOT NULL,
+    "commitMessage"     TEXT,
+    "branch"            TEXT NOT NULL,
+    "status"            "BuildStatus" NOT NULL DEFAULT 'PENDING',
+    "k8sJobName"        TEXT,
+    "imageTag"          TEXT,
+    "detectedFramework" TEXT,
+    "detectedPort"      INTEGER,
+    "logs"              TEXT,
+    "triggeredBy"       TEXT,
+    "startedAt"         TIMESTAMP(3),
+    "finishedAt"        TIMESTAMP(3),
+    "errorMessage"      TEXT,
+    "createdAt"         TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt"         TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "build_job_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "build_job_serviceId_idx" ON "build_job"("serviceId");
+CREATE INDEX "build_job_status_idx" ON "build_job"("status");
+CREATE INDEX "build_job_commitSha_idx" ON "build_job"("commitSha");
+
+ALTER TABLE "build_job"
+    ADD CONSTRAINT "build_job_serviceId_fkey"
+    FOREIGN KEY ("serviceId") REFERENCES "Service"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/services/providers/gpuBidProbe.test.ts
+++ b/src/services/providers/gpuBidProbe.test.ts
@@ -366,7 +366,91 @@ describe('probeOneGpuModel', () => {
     // Bids were still recorded; only the close best-effort failed (the
     // chain-orphan sweep in escrowHealthMonitor will reclaim).
     expect(result.bidsReceived).toBe(2)
+    expect(result.closed).toBe(false)
     expect(prisma.gpuBidObservation.createMany).toHaveBeenCalledOnce()
+  })
+
+  it('marks closed=true when close TX returns code 0', async () => {
+    const execCli = vi.fn(async (_bin: string, args: string[]): Promise<ExecResult> => {
+      if (args[0] === 'keys' && args[1] === 'show') return ok(KEYS_SHOW_OUT)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'create') return ok(TX_OK_WITH_DSEQ)
+      if (args[0] === 'query' && args[1] === 'market' && args[2] === 'bid' && args[3] === 'list') return ok(BIDS_EMPTY)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'close') return ok(TX_CLOSE_OK)
+      return ok('{}')
+    })
+
+    const result = await probeOneGpuModel(buildPrisma() as any, 'h100', 'nvidia', 'run-1', { execCli, sleep: fastSleep })
+
+    expect(result.dseq).toBe(424242)
+    expect(result.closed).toBe(true)
+  })
+
+  it('retries close on sequence-mismatch (code 32) and marks closed=true on eventual success', async () => {
+    // Regression: production "4 runs · $3 spent" dashboard reading came
+    // from close TXs returning CLI exit 0 with JSON code 32. The
+    // previous code only checked exit code and silently leaked the $1
+    // deposit per failed close. Now we parse the JSON code, retry on
+    // 32, and only mark closed=true after a real code-0 confirmation.
+    const TX_CLOSE_SEQ_MISMATCH = JSON.stringify({ code: 32, raw_log: 'account sequence mismatch' })
+    let closeCalls = 0
+    const execCli = vi.fn(async (_bin: string, args: string[]): Promise<ExecResult> => {
+      if (args[0] === 'keys' && args[1] === 'show') return ok(KEYS_SHOW_OUT)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'create') return ok(TX_OK_WITH_DSEQ)
+      if (args[0] === 'query' && args[1] === 'market' && args[2] === 'bid' && args[3] === 'list') return ok(BIDS_EMPTY)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'close') {
+        closeCalls++
+        if (closeCalls < 3) return ok(TX_CLOSE_SEQ_MISMATCH)
+        return ok(TX_CLOSE_OK)
+      }
+      return ok('{}')
+    })
+
+    const result = await probeOneGpuModel(buildPrisma() as any, 'h100', 'nvidia', 'run-1', { execCli, sleep: fastSleep })
+
+    expect(closeCalls).toBe(3)
+    expect(result.closed).toBe(true)
+  })
+
+  it('exhausts close retries on persistent code-32 and reports closed=false', async () => {
+    const TX_CLOSE_SEQ_MISMATCH = JSON.stringify({ code: 32, raw_log: 'account sequence mismatch' })
+    let closeCalls = 0
+    const execCli = vi.fn(async (_bin: string, args: string[]): Promise<ExecResult> => {
+      if (args[0] === 'keys' && args[1] === 'show') return ok(KEYS_SHOW_OUT)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'create') return ok(TX_OK_WITH_DSEQ)
+      if (args[0] === 'query' && args[1] === 'market' && args[2] === 'bid' && args[3] === 'list') return ok(BIDS_EMPTY)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'close') {
+        closeCalls++
+        return ok(TX_CLOSE_SEQ_MISMATCH)
+      }
+      return ok('{}')
+    })
+
+    const result = await probeOneGpuModel(buildPrisma() as any, 'h100', 'nvidia', 'run-1', { execCli, sleep: fastSleep })
+
+    expect(closeCalls).toBe(3) // TX_RETRIES = 3
+    expect(result.closed).toBe(false)
+    expect(result.dseq).toBe(424242)
+  })
+
+  it('marks closed=false when close TX returns a non-zero non-32 code (chain rejection)', async () => {
+    const TX_CLOSE_REJECT = JSON.stringify({ code: 7, raw_log: 'unauthorized' })
+    let closeCalls = 0
+    const execCli = vi.fn(async (_bin: string, args: string[]): Promise<ExecResult> => {
+      if (args[0] === 'keys' && args[1] === 'show') return ok(KEYS_SHOW_OUT)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'create') return ok(TX_OK_WITH_DSEQ)
+      if (args[0] === 'query' && args[1] === 'market' && args[2] === 'bid' && args[3] === 'list') return ok(BIDS_EMPTY)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'close') {
+        closeCalls++
+        return ok(TX_CLOSE_REJECT)
+      }
+      return ok('{}')
+    })
+
+    const result = await probeOneGpuModel(buildPrisma() as any, 'h100', 'nvidia', 'run-1', { execCli, sleep: fastSleep })
+
+    // Non-32 chain rejection breaks out of the retry loop immediately.
+    expect(closeCalls).toBe(1)
+    expect(result.closed).toBe(false)
   })
 })
 
@@ -575,6 +659,99 @@ describe('runGpuBidProbeCycle GpuProbeRun telemetry', () => {
     expect(updateArg.data.bidsCollected).toBe(0)
     expect(updateArg.data.uniqueProviders).toBe(0)
     expect(updateArg.data.completedAt).toBeInstanceOf(Date)
+  })
+
+  it('subtracts in-flight probe deposits from cycle cost (the $3-spent dashboard bug fix)', async () => {
+    // 2026-04-20 incident: probe cycle reported $1 spent per run on a
+    // dashboard showing "4 runs · $3 spent" — root cause was every
+    // failed close (deposit still in escrow, awaiting orphan sweep)
+    // contributing its full DEFAULT_DEPOSIT_UACT to the wallet-delta.
+    // Now we subtract in-flight deposits so the dashboard reflects
+    // realised gas spend, not temporarily-locked refunds.
+    const TX_CLOSE_SEQ_MISMATCH = JSON.stringify({ code: 32, raw_log: 'account sequence mismatch' })
+    const prisma = buildPrisma()
+    prisma.computeProvider.findMany.mockResolvedValue([
+      { gpuModels: ['h100', 'a100'] }, // two probes this cycle
+    ])
+
+    // Wallet drops by 2_050_000 uact across the cycle (2 deposits + gas).
+    vi.mocked(checkBalance)
+      .mockResolvedValueOnce({ uact: 100_000_000, uakt: 0, act: '100' } as any)
+      .mockResolvedValueOnce({ uact: 97_950_000, uakt: 0, act: '97.95' } as any)
+
+    // h100 closes cleanly; a100 close fails permanently (code 32 ×3).
+    let h100Close = 0
+    let a100Close = 0
+    let createCalls = 0
+    const execCli = vi.fn(async (_bin: string, args: string[]): Promise<ExecResult> => {
+      if (args[0] === 'keys' && args[1] === 'show') return ok(KEYS_SHOW_OUT)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'create') {
+        createCalls++
+        // Vary the dseq so finalisation can attribute correctly per probe.
+        const dseq = 100_000 + createCalls
+        return ok(JSON.stringify({
+          code: 0,
+          txhash: `tx${dseq}`,
+          logs: [{ events: [{ attributes: [{ key: 'dseq', value: String(dseq) }] }] }],
+        }))
+      }
+      if (args[0] === 'query' && args[1] === 'market' && args[2] === 'bid' && args[3] === 'list') {
+        return ok(BIDS_EMPTY)
+      }
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'close') {
+        // First probe (h100, dseq 100_001) succeeds; second probe (a100,
+        // dseq 100_002) fails on every attempt.
+        const dseq = args[args.indexOf('--dseq') + 1]
+        if (dseq === '100001') {
+          h100Close++
+          return ok(TX_CLOSE_OK)
+        }
+        a100Close++
+        return ok(TX_CLOSE_SEQ_MISMATCH)
+      }
+      return ok('{}')
+    })
+
+    await runGpuBidProbeCycle(prisma as any, { execCli, sleep: () => Promise.resolve() })
+
+    expect(h100Close).toBe(1)
+    expect(a100Close).toBe(3) // exhausted retries
+
+    const updateArg = prisma.gpuProbeRun.update.mock.calls[0][0]
+    // Wallet drop = 2_050_000. In-flight = 1 × 1_000_000 (a100 deposit).
+    // Realised cost = 2_050_000 - 1_000_000 = 1_050_000 uact (~$1.05).
+    // Without this fix the dashboard would report 2_050_000 (~$2.05).
+    expect(updateArg.data.costUact).toBe(1_050_000n)
+  })
+
+  it('records full wallet-delta as cost when every close succeeds (no in-flight)', async () => {
+    const prisma = buildPrisma()
+    prisma.computeProvider.findMany.mockResolvedValue([
+      { gpuModels: ['h100'] },
+    ])
+
+    vi.mocked(checkBalance)
+      .mockResolvedValueOnce({ uact: 100_000_000, uakt: 0, act: '100' } as any)
+      .mockResolvedValueOnce({ uact: 99_995_000, uakt: 0, act: '99.995' } as any)
+
+    let createCalls = 0
+    const execCli = vi.fn(async (_bin: string, args: string[]): Promise<ExecResult> => {
+      if (args[0] === 'keys' && args[1] === 'show') return ok(KEYS_SHOW_OUT)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'create') {
+        createCalls++
+        return ok(TX_OK_WITH_DSEQ)
+      }
+      if (args[0] === 'query' && args[1] === 'market' && args[2] === 'bid' && args[3] === 'list') return ok(BIDS_EMPTY)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'close') return ok(TX_CLOSE_OK)
+      return ok('{}')
+    })
+
+    await runGpuBidProbeCycle(prisma as any, { execCli, sleep: () => Promise.resolve() })
+
+    expect(createCalls).toBe(1)
+    const updateArg = prisma.gpuProbeRun.update.mock.calls[0][0]
+    // Pure gas spend, no deposit subtraction — 5_000 uact.
+    expect(updateArg.data.costUact).toBe(5_000n)
   })
 
   it('aggregates bids back into the run record when probes succeed', async () => {

--- a/src/services/providers/gpuBidProbe.ts
+++ b/src/services/providers/gpuBidProbe.ts
@@ -94,6 +94,16 @@ export interface ProbeOneResult {
   providersBidding: number
   durationMs: number
   error?: string
+  /**
+   * True if `tx deployment close` was confirmed accepted by the chain
+   * (CLI exit 0 AND `code === 0` in the JSON response). When false but
+   * `dseq` is set, the deposit is in-flight: it'll either come back via
+   * a future close attempt or be reclaimed by the orphan sweeper in
+   * `escrowHealthMonitor`. The cycle uses this to subtract in-flight
+   * deposits from "cycle cost" so the dashboard doesn't double-charge
+   * us for funds that are temporarily locked but coming back.
+   */
+  closed: boolean
 }
 
 export interface ProbeCycleSummary {
@@ -197,6 +207,7 @@ export async function probeOneGpuModel(
     bidsReceived: 0,
     providersBidding: 0,
     durationMs: 0,
+    closed: false,
   }
 
   if (!process.env.AKASH_MNEMONIC) {
@@ -386,21 +397,73 @@ export async function probeOneGpuModel(
     result.error = err instanceof Error ? err.message : String(err)
   } finally {
     if (dseq) {
-      try {
-        await lock(() =>
-          execCli('akash', [
-            'tx', 'deployment', 'close',
-            '--dseq', String(dseq),
-            '-o', 'json', '-y',
-          ])
-        )
-        log.info({ dseq, model }, 'Probe deployment closed')
-      } catch (closeErr) {
-        // Best-effort. The chain-orphan sweep in escrowHealthMonitor
-        // catches any deployment that survives this close failure.
+      // Mirror the create-flow retry shape (line ~241): parse the JSON
+      // `code` and back off on sequence-mismatch (32). Without this, a
+      // CLI exit-0 with code-32 silently leaks the $1 deposit until the
+      // hourly orphan sweeper reclaims it ~1-2h later, and the cycle's
+      // wallet-delta cost calculation over-attributes the leak as
+      // "spend" on the dashboard.
+      let lastCloseErr: string | undefined
+      for (let attempt = 1; attempt <= TX_RETRIES; attempt++) {
+        try {
+          const closeRes = await lock(() =>
+            execCli('akash', [
+              'tx', 'deployment', 'close',
+              '--dseq', String(dseq),
+              '-o', 'json', '-y',
+            ])
+          )
+          if (closeRes.exitCode !== 0) {
+            lastCloseErr = `cli exit ${closeRes.exitCode}: ${closeRes.stderr.trim().slice(0, 200)}`
+            // CLI errors here (gas estimation, RPC blip) are usually
+            // transient — retry, but don't sequence-backoff since the
+            // problem isn't the wallet sequence.
+            if (attempt < TX_RETRIES) {
+              await sleep(TX_SEQ_RETRY_DELAY_MS)
+              continue
+            }
+            break
+          }
+          let closeJson: any = {}
+          try { closeJson = extractJson(closeRes.stdout) } catch { /* treat as parse failure */ }
+          const code =
+            typeof closeJson.code === 'number'
+              ? closeJson.code
+              : parseInt(closeJson.code ?? '0', 10)
+          if (code === 32 && attempt < TX_RETRIES) {
+            // Account-sequence mismatch: the wallet mutex's settle delay
+            // wasn't long enough for the previous TX to land. Same
+            // backoff/retry strategy as the create flow above.
+            lastCloseErr = `code 32 (sequence mismatch)`
+            await sleep(TX_SEQ_RETRY_DELAY_MS)
+            continue
+          }
+          if (code !== 0) {
+            lastCloseErr = `code ${code}: ${(closeJson.raw_log || '').slice(0, 200)}`
+            break
+          }
+          result.closed = true
+          log.info({ dseq, model, attempt }, 'Probe deployment closed')
+          break
+        } catch (closeErr) {
+          lastCloseErr = closeErr instanceof Error ? closeErr.message : String(closeErr)
+          if (attempt < TX_RETRIES) {
+            await sleep(TX_SEQ_RETRY_DELAY_MS)
+            continue
+          }
+        }
+      }
+      if (!result.closed) {
+        // Best-effort exhausted. The chain-orphan sweep in
+        // escrowHealthMonitor catches any deployment that survives this
+        // close failure (deposit is ~$1 per probe; reclaim window
+        // ~ORPHAN_MIN_AGE_BLOCKS ≈ 60 min). The cycle excludes this
+        // dseq's deposit from `costUact` so the dashboard reports
+        // realised spend (gas) and surfaces the in-flight number
+        // separately.
         log.warn(
-          { dseq, model, err: closeErr instanceof Error ? closeErr.message : closeErr },
-          'Probe close failed — orphan sweep will reclaim it'
+          { dseq, model, err: lastCloseErr },
+          'Probe close failed after retries — orphan sweep will reclaim deposit',
         )
       }
     }
@@ -533,11 +596,48 @@ export async function runGpuBidProbeCycle(
 
     // Snapshot wallet after the cycle and compute spend. Floor at 0 — a
     // wallet refill mid-cycle would otherwise produce a negative cost.
+    //
+    // IMPORTANT — in-flight deposit re-attribution.
+    //   Each probe puts DEFAULT_DEPOSIT_UACT (1 ACT ≈ $1) into escrow on
+    //   `tx deployment create` and gets it back on `tx deployment close`.
+    //   When close fails (code 32 sequence-mismatch, RPC blip, etc.) the
+    //   deposit is in-flight: it'll come back via the orphan sweep in
+    //   `escrowHealthMonitor` within ~60-120 min. Without this
+    //   correction, a single failed close attributes a full $1 to the
+    //   probe cycle's "spent" number even though the money returns
+    //   shortly after — which is exactly what produced the misleading
+    //   "4 runs · $3 spent" dashboard reading on 2026-04-20.
+    //
+    //   We subtract the in-flight deposits from the wallet-delta so
+    //   `costUact` reflects realised spend (gas + truly burned funds).
+    //   The in-flight figure is logged separately for visibility; the
+    //   dashboard's totals stop double-counting refunds.
+    const inFlightDepositUact = results.reduce(
+      (acc, r) => (r.dseq && !r.closed ? acc + DEFAULT_DEPOSIT_UACT : acc),
+      0,
+    )
+    const inFlightProbes = results.filter(r => r.dseq && !r.closed).length
+
     if (balanceBefore) {
       try {
         const balanceAfter = await checkBalance()
-        costUact = BigInt(Math.max(0, balanceBefore.uact - balanceAfter.uact))
-        costUakt = BigInt(Math.max(0, balanceBefore.uakt - balanceAfter.uakt))
+        const walletDropUact = Math.max(0, balanceBefore.uact - balanceAfter.uact)
+        const walletDropUakt = Math.max(0, balanceBefore.uakt - balanceAfter.uakt)
+        const realisedUact = Math.max(0, walletDropUact - inFlightDepositUact)
+        costUact = BigInt(realisedUact)
+        costUakt = BigInt(walletDropUakt)
+        if (inFlightProbes > 0) {
+          log.info(
+            {
+              runId,
+              walletDropUact,
+              inFlightDepositUact,
+              inFlightProbes,
+              realisedUact,
+            },
+            'Cycle cost adjusted for in-flight probe deposits — orphan sweep will reclaim',
+          )
+        }
       } catch (err) {
         log.warn(
           { runId, err: err instanceof Error ? err.message : err },


### PR DESCRIPTION
The probe close TX never inspected the JSON response code, so chain
rejections with CLI exit 0 (notably code 32 account-sequence
mismatch) silently leaked the $1 deposit per probe until the orphan
sweeper reclaimed it ~1-2h later. The wallet-delta cost calculation
then attributed those temporarily-locked refunds as "spent",
producing the misleading "4 runs · $3 spent" dashboard reading.

- `probeOneGpuModel`: parse tx-code on close, retry up to TX_RETRIES
  with TX_SEQ_RETRY_DELAY_MS backoff on code 32 (mirrors create flow);
  expose new `closed: boolean` on ProbeOneResult.
- `runGpuBidProbeCycle`: subtract in-flight deposits
  (`DEFAULT_DEPOSIT_UACT × probes with dseq && !closed`) from the
  wallet-delta so costUact reflects realised gas spend, not refunds
  in transit. In-flight totals are logged for visibility.
- Tests: 5 new cases covering close happy-path, code-32 retry success,
  retry exhaustion, non-32 chain rejection short-circuit, and the
  cost-attribution math both with and without in-flight probes.