### PR TITLE
GitHub-source deploy flow + Akash gpu-probe close hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,3 +93,32 @@ OPENPROVIDER_PASSWORD=
 # Registrant contact handle from OpenProvider (e.g. AT123456-US). Required for domain purchase.
 # Find it at https://rcp.openprovider.eu → Contacts
 OPENPROVIDER_OWNER_HANDLE=
+
+# =============================================================================
+# GitHub App — "Deploy from GitHub"
+# =============================================================================
+# Register the App via infra/github-app/register.html (one-time, manifest flow).
+# All seven values come from that flow. Until they're set the GitHub deploy
+# tile in the UI shows the "not configured" state.
+GITHUB_APP_ID=
+GITHUB_APP_SLUG=
+GITHUB_APP_CLIENT_ID=
+GITHUB_APP_CLIENT_SECRET=
+GITHUB_APP_WEBHOOK_SECRET=
+# Base64 of the .pem private key GitHub gave you (so it survives K8s secrets).
+# Generate with: base64 -i path/to/private-key.pem | tr -d '\n'
+GITHUB_APP_PRIVATE_KEY_B64=
+
+# PAT (or App-installation token) with packages:write that the af-builder Job
+# uses to push the produced image to GHCR.
+GHCR_PUSH_TOKEN=
+# Optional overrides — defaults are sane.
+# GHCR_USER=alternatefutures-deploy
+# GHCR_NAMESPACE=alternatefutures
+# BUILDER_IMAGE=ghcr.io/alternatefutures/af-builder:latest
+# BUILDER_NAMESPACE=alternatefutures-builds
+# Local dev only: skip K8s Job creation, only persist the BuildJob row.
+# BUILDER_DRY_RUN=1
+# Override the URL af-builder Jobs POST status callbacks to (defaults to
+# API_BASE_URL or https://api.alternatefutures.ai).
+# API_BASE_URL=http://service-cloud-api:4000

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@cosmjs/proto-signing": "^0.38.1",
     "@graphql-tools/schema": "^10.0.29",
     "@infisical/sdk": "^4.0.6",
+    "@kubernetes/client-node": "^1.4.0",
     "@lighthouse-web3/sdk": "^0.4.3",
     "@opentelemetry/auto-instrumentations-node": "^0.71.0",
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.213.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,9 @@ importers:
       '@infisical/sdk':
         specifier: ^4.0.6
         version: 4.0.6(@aws-sdk/client-sso-oidc@3.600.0)
+      '@kubernetes/client-node':
+        specifier: ^1.4.0
+        version: 1.4.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
       '@lighthouse-web3/sdk':
         specifier: ^0.4.3
         version: 0.4.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -1492,6 +1495,21 @@ packages:
 
   '@js-sdsl/ordered-map@4.4.2':
     resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
+  '@jsep-plugin/assignment@1.3.0':
+    resolution: {integrity: sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
+  '@jsep-plugin/regex@1.0.4':
+    resolution: {integrity: sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
+  '@kubernetes/client-node@1.4.0':
+    resolution: {integrity: sha512-Zge3YvF7DJi264dU1b3wb/GmzR99JhUpqTvp+VGHfwZT+g7EOOYNScDJNZwXy9cszyIGPIs0VHr+kk8e95qqrA==}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -3300,6 +3318,9 @@ packages:
   '@types/http-proxy@1.17.17':
     resolution: {integrity: sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==}
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -3324,6 +3345,9 @@ packages:
   '@types/node-cron@3.0.11':
     resolution: {integrity: sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==}
 
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
+
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
@@ -3347,6 +3371,9 @@ packages:
 
   '@types/pg@8.15.6':
     resolution: {integrity: sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==}
+
+  '@types/stream-buffers@3.0.8':
+    resolution: {integrity: sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==}
 
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
@@ -3817,9 +3844,58 @@ packages:
   axios@1.15.0:
     resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
+  b4a@1.8.0:
+    resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.8.2:
+    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.1:
+    resolution: {integrity: sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-os@3.8.7:
+    resolution: {integrity: sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==}
+    engines: {bare: '>=1.14.0'}
+
+  bare-path@3.0.0:
+    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
+
+  bare-stream@2.13.0:
+    resolution: {integrity: sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.1:
+    resolution: {integrity: sha512-fZapLWNB25gS+etK27NV9KgBNXgo2yeYHuj+OyPblQd6GYAE3JVy6aKxszMV5jhGGFwraXQKA5fldvf3lMyEqw==}
 
   base-x@3.0.11:
     resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
@@ -4604,6 +4680,9 @@ packages:
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -5000,6 +5079,10 @@ packages:
     resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
+  hpagent@1.2.0:
+    resolution: {integrity: sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==}
+    engines: {node: '>=14'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -5107,6 +5190,10 @@ packages:
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
+  ip-address@10.1.0:
+    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
 
   ipfs-core-types@0.14.1:
     resolution: {integrity: sha512-4ujF8NlM9bYi2I6AIqPP9wfGGX0x/gRCkMoFdOQfxxrFg6HcAdfS+0/irK8mp4e7znOHWReOHeWqCGw+dAPwsw==}
@@ -5361,6 +5448,9 @@ packages:
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -5386,6 +5476,10 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsep@1.4.0:
+    resolution: {integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==}
+    engines: {node: '>= 10.16.0'}
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -5442,6 +5536,11 @@ packages:
   jsonparse@1.3.1:
     resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
     engines: {'0': node >= 0.2.0}
+
+  jsonpath-plus@10.4.0:
+    resolution: {integrity: sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
@@ -5868,6 +5967,9 @@ packages:
     engines: {node: ^14.16.0 || >=16.10.0}
     hasBin: true
 
+  oauth4webapi@3.8.5:
+    resolution: {integrity: sha512-A8jmyUckVhRJj5lspguklcl90Ydqk61H3dcU0oLhH3Yv13KpAliKTt5hknpGGPZSSfOwGyraNEFmofDYH+1kSg==}
+
   obj-multiplex@1.0.0:
     resolution: {integrity: sha512-0GNJAOsHoBHeNTvl5Vt6IWnpUEcc3uSRxzBri7EDyIcMgYvnY2JL2qdeV5zTMjWQX5OHcD5amcW2HFfDh0gjIA==}
 
@@ -5926,6 +6028,9 @@ packages:
 
   openapi-typescript-helpers@0.0.15:
     resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
+
+  openid-client@6.8.3:
+    resolution: {integrity: sha512-AoY/NaN9esS3+xvHInFSK0g3skSfeE0uqQAKRj4rB6/GsBIvzwTUaYo9+HcqpKIaP0dP85p5W07hayKgS4GAeA==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -6458,6 +6563,9 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rfc4648@1.5.4:
+    resolution: {integrity: sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==}
+
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
@@ -6593,6 +6701,10 @@ packages:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
 
@@ -6603,6 +6715,14 @@ packages:
   socket.io-parser@4.2.6:
     resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
     engines: {node: '>=10.0.0'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.7:
+    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
   sonic-boom@2.8.0:
     resolution: {integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==}
@@ -6639,6 +6759,10 @@ packages:
     resolution: {integrity: sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  stream-buffers@3.0.3:
+    resolution: {integrity: sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==}
+    engines: {node: '>= 0.10.0'}
+
   stream-chain@2.2.5:
     resolution: {integrity: sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==}
 
@@ -6653,6 +6777,9 @@ packages:
 
   stream-to-it@0.2.4:
     resolution: {integrity: sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==}
+
+  streamx@2.25.0:
+    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
 
   strict-uri-encode@2.0.0:
     resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
@@ -6749,6 +6876,18 @@ packages:
   synckit@0.11.11:
     resolution: {integrity: sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==}
     engines: {node: ^14.18.0 || >=16.0.0}
+
+  tar-fs@3.1.2:
+    resolution: {integrity: sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==}
+
+  tar-stream@3.1.8:
+    resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
+
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   text-encoding-utf-8@1.0.2:
     resolution: {integrity: sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==}
@@ -8025,7 +8164,7 @@ snapshots:
       idb-keyval: 6.2.1
       ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
       preact: 10.28.4
-      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.2.0)
       zustand: 5.0.3(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
     transitivePeerDependencies:
       - '@types/react'
@@ -8102,7 +8241,7 @@ snapshots:
       idb-keyval: 6.2.1
       ox: 0.6.9(typescript@5.9.3)(zod@3.25.76)
       preact: 10.28.4
-      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.2.0)
       zustand: 5.0.3(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
     transitivePeerDependencies:
       - '@types/react'
@@ -8836,7 +8975,7 @@ snapshots:
     dependencies:
       '@metamask/rpc-errors': 7.0.2
       eventemitter3: 5.0.1
-      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9585,6 +9724,41 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@js-sdsl/ordered-map@4.4.2': {}
+
+  '@jsep-plugin/assignment@1.3.0(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
+  '@jsep-plugin/regex@1.0.4(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
+  '@kubernetes/client-node@1.4.0(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@types/js-yaml': 4.0.9
+      '@types/node': 24.10.4
+      '@types/node-fetch': 2.6.13
+      '@types/stream-buffers': 3.0.8
+      form-data: 4.0.5
+      hpagent: 1.2.0
+      isomorphic-ws: 5.0.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      js-yaml: 4.1.1
+      jsonpath-plus: 10.4.0
+      node-fetch: 2.7.0(encoding@0.1.13)
+      openid-client: 6.8.3
+      rfc4648: 1.5.4
+      socks-proxy-agent: 8.0.5
+      stream-buffers: 3.0.3
+      tar-fs: 3.1.2
+      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - encoding
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 
@@ -10864,7 +11038,7 @@ snapshots:
     dependencies:
       big.js: 6.2.2
       dayjs: 1.11.13
-      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.2.0)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -10877,7 +11051,7 @@ snapshots:
       '@reown/appkit-wallet': 1.7.8(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 1.13.2(react@18.3.1)
-      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.2.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -11027,7 +11201,7 @@ snapshots:
       '@walletconnect/logger': 2.1.2
       '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       valtio: 1.13.2(react@18.3.1)
-      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.2.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -11081,7 +11255,7 @@ snapshots:
       '@walletconnect/universal-provider': 2.21.0(bufferutil@4.0.9)(encoding@0.1.13)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       bs58: 6.0.0
       valtio: 1.13.2(react@18.3.1)
-      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.2.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -11191,7 +11365,7 @@ snapshots:
   '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.23.1
-      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.2.0)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -12492,6 +12666,8 @@ snapshots:
     dependencies:
       '@types/node': 24.10.4
 
+  '@types/js-yaml@4.0.9': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/jsonwebtoken@9.0.10':
@@ -12514,6 +12690,11 @@ snapshots:
       '@types/node': 24.10.4
 
   '@types/node-cron@3.0.11': {}
+
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 24.10.4
+      form-data: 4.0.5
 
   '@types/node@12.20.55': {}
 
@@ -12546,6 +12727,10 @@ snapshots:
       '@types/node': 24.10.4
       pg-protocol: 1.13.0
       pg-types: 2.2.0
+
+  '@types/stream-buffers@3.0.8':
+    dependencies:
+      '@types/node': 24.10.4
 
   '@types/tedious@4.0.14':
     dependencies:
@@ -12728,7 +12913,7 @@ snapshots:
       '@walletconnect/ethereum-provider': 2.21.1(bufferutil@4.0.9)(encoding@0.1.13)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
       porto: 0.2.35(@tanstack/react-query@5.90.12(react@18.3.1))(@wagmi/core@2.22.1(@tanstack/query-core@5.90.12)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))
-      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.2.0)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -12774,7 +12959,7 @@ snapshots:
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.2.0)
       zustand: 5.0.0(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
     optionalDependencies:
       '@tanstack/query-core': 5.90.12
@@ -13390,6 +13575,11 @@ snapshots:
       typescript: 5.9.3
       zod: 3.25.76
 
+  abitype@1.1.0(typescript@5.9.3)(zod@4.2.0):
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 4.2.0
+
   abitype@1.2.2(typescript@5.9.3)(zod@3.22.4):
     optionalDependencies:
       typescript: 5.9.3
@@ -13574,7 +13764,41 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
+  b4a@1.8.0: {}
+
   balanced-match@4.0.4: {}
+
+  bare-events@2.8.2: {}
+
+  bare-fs@4.7.1:
+    dependencies:
+      bare-events: 2.8.2
+      bare-path: 3.0.0
+      bare-stream: 2.13.0(bare-events@2.8.2)
+      bare-url: 2.4.1
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-os@3.8.7: {}
+
+  bare-path@3.0.0:
+    dependencies:
+      bare-os: 3.8.7
+
+  bare-stream@2.13.0(bare-events@2.8.2):
+    dependencies:
+      streamx: 2.25.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.4.1:
+    dependencies:
+      bare-path: 3.0.0
 
   base-x@3.0.11:
     dependencies:
@@ -14465,6 +14689,12 @@ snapshots:
 
   eventemitter3@5.0.1: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   events@3.3.0: {}
 
   evp_bytestokey@1.0.3:
@@ -14912,6 +15142,8 @@ snapshots:
 
   hono@4.12.14: {}
 
+  hpagent@1.2.0: {}
+
   html-escaper@2.0.2: {}
 
   http-proxy@1.18.1:
@@ -15011,6 +15243,8 @@ snapshots:
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
+
+  ip-address@10.1.0: {}
 
   ipfs-core-types@0.14.1:
     dependencies:
@@ -15316,6 +15550,8 @@ snapshots:
 
   jose@6.1.3: {}
 
+  jose@6.2.2: {}
+
   joycon@3.1.1: {}
 
   jpeg-exif@1.1.4: {}
@@ -15335,6 +15571,8 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsep@1.4.0: {}
 
   jsesc@3.1.0: {}
 
@@ -15385,6 +15623,12 @@ snapshots:
   jsonify@0.0.1: {}
 
   jsonparse@1.3.1: {}
+
+  jsonpath-plus@10.4.0:
+    dependencies:
+      '@jsep-plugin/assignment': 1.3.0(jsep@1.4.0)
+      '@jsep-plugin/regex': 1.0.4(jsep@1.4.0)
+      jsep: 1.4.0
 
   jsonwebtoken@9.0.3:
     dependencies:
@@ -15777,6 +16021,8 @@ snapshots:
       pkg-types: 2.3.0
       tinyexec: 1.0.2
 
+  oauth4webapi@3.8.5: {}
+
   obj-multiplex@1.0.0:
     dependencies:
       end-of-stream: 1.4.5
@@ -15833,6 +16079,11 @@ snapshots:
       openapi-typescript-helpers: 0.0.15
 
   openapi-typescript-helpers@0.0.15: {}
+
+  openid-client@6.8.3:
+    dependencies:
+      jose: 6.2.2
+      oauth4webapi: 3.8.5
 
   optionator@0.9.4:
     dependencies:
@@ -15922,6 +16173,21 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.2(typescript@5.9.3)(zod@3.25.76)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.9.6(typescript@5.9.3)(zod@4.2.0):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.2(typescript@5.9.3)(zod@4.2.0)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.9.3
@@ -16196,14 +16462,14 @@ snapshots:
       idb-keyval: 6.2.2
       mipd: 0.0.7(typescript@5.9.3)
       ox: 0.9.17(typescript@5.9.3)(zod@4.2.0)
-      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.2.0)
       zod: 4.2.0
       zustand: 5.0.9(react@18.3.1)(use-sync-external-store@1.4.0(react@18.3.1))
     optionalDependencies:
       '@tanstack/react-query': 5.90.12(react@18.3.1)
       react: 18.3.1
       typescript: 5.9.3
-      wagmi: 2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+      wagmi: 2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.2.0)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -16448,6 +16714,8 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rfc4648@1.5.4: {}
+
   rfdc@1.4.1: {}
 
   ripemd160@2.0.3:
@@ -16614,6 +16882,8 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
+  smart-buffer@4.2.0: {}
+
   snake-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
@@ -16636,6 +16906,19 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.7
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.7:
+    dependencies:
+      ip-address: 10.1.0
+      smart-buffer: 4.2.0
 
   sonic-boom@2.8.0:
     dependencies:
@@ -16665,6 +16948,8 @@ snapshots:
     dependencies:
       bl: 5.1.0
 
+  stream-buffers@3.0.3: {}
+
   stream-chain@2.2.5: {}
 
   stream-chunker@1.2.8:
@@ -16681,6 +16966,15 @@ snapshots:
   stream-to-it@0.2.4:
     dependencies:
       get-iterator: 1.0.2
+
+  streamx@2.25.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
 
   strict-uri-encode@2.0.0: {}
 
@@ -16779,6 +17073,42 @@ snapshots:
   synckit@0.11.11:
     dependencies:
       '@pkgr/core': 0.2.9
+
+  tar-fs@3.1.2:
+    dependencies:
+      pump: 3.0.3
+      tar-stream: 3.1.8
+    optionalDependencies:
+      bare-fs: 4.7.1
+      bare-path: 3.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  tar-stream@3.1.8:
+    dependencies:
+      b4a: 1.8.0
+      bare-fs: 4.7.1
+      fast-fifo: 1.3.2
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.0
+    transitivePeerDependencies:
+      - react-native-b4a
 
   text-encoding-utf-8@1.0.2: {}
 
@@ -17064,6 +17394,23 @@ snapshots:
       - utf-8-validate
       - zod
 
+  viem@2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.2.0):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.1.0(typescript@5.9.3)(zod@4.2.0)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      ox: 0.9.6(typescript@5.9.3)(zod@4.2.0)
+      ws: 8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   vite@7.3.0(@types/node@24.10.4)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.1
@@ -17117,14 +17464,14 @@ snapshots:
       - tsx
       - yaml
 
-  wagmi@2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76):
+  wagmi@2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.2.0):
     dependencies:
       '@tanstack/react-query': 5.90.12(react@18.3.1)
       '@wagmi/connectors': 6.2.0(@tanstack/react-query@5.90.12(react@18.3.1))(@wagmi/core@2.22.1(@tanstack/query-core@5.90.12)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(utf-8-validate@5.0.10)(viem@2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
       '@wagmi/core': 2.22.1(@tanstack/query-core@5.90.12)(react@18.3.1)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@18.3.1))(viem@2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       react: 18.3.1
       use-sync-external-store: 1.4.0(react@18.3.1)
-      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.2.0)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -17314,8 +17661,8 @@ snapshots:
       '@wallet-standard/app': 1.1.0
       '@wallet-standard/base': 1.1.0
       '@wallet-standard/features': 1.1.0
-      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
-      wagmi: 2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+      viem: 2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.2.0)
+      wagmi: 2.19.5(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@18.3.1))(bufferutil@4.0.9)(encoding@0.1.13)(fastestsmallesttextencoderdecoder@1.0.22)(react@18.3.1)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.42.1(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@4.2.0)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@azure/app-configuration'

--- a/prisma/migrations/20260420130000_add_github_app_and_build_jobs/migration.sql
+++ b/prisma/migrations/20260420130000_add_github_app_and_build_jobs/migration.sql
@@ -1,0 +1,94 @@
+-- Phase: GitHub deploy (2026-04-20)
+-- Vercel-style "connect a repo, we build and ship it" flow.
+-- - GithubInstallation: one row per (org, GitHub App installation)
+-- - BuildJob: append-only history of build attempts
+-- - Service: new git-source columns (gitProvider/gitOwner/gitRepo/...)
+
+-- 1. New enum for BuildJob.status
+CREATE TYPE "BuildStatus" AS ENUM ('PENDING', 'RUNNING', 'SUCCEEDED', 'FAILED', 'CANCELED');
+
+-- 2. github_installation table
+CREATE TABLE "github_installation" (
+    "id" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "installationId" BIGINT NOT NULL,
+    "accountLogin" TEXT NOT NULL,
+    "accountId" BIGINT NOT NULL,
+    "accountType" TEXT NOT NULL,
+    "targetType" TEXT NOT NULL,
+    "installedByUserId" TEXT,
+    "selectedRepos" JSONB,
+    "suspendedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "github_installation_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "github_installation_installationId_key" ON "github_installation"("installationId");
+CREATE INDEX "github_installation_organizationId_idx" ON "github_installation"("organizationId");
+CREATE INDEX "github_installation_accountLogin_idx" ON "github_installation"("accountLogin");
+
+ALTER TABLE "github_installation"
+    ADD CONSTRAINT "github_installation_organizationId_fkey"
+    FOREIGN KEY ("organizationId") REFERENCES "Organization"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "github_installation"
+    ADD CONSTRAINT "github_installation_installedByUserId_fkey"
+    FOREIGN KEY ("installedByUserId") REFERENCES "User"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- 3. New columns on Service for git-source deploys
+ALTER TABLE "Service"
+    ADD COLUMN "gitProvider"       TEXT,
+    ADD COLUMN "gitOwner"          TEXT,
+    ADD COLUMN "gitRepo"           TEXT,
+    ADD COLUMN "gitBranch"         TEXT,
+    ADD COLUMN "gitInstallationId" TEXT,
+    ADD COLUMN "buildCommand"      TEXT,
+    ADD COLUMN "startCommand"      TEXT,
+    ADD COLUMN "rootDirectory"     TEXT,
+    ADD COLUMN "detectedFramework" TEXT,
+    ADD COLUMN "detectedPort"      INTEGER,
+    ADD COLUMN "lastBuildSha"      TEXT,
+    ADD COLUMN "lastBuildStatus"   TEXT,
+    ADD COLUMN "lastBuildAt"       TIMESTAMP(3);
+
+CREATE INDEX "Service_gitInstallationId_idx" ON "Service"("gitInstallationId");
+CREATE INDEX "Service_gitOwner_gitRepo_idx" ON "Service"("gitOwner", "gitRepo");
+
+ALTER TABLE "Service"
+    ADD CONSTRAINT "Service_gitInstallationId_fkey"
+    FOREIGN KEY ("gitInstallationId") REFERENCES "github_installation"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- 4. build_job table
+CREATE TABLE "build_job" (
+    "id"                TEXT NOT NULL,
+    "serviceId"         TEXT NOT NULL,
+    "commitSha"         TEXT NOT NULL,
+    "commitMessage"     TEXT,
+    "branch"            TEXT NOT NULL,
+    "status"            "BuildStatus" NOT NULL DEFAULT 'PENDING',
+    "k8sJobName"        TEXT,
+    "imageTag"          TEXT,
+    "detectedFramework" TEXT,
+    "detectedPort"      INTEGER,
+    "logs"              TEXT,
+    "triggeredBy"       TEXT,
+    "startedAt"         TIMESTAMP(3),
+    "finishedAt"        TIMESTAMP(3),
+    "errorMessage"      TEXT,
+    "createdAt"         TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt"         TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "build_job_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "build_job_serviceId_idx" ON "build_job"("serviceId");
+CREATE INDEX "build_job_status_idx" ON "build_job"("status");
+CREATE INDEX "build_job_commitSha_idx" ON "build_job"("commitSha");
+
+ALTER TABLE "build_job"
+    ADD CONSTRAINT "build_job_serviceId_fkey"
+    FOREIGN KEY ("serviceId") REFERENCES "Service"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,21 +34,22 @@ enum ServiceType {
 // ============================================
 
 model User {
-  id            String   @id @default(cuid())
-  email         String?  @unique
-  username      String?  @unique
-  walletAddress String?  @unique
+  id            String  @id @default(cuid())
+  email         String? @unique
+  username      String? @unique
+  walletAddress String? @unique
 
-  projects              Project[]
-  organizationMemberships OrganizationMember[]
-  createdServices       Service[]
-  agents                Agent[]
-  chats                 Chat[]
-  messages              Message[]
-  pinnedContent         PinnedContent[]
-  storageSnapshots      StorageSnapshot[]
-  feedbackReports       FeedbackReport[]
-  customer              Customer?
+  projects                     Project[]
+  organizationMemberships      OrganizationMember[]
+  createdServices              Service[]
+  agents                       Agent[]
+  chats                        Chat[]
+  messages                     Message[]
+  pinnedContent                PinnedContent[]
+  storageSnapshots             StorageSnapshot[]
+  feedbackReports              FeedbackReport[]
+  customer                     Customer?
+  installedGithubInstallations GithubInstallation[] @relation("GithubInstallationInstaller")
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -63,14 +64,14 @@ model User {
 // ============================================
 
 model Project {
-  id             String   @id @default(cuid())
+  id             String  @id @default(cuid())
   name           String
-  slug           String   @unique
+  slug           String  @unique
   description    String?
-  organizationId String?  @map("organization_id")
+  organizationId String? @map("organization_id")
 
-  userId    String
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   organization Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
 
@@ -95,28 +96,28 @@ model Project {
 // ============================================
 
 model Site {
-  id          String   @id @default(cuid())
-  name        String
-  slug        String   @unique
+  id   String @id @default(cuid())
+  name String
+  slug String @unique
 
-  projectId   String
-  project     Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  projectId String
+  project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
-  serviceId   String?  @unique
-  service     Service? @relation(fields: [serviceId], references: [id], onDelete: Cascade)
+  serviceId String?  @unique
+  service   Service? @relation(fields: [serviceId], references: [id], onDelete: Cascade)
 
-  deployments Deployment[]
-  domains     Domain[]
-  ipnsRecords IPNSRecord[]
-  zones       Zone[]
+  deployments      Deployment[]
+  domains          Domain[]
+  ipnsRecords      IPNSRecord[]
+  zones            Zone[]
   akashDeployments AkashDeployment[]
   phalaDeployments PhalaDeployment[]
 
   primaryDomainId String?
   primaryDomain   Domain? @relation("PrimaryDomain", fields: [primaryDomainId], references: [id])
 
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([projectId])
   @@index([slug])
@@ -128,13 +129,13 @@ model Deployment {
   status      DeploymentStatus @default(PENDING)
   storageType StorageType      @default(IPFS)
 
-  siteId      String
-  site        Site             @relation(fields: [siteId], references: [id], onDelete: Cascade)
+  siteId String
+  site   Site   @relation(fields: [siteId], references: [id], onDelete: Cascade)
 
-  pin         Pin?
+  pin Pin?
 
-  createdAt   DateTime         @default(now())
-  updatedAt   DateTime         @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([siteId])
   @@index([cid])
@@ -160,32 +161,32 @@ enum StorageType {
 // ============================================
 
 model AFFunction {
-  id                  String               @id @default(cuid())
-  name                String
-  slug                String               @unique
-  sourceCode          String?              @db.Text
-  invokeUrl           String?
-  routes              Json?
-  status              FunctionStatus       @default(ACTIVE)
+  id         String         @id @default(cuid())
+  name       String
+  slug       String         @unique
+  sourceCode String?        @db.Text
+  invokeUrl  String?
+  routes     Json?
+  status     FunctionStatus @default(ACTIVE)
 
-  projectId           String
-  project             Project              @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  projectId String
+  project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
-  serviceId           String?              @unique
-  service             Service?             @relation(fields: [serviceId], references: [id], onDelete: Cascade)
+  serviceId String?  @unique
+  service   Service? @relation(fields: [serviceId], references: [id], onDelete: Cascade)
 
-  siteId              String?
+  siteId String?
 
-  currentDeploymentId String?              @unique
+  currentDeploymentId String?               @unique
   currentDeployment   AFFunctionDeployment? @relation("CurrentDeployment", fields: [currentDeploymentId], references: [id])
 
-  deployments         AFFunctionDeployment[] @relation("FunctionDeployments")
-  akashDeployments    AkashDeployment[]
-  phalaDeployments    PhalaDeployment[]
-  agents              Agent[]
+  deployments      AFFunctionDeployment[] @relation("FunctionDeployments")
+  akashDeployments AkashDeployment[]
+  phalaDeployments PhalaDeployment[]
+  agents           Agent[]
 
-  createdAt           DateTime             @default(now())
-  updatedAt           DateTime             @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([projectId])
   @@index([slug])
@@ -193,19 +194,19 @@ model AFFunction {
 }
 
 model AFFunctionDeployment {
-  id              String         @id @default(cuid())
-  cid             String
-  blake3Hash      String?
-  assetsCid       String?
-  sgx             Boolean        @default(false)
+  id         String  @id @default(cuid())
+  cid        String
+  blake3Hash String?
+  assetsCid  String?
+  sgx        Boolean @default(false)
 
   afFunctionId String
-  afFunction   AFFunction  @relation("FunctionDeployments", fields: [afFunctionId], references: [id], onDelete: Cascade)
+  afFunction   AFFunction @relation("FunctionDeployments", fields: [afFunctionId], references: [id], onDelete: Cascade)
 
   currentFunction AFFunction? @relation("CurrentDeployment")
 
-  createdAt       DateTime       @default(now())
-  updatedAt       DateTime       @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([afFunctionId])
   @@index([cid])
@@ -225,9 +226,10 @@ model Organization {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  members   OrganizationMember[]
-  projects  Project[]
-  domains   Domain[]
+  members             OrganizationMember[]
+  projects            Project[]
+  domains             Domain[]
+  githubInstallations GithubInstallation[]
 
   @@index([slug])
 }
@@ -240,57 +242,87 @@ model OrganizationMember {
   createdAt      DateTime         @default(now())
   updatedAt      DateTime         @updatedAt
 
-  organization   Organization     @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  user           User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([organizationId, userId])
   @@index([userId])
 }
 
 model Service {
-  id              String      @id @default(cuid())
-  type            ServiceType
-  name            String
-  slug            String
-  projectId       String
-  templateId      String?
-  dockerImage     String?     // Custom Docker image (e.g. ghcr.io/org/app:v1)
-  flavor          String?     // Create-time discriminator: 'docker' | 'server' | 'function' | 'template'. Null = legacy row. Immutable post-creation. (Phase 39)
-  containerPort   Int?        // Port the container listens on (default: 80). Used in SDL generation.
-  volumes         Json?       // Persistent volumes for raw Docker images: Array<{ name: string; mountPath: string; size: string }>. Templates use template.persistentStorage instead. (Phase 38)
-  healthProbe     Json?       // Optional application HTTP health probe: { path: string; port?: number; expectStatus?: number; intervalSec?: number; timeoutSec?: number }. (Phase 42)
-  failoverPolicy  Json?       // Optional health-aware auto-failover policy: { enabled: boolean; maxAttempts?: number; windowHours?: number }. Defaults applied at runtime when null. (Phase 43)
-  internalHostname String?    // Deterministic hostname: {slug}.{project-slug}.internal
-  createdByUserId String?
-  parentServiceId String?     // Companion services share the parent's deployment lifecycle
-  sdlServiceName  String?     // Akash SDL service name for multi-service deployments (e.g. "postgres", "app", "web")
-  shutdownPriority Int        @default(50) @map("shutdown_priority") // Lower = last to shut down. Used by billing scheduler for priority-based suspension.
-  createdAt       DateTime    @default(now())
-  updatedAt       DateTime    @updatedAt
+  id               String      @id @default(cuid())
+  type             ServiceType
+  name             String
+  slug             String
+  projectId        String
+  templateId       String?
+  dockerImage      String? // Custom Docker image (e.g. ghcr.io/org/app:v1)
+  flavor           String? // Create-time discriminator: 'docker' | 'server' | 'function' | 'template'. Null = legacy row. Immutable post-creation. (Phase 39)
+  containerPort    Int? // Port the container listens on (default: 80). Used in SDL generation.
+  volumes          Json? // Persistent volumes for raw Docker images: Array<{ name: string; mountPath: string; size: string }>. Templates use template.persistentStorage instead. (Phase 38)
+  healthProbe      Json? // Optional application HTTP health probe: { path: string; port?: number; expectStatus?: number; intervalSec?: number; timeoutSec?: number }. (Phase 42)
+  failoverPolicy   Json? // Optional health-aware auto-failover policy: { enabled: boolean; maxAttempts?: number; windowHours?: number }. Defaults applied at runtime when null. (Phase 43)
+  internalHostname String? // Deterministic hostname: {slug}.{project-slug}.internal
+  createdByUserId  String?
+  parentServiceId  String? // Companion services share the parent's deployment lifecycle
+  sdlServiceName   String? // Akash SDL service name for multi-service deployments (e.g. "postgres", "app", "web")
+  shutdownPriority Int         @default(50) @map("shutdown_priority") // Lower = last to shut down. Used by billing scheduler for priority-based suspension.
 
-  project         Project     @relation(fields: [projectId], references: [id], onDelete: Cascade)
-  createdByUser   User?       @relation(fields: [createdByUserId], references: [id], onDelete: SetNull)
-  parentService   Service?    @relation("CompanionServices", fields: [parentServiceId], references: [id], onDelete: Cascade)
-  companionServices Service[] @relation("CompanionServices")
+  // ── Git-source deploy fields (Vercel-style) ───────────────────────
+  // Set when the Service was created by connecting a git repo. Provider-
+  // agnostic: the same shape works for github / gitlab / bitbucket.
+  // The compute provider that runs the built image is NOT stored here —
+  // it's derived per-deploy from the live ComputeMode picker (Standard
+  // → Akash, Confidential → Phala) just like every other flavor. The
+  // build callback's auto-deploy reads the active deployment's provider
+  // on rebuilds, and falls back to Akash on first deploy (matches the
+  // ServiceDetailPanel default at onDeploy → onDeployToAkash).
+  gitProvider       String? // 'github' | 'gitlab' | 'bitbucket' | …
+  gitOwner          String? // Repo owner (user or org login)
+  gitRepo           String? // Repo name
+  gitBranch         String? // Tracked branch — pushes to this trigger rebuilds
+  gitInstallationId String? // FK → GithubInstallation (or future provider install table)
+  rootDirectory     String? // Subdirectory inside the repo to build from (monorepos)
+  buildCommand      String? // Override build command (else framework-detected)
+  startCommand      String? // Override start command (else framework-detected)
+  detectedFramework String? // Last build's detected framework (Next.js, Vite, Astro, …)
+  detectedPort      Int? // Port the built image listens on
+  lastBuildSha      String? // Most recent built commit SHA
+  lastBuildStatus   String? // 'PENDING' | 'RUNNING' | 'SUCCEEDED' | 'FAILED' | 'CANCELED'
+  lastBuildAt       DateTime?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  project           Project             @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  createdByUser     User?               @relation(fields: [createdByUserId], references: [id], onDelete: SetNull)
+  parentService     Service?            @relation("CompanionServices", fields: [parentServiceId], references: [id], onDelete: Cascade)
+  companionServices Service[]           @relation("CompanionServices")
+  gitInstallation   GithubInstallation? @relation(fields: [gitInstallationId], references: [id], onDelete: SetNull)
 
   // One-to-one (subtype tables have the FK via serviceId)
-  site            Site?
-  afFunction      AFFunction?
+  site       Site?
+  afFunction AFFunction?
 
   // Akash deployments for this service (can have multiple over time)
   akashDeployments AkashDeployment[]
   phalaDeployments PhalaDeployment[]
 
+  // Build history for git-source services
+  buildJobs BuildJob[]
+
   // Inter-service communication
-  envVars          ServiceEnvVar[]
-  ports            ServicePort[]
-  linksFrom        ServiceLink[]  @relation("ServiceLinksFrom")
-  linksTo          ServiceLink[]  @relation("ServiceLinksTo")
+  envVars   ServiceEnvVar[]
+  ports     ServicePort[]
+  linksFrom ServiceLink[]   @relation("ServiceLinksFrom")
+  linksTo   ServiceLink[]   @relation("ServiceLinksTo")
 
   @@unique([type, slug])
   @@index([projectId])
   @@index([createdByUserId])
   @@index([parentServiceId])
+  @@index([gitInstallationId])
+  @@index([gitOwner, gitRepo])
 }
 
 // ============================================
@@ -298,14 +330,14 @@ model Service {
 // ============================================
 
 model ServiceEnvVar {
-  id        String   @id @default(cuid())
+  id        String  @id @default(cuid())
   serviceId String
   key       String
-  value     String   @db.Text
-  secret    Boolean  @default(false)
-  source    String?  // null = user-set, "link:<serviceId>" = auto-generated from a service link
+  value     String  @db.Text
+  secret    Boolean @default(false)
+  source    String? // null = user-set, "link:<serviceId>" = auto-generated from a service link
 
-  service   Service  @relation(fields: [serviceId], references: [id], onDelete: Cascade)
+  service Service @relation(fields: [serviceId], references: [id], onDelete: Cascade)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -319,16 +351,16 @@ model ServiceEnvVar {
 // ============================================
 
 model ServicePort {
-  id            String  @id @default(cuid())
+  id            String @id @default(cuid())
   serviceId     String
   containerPort Int
-  publicPort    Int?    // null = internal only
-  protocol      String  @default("TCP") // TCP | UDP | HTTP
+  publicPort    Int? // null = internal only
+  protocol      String @default("TCP") // TCP | UDP | HTTP
 
-  service       Service @relation(fields: [serviceId], references: [id], onDelete: Cascade)
+  service Service @relation(fields: [serviceId], references: [id], onDelete: Cascade)
 
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@unique([serviceId, containerPort])
   @@index([serviceId])
@@ -339,16 +371,16 @@ model ServicePort {
 // ============================================
 
 model ServiceLink {
-  id              String   @id @default(cuid())
-  sourceServiceId String   // The service that receives injected env vars
-  targetServiceId String   // The service being connected to (e.g. postgres)
-  alias           String?  // Optional alias for variable interpolation
+  id              String  @id @default(cuid())
+  sourceServiceId String // The service that receives injected env vars
+  targetServiceId String // The service being connected to (e.g. postgres)
+  alias           String? // Optional alias for variable interpolation
 
-  sourceService   Service  @relation("ServiceLinksFrom", fields: [sourceServiceId], references: [id], onDelete: Cascade)
-  targetService   Service  @relation("ServiceLinksTo", fields: [targetServiceId], references: [id], onDelete: Cascade)
+  sourceService Service @relation("ServiceLinksFrom", fields: [sourceServiceId], references: [id], onDelete: Cascade)
+  targetService Service @relation("ServiceLinksTo", fields: [targetServiceId], references: [id], onDelete: Cascade)
 
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@unique([sourceServiceId, targetServiceId])
   @@index([sourceServiceId])
@@ -360,49 +392,49 @@ model ServiceLink {
 // ============================================
 
 model Domain {
-  id          String       @id @default(cuid())
-  hostname    String       @unique
-  verified    Boolean      @default(false)
-  domainType  DomainType   @default(WEB2)
+  id         String     @id @default(cuid())
+  hostname   String     @unique
+  verified   Boolean    @default(false)
+  domainType DomainType @default(WEB2)
 
   // Org-level ownership (domain can exist at org level without a site)
-  organizationId String?  @map("organization_id")
+  organizationId String?       @map("organization_id")
   organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: SetNull)
 
-  siteId      String?
-  site        Site?        @relation(fields: [siteId], references: [id], onDelete: Cascade)
+  siteId String?
+  site   Site?   @relation(fields: [siteId], references: [id], onDelete: Cascade)
 
-  primarySite Site[]       @relation("PrimaryDomain")
+  primarySite Site[] @relation("PrimaryDomain")
 
   // DNS Verification
-  txtVerificationToken    String?   // Token to verify via TXT record
-  txtVerificationStatus   VerificationStatus @default(PENDING)
-  dnsVerifiedAt           DateTime?
+  txtVerificationToken  String? // Token to verify via TXT record
+  txtVerificationStatus VerificationStatus @default(PENDING)
+  dnsVerifiedAt         DateTime?
 
   // DNS Records for verification
-  expectedCname           String?   // Expected CNAME value
-  expectedARecord         String?   // Expected A record value
+  expectedCname   String? // Expected CNAME value
+  expectedARecord String? // Expected A record value
 
   // SSL Certificate
-  sslStatus               SslStatus @default(NONE)
-  sslCertificateId        String?   // Let's Encrypt cert ID
-  sslIssuedAt             DateTime?
-  sslExpiresAt            DateTime?
-  sslAutoRenew            Boolean   @default(true)
+  sslStatus        SslStatus @default(NONE)
+  sslCertificateId String? // Let's Encrypt cert ID
+  sslIssuedAt      DateTime?
+  sslExpiresAt     DateTime?
+  sslAutoRenew     Boolean   @default(true)
 
   // Web3 Domain Integration
-  arnsName                String?   // ArNS name for Arweave
-  arnsTransactionId       String?   // Arweave transaction ID
-  ensName                 String?   // ENS domain name
-  ensContentHash          String?   // ENS content hash
-  ipnsHash                String?   // IPNS hash
+  arnsName          String? // ArNS name for Arweave
+  arnsTransactionId String? // Arweave transaction ID
+  ensName           String? // ENS domain name
+  ensContentHash    String? // ENS content hash
+  ipnsHash          String? // IPNS hash
 
   // DNS Propagation
-  lastDnsCheck            DateTime?
-  dnsCheckAttempts        Int       @default(0)
+  lastDnsCheck     DateTime?
+  dnsCheckAttempts Int       @default(0)
 
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([siteId])
   @@index([organizationId])
@@ -413,10 +445,10 @@ model Domain {
 }
 
 enum DomainType {
-  WEB2        // Traditional domain (example.com)
-  ARNS        // Arweave Name System
-  ENS         // Ethereum Name System
-  IPNS        // InterPlanetary Name System
+  WEB2 // Traditional domain (example.com)
+  ARNS // Arweave Name System
+  ENS // Ethereum Name System
+  IPNS // InterPlanetary Name System
 }
 
 enum VerificationStatus {
@@ -434,11 +466,11 @@ enum SslStatus {
 }
 
 model Zone {
-  id        String   @id @default(cuid())
-  name      String
+  id   String @id @default(cuid())
+  name String
 
-  siteId    String
-  site      Site     @relation(fields: [siteId], references: [id], onDelete: Cascade)
+  siteId String
+  site   Site   @relation(fields: [siteId], references: [id], onDelete: Cascade)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -451,27 +483,27 @@ model Zone {
 // ============================================
 
 model Pin {
-  id           String     @id @default(cuid())
-  cid          String     @unique
-  name         String?
-  size         Int?
+  id   String  @id @default(cuid())
+  cid  String  @unique
+  name String?
+  size Int?
 
   deploymentId String     @unique
   deployment   Deployment @relation(fields: [deploymentId], references: [id], onDelete: Cascade)
 
-  createdAt    DateTime   @default(now())
-  updatedAt    DateTime   @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([cid])
 }
 
 model IPNSRecord {
-  id        String   @id @default(cuid())
-  name      String   @unique
-  hash      String
+  id   String @id @default(cuid())
+  name String @unique
+  hash String
 
-  siteId    String
-  site      Site     @relation(fields: [siteId], references: [id], onDelete: Cascade)
+  siteId String
+  site   Site   @relation(fields: [siteId], references: [id], onDelete: Cascade)
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -485,27 +517,27 @@ model IPNSRecord {
 // ============================================
 
 model Agent {
-  id          String       @id @default(cuid())
-  name        String
-  slug        String       @unique
-  description String?
-  avatar      String?
+  id           String      @id @default(cuid())
+  name         String
+  slug         String      @unique
+  description  String?
+  avatar       String?
   systemPrompt String?
-  model       String       @default("gpt-4")
-  status      AgentStatus  @default(ACTIVE)
+  model        String      @default("gpt-4")
+  status       AgentStatus @default(ACTIVE)
 
   // Agent can be tied to a deployed function or external service
-  functionId  String?
-  afFunction  AFFunction?  @relation(fields: [functionId], references: [id], onDelete: SetNull)
+  functionId String?
+  afFunction AFFunction? @relation(fields: [functionId], references: [id], onDelete: SetNull)
 
-  userId      String
-  user        User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  chats       Chat[]
-  messages    Message[]
+  chats    Chat[]
+  messages Message[]
 
-  createdAt   DateTime     @default(now())
-  updatedAt   DateTime     @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([userId])
   @@index([slug])
@@ -521,25 +553,25 @@ enum AgentStatus {
 }
 
 model Chat {
-  id          String      @id @default(cuid())
-  title       String?
+  id    String  @id @default(cuid())
+  title String?
 
-  userId      String
-  user        User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
-  agentId     String
-  agent       Agent       @relation(fields: [agentId], references: [id], onDelete: Cascade)
+  agentId String
+  agent   Agent  @relation(fields: [agentId], references: [id], onDelete: Cascade)
 
   messages    Message[]
   attachments Attachment[]
 
   // Chat metadata
-  metadata    Json?
+  metadata Json?
 
   lastMessageAt DateTime?
 
-  createdAt   DateTime    @default(now())
-  updatedAt   DateTime    @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([userId])
   @@index([agentId])
@@ -547,28 +579,28 @@ model Chat {
 }
 
 model Message {
-  id          String        @id @default(cuid())
-  content     String
-  role        MessageRole
+  id      String      @id @default(cuid())
+  content String
+  role    MessageRole
 
-  chatId      String
-  chat        Chat          @relation(fields: [chatId], references: [id], onDelete: Cascade)
+  chatId String
+  chat   Chat   @relation(fields: [chatId], references: [id], onDelete: Cascade)
 
   // Agent that sent the message (if role is AGENT)
-  agentId     String?
-  agent       Agent?        @relation(fields: [agentId], references: [id], onDelete: SetNull)
+  agentId String?
+  agent   Agent?  @relation(fields: [agentId], references: [id], onDelete: SetNull)
 
   // User that sent the message (if role is USER)
-  userId      String?
-  user        User?         @relation(fields: [userId], references: [id], onDelete: SetNull)
+  userId String?
+  user   User?   @relation(fields: [userId], references: [id], onDelete: SetNull)
 
   attachments Attachment[]
 
   // Message metadata (tokens used, model, etc.)
-  metadata    Json?
+  metadata Json?
 
-  createdAt   DateTime      @default(now())
-  updatedAt   DateTime      @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([chatId])
   @@index([agentId])
@@ -584,7 +616,7 @@ enum MessageRole {
 }
 
 model Attachment {
-  id          String   @id @default(cuid())
+  id          String @id @default(cuid())
   filename    String
   contentType String
   size        Int
@@ -594,14 +626,14 @@ model Attachment {
   cid         String?
   storageType StorageType?
 
-  chatId      String?
-  chat        Chat?    @relation(fields: [chatId], references: [id], onDelete: Cascade)
+  chatId String?
+  chat   Chat?   @relation(fields: [chatId], references: [id], onDelete: Cascade)
 
-  messageId   String?
-  message     Message? @relation(fields: [messageId], references: [id], onDelete: Cascade)
+  messageId String?
+  message   Message? @relation(fields: [messageId], references: [id], onDelete: Cascade)
 
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([chatId])
   @@index([messageId])
@@ -613,28 +645,28 @@ model Attachment {
 // ============================================
 
 model PinnedContent {
-  id          String    @id @default(cuid())
+  id String @id @default(cuid())
 
-  userId      String
-  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   // IPFS Content Identifier (immutable)
-  cid         String
+  cid String
 
   // Size in bytes (immutable for this CID)
-  sizeBytes   BigInt
+  sizeBytes BigInt
 
   // Pin tracking
-  pinnedAt    DateTime  @default(now())
-  unpinnedAt  DateTime? // Null if still pinned
+  pinnedAt   DateTime  @default(now())
+  unpinnedAt DateTime? // Null if still pinned
 
   // Optional metadata
-  filename    String?
-  mimeType    String?
-  metadata    Json?
+  filename String?
+  mimeType String?
+  metadata Json?
 
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([userId])
   @@index([cid])
@@ -644,21 +676,21 @@ model PinnedContent {
 }
 
 model StorageSnapshot {
-  id          String   @id @default(cuid())
+  id String @id @default(cuid())
 
-  userId      String
-  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId String
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   // Snapshot date (daily)
-  date        DateTime
+  date DateTime
 
   // Total storage at this date
-  totalBytes  BigInt
+  totalBytes BigInt
 
   // Pin count
-  pinCount    Int
+  pinCount Int
 
-  createdAt   DateTime @default(now())
+  createdAt DateTime @default(now())
 
   @@unique([userId, date])
   @@index([userId])
@@ -670,23 +702,23 @@ model StorageSnapshot {
 // ============================================
 
 model TelemetryIngestion {
-  id              String   @id @default(cuid())
+  id String @id @default(cuid())
 
-  projectId       String
-  project         Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  projectId String
+  project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
   // Ingestion stats per period
-  bytesIngested   BigInt   @default(0)
-  spansCount      Int      @default(0)
-  metricsCount    Int      @default(0)
-  logsCount       Int      @default(0)
+  bytesIngested BigInt @default(0)
+  spansCount    Int    @default(0)
+  metricsCount  Int    @default(0)
+  logsCount     Int    @default(0)
 
   // Billing period (hourly granularity)
-  periodStart     DateTime
-  periodEnd       DateTime
+  periodStart DateTime
+  periodEnd   DateTime
 
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@unique([projectId, periodStart, periodEnd])
   @@index([projectId])
@@ -694,29 +726,29 @@ model TelemetryIngestion {
 }
 
 model ObservabilitySettings {
-  id              String   @id @default(cuid())
+  id String @id @default(cuid())
 
-  projectId       String   @unique
-  project         Project  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  projectId String  @unique
+  project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
   // Feature toggles
-  tracesEnabled   Boolean  @default(true)
-  metricsEnabled  Boolean  @default(true)
-  logsEnabled     Boolean  @default(true)
+  tracesEnabled  Boolean @default(true)
+  metricsEnabled Boolean @default(true)
+  logsEnabled    Boolean @default(true)
 
   // Retention (days)
-  traceRetention  Int      @default(7)
-  metricRetention Int      @default(30)
-  logRetention    Int      @default(7)
+  traceRetention  Int @default(7)
+  metricRetention Int @default(30)
+  logRetention    Int @default(7)
 
   // Sampling rate (1.0 = 100%)
-  sampleRate      Float    @default(1.0)
+  sampleRate Float @default(1.0)
 
   // Rate limits (null = unlimited)
   maxBytesPerHour BigInt?
 
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([projectId])
 }
@@ -731,30 +763,30 @@ model ObservabilitySettings {
 // JSONL stream. Schema-free `payload` — each subsystem writes its own keys
 // with the privacy allowlist enforced in the `audit()` helper, never here.
 model AuditEvent {
-  id           String   @id @default(cuid())
-  timestamp    DateTime @default(now())
+  id        String   @id @default(cuid())
+  timestamp DateTime @default(now())
 
   // Trace correlation — groups events from one user action across services.
   // Populated by the HTTP middleware that mints a cuid per request and
   // forwards it via `x-af-trace-id`. Background jobs mint their own.
-  traceId      String
+  traceId String
 
   // Origin service + logical grouping.
-  source       String   // "auth" | "cloud-api" | "web" | "monitor" | "cron"
-  category     String   // "billing" | "deployment" | "health" | "user" | "auth" | "provider" | "ai-proxy" | "cron" | "system"
-  action       String   // verb-first, dotted: "deployment.requested", "billing.hourly_tick", "lease.closed"
-  status       String   // "ok" | "warn" | "error"
+  source   String // "auth" | "cloud-api" | "web" | "monitor" | "cron"
+  category String // "billing" | "deployment" | "health" | "user" | "auth" | "provider" | "ai-proxy" | "cron" | "system"
+  action   String // verb-first, dotted: "deployment.requested", "billing.hourly_tick", "lease.closed"
+  status   String // "ok" | "warn" | "error"
 
   // Identity dimensions (all nullable — system events have none of these).
   userId       String?
   orgId        String?
   projectId    String?
   serviceId    String?
-  deploymentId String?                                    // Akash, Phala, Site — generic key
+  deploymentId String? // Akash, Phala, Site — generic key
 
   // Timing + payload.
-  durationMs   Int?
-  payload      Json                                       // subsystem-specific; privacy-allowlisted upstream
+  durationMs Int?
+  payload    Json // subsystem-specific; privacy-allowlisted upstream
 
   // Error dimensions (populated when status = "error").
   errorCode    String?
@@ -775,25 +807,25 @@ model AuditEvent {
 // ============================================
 
 model UsageBuffer {
-  id        String   @id @default(cuid())
-  userId    String   @unique
-  
-  bandwidth Int      @default(0)
-  compute   Int      @default(0)
-  requests  Int      @default(0)
-  
+  id     String @id @default(cuid())
+  userId String @unique
+
+  bandwidth Int @default(0)
+  compute   Int @default(0)
+  requests  Int @default(0)
+
   updatedAt DateTime @updatedAt
-  
+
   @@index([userId])
 }
 
 model UsageMetadata {
   id        String   @id @default(cuid())
   userId    String
-  type      String   // BANDWIDTH, COMPUTE, REQUESTS
+  type      String // BANDWIDTH, COMPUTE, REQUESTS
   metadata  Json
   createdAt DateTime @default(now())
-  
+
   @@index([userId])
   @@index([createdAt])
 }
@@ -803,76 +835,76 @@ model UsageMetadata {
 // ============================================
 
 model Customer {
-  id               String   @id @default(cuid())
-  userId           String   @unique
-  user             User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id               String  @id @default(cuid())
+  userId           String  @unique
+  user             User    @relation(fields: [userId], references: [id], onDelete: Cascade)
   email            String?
   name             String?
-  stripeCustomerId String?  @unique
-  
+  stripeCustomerId String? @unique
+
   defaultPaymentMethodId String?
   defaultPaymentMethod   PaymentMethod? @relation("DefaultPaymentMethod", fields: [defaultPaymentMethodId], references: [id])
-  
-  paymentMethods   PaymentMethod[] @relation("CustomerPaymentMethods")
-  subscriptions    Subscription[]
-  invoices         Invoice[]
-  payments         Payment[]
-  
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
-  
+
+  paymentMethods PaymentMethod[] @relation("CustomerPaymentMethods")
+  subscriptions  Subscription[]
+  invoices       Invoice[]
+  payments       Payment[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
   @@index([stripeCustomerId])
 }
 
 model PaymentMethod {
-  id                    String    @id @default(cuid())
-  customerId            String
-  customer              Customer  @relation("CustomerPaymentMethods", fields: [customerId], references: [id], onDelete: Cascade)
-  
-  type                  String    // CARD, CRYPTO
-  provider              String    @default("stripe") // stripe, stax, relay
+  id         String   @id @default(cuid())
+  customerId String
+  customer   Customer @relation("CustomerPaymentMethods", fields: [customerId], references: [id], onDelete: Cascade)
+
+  type                  String // CARD, CRYPTO
+  provider              String  @default("stripe") // stripe, stax, relay
   cardBrand             String?
   cardLast4             String?
   cardExpMonth          Int?
   cardExpYear           Int?
-  stripePaymentMethodId String?   @unique
+  stripePaymentMethodId String? @unique
   walletAddress         String?
   blockchain            String?
-  isDefault             Boolean   @default(false)
-  isActive              Boolean   @default(true)
-  
-  defaultForCustomers   Customer[] @relation("DefaultPaymentMethod")
-  payments              Payment[]
-  
-  createdAt             DateTime  @default(now())
-  updatedAt             DateTime  @updatedAt
-  
+  isDefault             Boolean @default(false)
+  isActive              Boolean @default(true)
+
+  defaultForCustomers Customer[] @relation("DefaultPaymentMethod")
+  payments            Payment[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
   @@index([customerId])
 }
 
 model SubscriptionPlan {
-  id               String   @id @default(cuid())
-  name             String   @unique // FREE, STARTER, PRO, ENTERPRISE
-  basePricePerSeat Int      // in cents
-  usageMarkup      Float    @default(0) // percentage as decimal
-  features         String?  // JSON array
+  id               String  @id @default(cuid())
+  name             String  @unique // FREE, STARTER, PRO, ENTERPRISE
+  basePricePerSeat Int // in cents
+  usageMarkup      Float   @default(0) // percentage as decimal
+  features         String? // JSON array
   stripePriceId    String?
-  
-  subscriptions    Subscription[]
-  
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
+
+  subscriptions Subscription[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }
 
 model Subscription {
-  id                   String    @id @default(cuid())
-  customerId           String
-  customer             Customer  @relation(fields: [customerId], references: [id], onDelete: Cascade)
-  
-  planId               String
-  plan                 SubscriptionPlan @relation(fields: [planId], references: [id])
-  
-  status               String    // ACTIVE, CANCELED, PAST_DUE, UNPAID, TRIALING
+  id         String   @id @default(cuid())
+  customerId String
+  customer   Customer @relation(fields: [customerId], references: [id], onDelete: Cascade)
+
+  planId String
+  plan   SubscriptionPlan @relation(fields: [planId], references: [id])
+
+  status               String // ACTIVE, CANCELED, PAST_DUE, UNPAID, TRIALING
   seats                Int       @default(1)
   stripeSubscriptionId String?   @unique
   currentPeriodStart   DateTime
@@ -880,157 +912,157 @@ model Subscription {
   cancelAt             DateTime?
   canceledAt           DateTime?
   trialEnd             DateTime?
-  
-  invoices             Invoice[]
-  usageRecords         UsageRecord[]
-  
-  createdAt            DateTime  @default(now())
-  updatedAt            DateTime  @updatedAt
-  
+
+  invoices     Invoice[]
+  usageRecords UsageRecord[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
   @@index([customerId])
   @@index([status])
 }
 
 model Invoice {
-  id               String    @id @default(cuid())
-  customerId       String
-  customer         Customer  @relation(fields: [customerId], references: [id], onDelete: Cascade)
-  
-  subscriptionId   String?
-  subscription     Subscription? @relation(fields: [subscriptionId], references: [id], onDelete: SetNull)
-  
-  invoiceNumber    String    @unique
-  status           String    // DRAFT, OPEN, PAID, VOID, UNCOLLECTIBLE
-  subtotal         Int       // in cents
-  tax              Int       @default(0)
-  total            Int
-  amountPaid       Int       @default(0)
-  amountDue        Int
-  currency         String    @default("usd")
-  periodStart      DateTime?
-  periodEnd        DateTime?
-  dueDate          DateTime?
-  paidAt           DateTime?
-  pdfUrl           String?
-  stripeInvoiceId  String?   @unique
-  
-  lineItems        InvoiceLineItem[]
-  payments         Payment[]
-  
-  createdAt        DateTime  @default(now())
-  updatedAt        DateTime  @updatedAt
-  
+  id         String   @id @default(cuid())
+  customerId String
+  customer   Customer @relation(fields: [customerId], references: [id], onDelete: Cascade)
+
+  subscriptionId String?
+  subscription   Subscription? @relation(fields: [subscriptionId], references: [id], onDelete: SetNull)
+
+  invoiceNumber   String    @unique
+  status          String // DRAFT, OPEN, PAID, VOID, UNCOLLECTIBLE
+  subtotal        Int // in cents
+  tax             Int       @default(0)
+  total           Int
+  amountPaid      Int       @default(0)
+  amountDue       Int
+  currency        String    @default("usd")
+  periodStart     DateTime?
+  periodEnd       DateTime?
+  dueDate         DateTime?
+  paidAt          DateTime?
+  pdfUrl          String?
+  stripeInvoiceId String?   @unique
+
+  lineItems InvoiceLineItem[]
+  payments  Payment[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
   @@index([customerId])
   @@index([status])
 }
 
 model InvoiceLineItem {
-  id          String   @id @default(cuid())
-  invoiceId   String
-  invoice     Invoice  @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
-  
+  id        String  @id @default(cuid())
+  invoiceId String
+  invoice   Invoice @relation(fields: [invoiceId], references: [id], onDelete: Cascade)
+
   description String
   quantity    Float
-  unitPrice   Int      // in cents
-  amount      Int      // in cents
+  unitPrice   Int // in cents
+  amount      Int // in cents
   metadata    Json?
-  
-  createdAt   DateTime @default(now())
-  
+
+  createdAt DateTime @default(now())
+
   @@index([invoiceId])
 }
 
 model Payment {
-  id                    String    @id @default(cuid())
-  customerId            String
-  customer              Customer  @relation(fields: [customerId], references: [id], onDelete: Cascade)
-  
-  invoiceId             String?
-  invoice               Invoice?  @relation(fields: [invoiceId], references: [id], onDelete: SetNull)
-  
-  paymentMethodId       String?
-  paymentMethod         PaymentMethod? @relation(fields: [paymentMethodId], references: [id], onDelete: SetNull)
-  
-  amount                Int       // in cents
-  currency              String    @default("usd")
-  status                String    // PENDING, SUCCEEDED, FAILED, REFUNDED
-  provider              String    @default("stripe") // stripe, stax, relay
-  stripePaymentIntentId String?   @unique
-  txHash                String?   @unique
+  id         String   @id @default(cuid())
+  customerId String
+  customer   Customer @relation(fields: [customerId], references: [id], onDelete: Cascade)
+
+  invoiceId String?
+  invoice   Invoice? @relation(fields: [invoiceId], references: [id], onDelete: SetNull)
+
+  paymentMethodId String?
+  paymentMethod   PaymentMethod? @relation(fields: [paymentMethodId], references: [id], onDelete: SetNull)
+
+  amount                Int // in cents
+  currency              String  @default("usd")
+  status                String // PENDING, SUCCEEDED, FAILED, REFUNDED
+  provider              String  @default("stripe") // stripe, stax, relay
+  stripePaymentIntentId String? @unique
+  txHash                String? @unique
   blockchain            String?
   fromAddress           String?
   toAddress             String?
   failureReason         String?
   failureCode           String?
   failureMessage        String?
-  
-  createdAt             DateTime  @default(now())
-  updatedAt             DateTime  @updatedAt
-  
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
   @@index([customerId])
   @@index([invoiceId])
 }
 
 model BillingSettings {
-  id              String   @id @default(cuid())
-  userId          String   @unique
-  
+  id     String @id @default(cuid())
+  userId String @unique
+
   // Feature toggles
-  autoPayEnabled  Boolean  @default(true)
-  
+  autoPayEnabled Boolean @default(true)
+
   // Pricing settings (in cents)
-  bandwidthPerGBCents   Int? // cents per GB
-  computePerHourCents   Int? // cents per compute hour
-  requestsPer1000Cents  Int? // cents per 1000 requests
-  storagePerGBCents     Int? // cents per GB per month
-  telemetryPerGBCents   Int? // cents per GB telemetry
-  pricePerSeatCents     Int? // cents per seat
-  usageMarkupPercent    Float? // percentage markup for usage
-  
+  bandwidthPerGBCents  Int? // cents per GB
+  computePerHourCents  Int? // cents per compute hour
+  requestsPer1000Cents Int? // cents per 1000 requests
+  storagePerGBCents    Int? // cents per GB per month
+  telemetryPerGBCents  Int? // cents per GB telemetry
+  pricePerSeatCents    Int? // cents per seat
+  usageMarkupPercent   Float? // percentage markup for usage
+
   // Tax settings
-  taxId           String?
-  taxCountry      String?
-  taxRatePercent  Float?   // tax rate percentage
-  
+  taxId          String?
+  taxCountry     String?
+  taxRatePercent Float? // tax rate percentage
+
   // Invoice settings
-  invoiceDueDays  Int?     @default(30)
-  
+  invoiceDueDays Int? @default(30)
+
   // Billing address
-  billingEmail    String?
-  billingAddress  String?
-  billingCity     String?
-  billingState    String?
-  billingZip      String?
-  billingCountry  String?
-  
-  createdAt       DateTime @default(now())
-  updatedAt       DateTime @updatedAt
-  
+  billingEmail   String?
+  billingAddress String?
+  billingCity    String?
+  billingState   String?
+  billingZip     String?
+  billingCountry String?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
   @@index([userId])
 }
 
 model UsageRecord {
-  id             String   @id @default(cuid())
+  id             String        @id @default(cuid())
   customerId     String
   subscriptionId String?
   subscription   Subscription? @relation(fields: [subscriptionId], references: [id], onDelete: SetNull)
-  
-  type           String   // BANDWIDTH, COMPUTE, REQUESTS, STORAGE
-  metricType     String   @default("") // storage, bandwidth, compute, requests (alias for type)
-  resourceType   String?  // AGGREGATED, etc.
-  resourceId     String?  // ID of the resource being tracked
-  quantity       Float
-  unit           String?  // GB, HOURS, REQUESTS
-  unitPrice      Int?     // in cents
-  amount         Int?     // in cents
-  periodStart    DateTime
-  periodEnd      DateTime
-  recordedAt     DateTime @default(now())
-  timestamp      DateTime @default(now())
-  metadata       Json?
-  
-  createdAt      DateTime @default(now())
-  
+
+  type         String // BANDWIDTH, COMPUTE, REQUESTS, STORAGE
+  metricType   String   @default("") // storage, bandwidth, compute, requests (alias for type)
+  resourceType String? // AGGREGATED, etc.
+  resourceId   String? // ID of the resource being tracked
+  quantity     Float
+  unit         String? // GB, HOURS, REQUESTS
+  unitPrice    Int? // in cents
+  amount       Int? // in cents
+  periodStart  DateTime
+  periodEnd    DateTime
+  recordedAt   DateTime @default(now())
+  timestamp    DateTime @default(now())
+  metadata     Json?
+
+  createdAt DateTime @default(now())
+
   @@index([customerId, periodStart])
   @@index([type])
   @@index([metricType])
@@ -1042,53 +1074,53 @@ model UsageRecord {
 // ============================================
 
 model AkashDeployment {
-  id              String              @id @default(cuid())
+  id String @id @default(cuid())
 
   // Akash identifiers
-  owner           String              // Akash wallet address (owner)
-  dseq            BigInt              // Deployment sequence number
-  gseq            Int                 @default(1) // Group sequence
-  oseq            Int                 @default(1) // Order sequence
-  provider        String?             // Provider address once lease created
+  owner    String // Akash wallet address (owner)
+  dseq     BigInt // Deployment sequence number
+  gseq     Int     @default(1) // Group sequence
+  oseq     Int     @default(1) // Order sequence
+  provider String? // Provider address once lease created
 
   // Status tracking
-  status          AkashDeploymentStatus @default(CREATING)
+  status AkashDeploymentStatus @default(CREATING)
 
   // Service endpoints (populated after manifest sent)
-  serviceUrls     Json?               // { serviceName: ["url1", "url2"] }
+  serviceUrls Json? // { serviceName: ["url1", "url2"] }
 
   // SDL content used for deployment
-  sdlContent      String              @db.Text
+  sdlContent String @db.Text
 
   // Link to the canonical Service registry (can deploy any service type)
-  serviceId       String
-  service         Service             @relation(fields: [serviceId], references: [id], onDelete: Cascade)
+  serviceId String
+  service   Service @relation(fields: [serviceId], references: [id], onDelete: Cascade)
 
   // Optional direct links to specific resource types (for convenience queries)
-  afFunctionId    String?
-  afFunction      AFFunction?         @relation(fields: [afFunctionId], references: [id], onDelete: SetNull)
-  
-  siteId          String?
-  site            Site?               @relation(fields: [siteId], references: [id], onDelete: SetNull)
+  afFunctionId String?
+  afFunction   AFFunction? @relation(fields: [afFunctionId], references: [id], onDelete: SetNull)
+
+  siteId String?
+  site   Site?   @relation(fields: [siteId], references: [id], onDelete: SetNull)
 
   // Cost tracking (on-chain)
-  depositUakt     BigInt?             // Deposit amount in uakt
-  pricePerBlock   String?             // Price from accepted bid
+  depositUakt   BigInt? // Deposit amount in uakt
+  pricePerBlock String? // Price from accepted bid
 
   // Billing (platform escrow — mirrors on-chain escrow in USD)
-  escrow          DeploymentEscrow?   // Platform-level escrow for this deployment
-  savedSdl        String?             @db.Text // SDL saved on SUSPEND for re-deploy on resume
+  escrow   DeploymentEscrow? // Platform-level escrow for this deployment
+  savedSdl String?           @db.Text // SDL saved on SUSPEND for re-deploy on resume
 
   // GPU model resolved from provider after lease creation (e.g. "rtx4090", "a100")
-  gpuModel        String?
+  gpuModel String?
 
   // Error info
-  errorMessage    String?
+  errorMessage String?
 
   // QStash background job retry tracking
-  retryCount      Int                 @default(0)
-  parentDeploymentId String?          // Links retries to the original deployment
-  qstashMessageId String?             // For cancellation of pending QStash messages
+  retryCount         Int     @default(0)
+  parentDeploymentId String? // Links retries to the original deployment
+  qstashMessageId    String? // For cancellation of pending QStash messages
 
   // Phase 43 — health-aware auto-failover.
   // failoverParentId chains deployments that were spawned because the previous
@@ -1096,23 +1128,23 @@ model AkashDeployment {
   // links queue-step retries within a single deploy attempt).
   // excludedProviders accumulates per-chain bad providers so successive
   // failovers don't pick the same dead host.
-  failoverParentId    String?         @map("failover_parent_id")
-  excludedProviders   String[]        @default([]) @map("excluded_providers")
-  failoverReason      String?         @map("failover_reason")
+  failoverParentId  String?  @map("failover_parent_id")
+  excludedProviders String[] @default([]) @map("excluded_providers")
+  failoverReason    String?  @map("failover_reason")
 
   // Cost display (computed at lease creation, includes margin)
-  dailyRateCentsRaw     Int?          // Raw provider cost per day in cents
-  dailyRateCentsCharged Int?          // Cost after margin per day in cents
+  dailyRateCentsRaw     Int? // Raw provider cost per day in cents
+  dailyRateCentsCharged Int? // Cost after margin per day in cents
 
   // Deployment policy (budget, GPU, runtime constraints)
-  policyId        String?             @unique @map("policy_id")
-  policy          DeploymentPolicy?   @relation(fields: [policyId], references: [id], onDelete: SetNull)
+  policyId String?           @unique @map("policy_id")
+  policy   DeploymentPolicy? @relation(fields: [policyId], references: [id], onDelete: SetNull)
 
   // Timestamps
-  createdAt       DateTime            @default(now())
-  updatedAt       DateTime            @updatedAt
-  deployedAt      DateTime?           // When services became available
-  closedAt        DateTime?           // When deployment was closed
+  createdAt  DateTime  @default(now())
+  updatedAt  DateTime  @updatedAt
+  deployedAt DateTime? // When services became available
+  closedAt   DateTime? // When deployment was closed
 
   @@unique([owner, dseq])
   @@index([serviceId])
@@ -1124,18 +1156,18 @@ model AkashDeployment {
 }
 
 enum AkashDeploymentStatus {
-  CREATING           // Creating deployment on chain
-  WAITING_BIDS       // Waiting for provider bids
-  SELECTING_BID      // Selecting provider
-  CREATING_LEASE     // Creating lease with provider
-  SENDING_MANIFEST   // Sending manifest to provider
-  DEPLOYING          // Provider deploying containers
-  ACTIVE             // Deployment running
-  FAILED             // Deployment failed
-  CLOSED             // Deployment closed (permanent)
-  SUSPENDED          // Paused due to low balance (will auto-resume on topup)
+  CREATING // Creating deployment on chain
+  WAITING_BIDS // Waiting for provider bids
+  SELECTING_BID // Selecting provider
+  CREATING_LEASE // Creating lease with provider
+  SENDING_MANIFEST // Sending manifest to provider
+  DEPLOYING // Provider deploying containers
+  ACTIVE // Deployment running
+  FAILED // Deployment failed
+  CLOSED // Deployment closed (permanent)
+  SUSPENDED // Paused due to low balance (will auto-resume on topup)
   PERMANENTLY_FAILED // Failed after all retries exhausted
-  CLOSE_FAILED       // Local close attempt failed on-chain (RPC down, wallet empty, etc.) — needs operator/sweeper retry
+  CLOSE_FAILED // Local close attempt failed on-chain (RPC down, wallet empty, etc.) — needs operator/sweeper retry
 }
 
 // ============================================
@@ -1202,28 +1234,28 @@ model OrganizationConcurrencyCounter {
 // charge guard: even a buggy caller cannot insert two rows for the same
 // settlement window and end up double-billing the user.
 model PolicySettlementLedger {
-  id              String                  @id @default(cuid())
+  id String @id @default(cuid())
 
-  provider        SettlementProvider
-  kind            SettlementKind
-  deploymentRef   String                  @map("deployment_ref")
+  provider      SettlementProvider
+  kind          SettlementKind
+  deploymentRef String             @map("deployment_ref")
 
-  idempotencyKey  String                  @unique @map("idempotency_key")
+  idempotencyKey String @unique @map("idempotency_key")
 
-  orgBillingId    String                  @map("org_billing_id")
-  amountCents     Int                     @map("amount_cents")
-  settledTo       DateTime                @map("settled_to")
+  orgBillingId String   @map("org_billing_id")
+  amountCents  Int      @map("amount_cents")
+  settledTo    DateTime @map("settled_to")
 
-  status          PolicySettlementStatus  @default(PENDING)
-  attemptCount    Int                     @default(0) @map("attempt_count")
-  lastError       String?                 @map("last_error")
-  committedAt     DateTime?               @map("committed_at")
+  status       PolicySettlementStatus @default(PENDING)
+  attemptCount Int                    @default(0) @map("attempt_count")
+  lastError    String?                @map("last_error")
+  committedAt  DateTime?              @map("committed_at")
 
-  policyId        String?                 @map("policy_id")
-  metadata        Json?
+  policyId String? @map("policy_id")
+  metadata Json?
 
-  createdAt       DateTime                @default(now())
-  updatedAt       DateTime                @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([status, createdAt])
   @@index([deploymentRef])
@@ -1248,38 +1280,38 @@ enum PolicySettlementStatus {
 
 enum EscrowStatus {
   PENDING_DEPOSIT // Write-ahead: row created BEFORE the deposit RPC.
-                  // Reconciler retries / fails-out stuck rows so we never end up
-                  // in a state where the wallet was debited but no row exists
-                  // (or vice-versa: the row was created but the deposit failed).
-  ACTIVE          // Funds locked, daily consumption active
-  DEPLETED        // Escrow consumed, needs top-up or auto-top-up from wallet
-  REFUNDING       // Write-ahead for refund: row marked BEFORE the
-                  // refund RPC so we can reconcile if the credit RPC succeeded
-                  // but our local update never landed.
-  REFUNDED        // Deployment closed, remaining refunded to wallet
-  PAUSED          // Deployment paused due to low org balance
-  FAILED          // Terminal: write-ahead deposit could not be
-                  // completed (insufficient balance, persistent RPC failure).
+  // Reconciler retries / fails-out stuck rows so we never end up
+  // in a state where the wallet was debited but no row exists
+  // (or vice-versa: the row was created but the deposit failed).
+  ACTIVE // Funds locked, daily consumption active
+  DEPLETED // Escrow consumed, needs top-up or auto-top-up from wallet
+  REFUNDING // Write-ahead for refund: row marked BEFORE the
+  // refund RPC so we can reconcile if the credit RPC succeeded
+  // but our local update never landed.
+  REFUNDED // Deployment closed, remaining refunded to wallet
+  PAUSED // Deployment paused due to low org balance
+  FAILED // Terminal: write-ahead deposit could not be
+  // completed (insufficient balance, persistent RPC failure).
 }
 
 model DeploymentEscrow {
-  id                String        @id @default(cuid())
-  akashDeploymentId String        @unique @map("akash_deployment_id")
-  orgBillingId      String        @map("org_billing_id")    // OrganizationBilling.id from auth service
-  organizationId    String        @map("organization_id")
+  id                String @id @default(cuid())
+  akashDeploymentId String @unique @map("akash_deployment_id")
+  orgBillingId      String @map("org_billing_id") // OrganizationBilling.id from auth service
+  organizationId    String @map("organization_id")
 
-  depositCents      Int           @map("deposit_cents")      // Initial escrow amount (USD cents)
-  consumedCents     Int           @default(0) @map("consumed_cents")  // Consumed so far
-  dailyRateCents    Int           @map("daily_rate_cents")    // Provider cost/day + margin (USD cents)
-  refundedCents     Int           @default(0) @map("refunded_cents")  // Refunded on close
-  marginRate        Float         @map("margin_rate")         // Plan markup (0.25 or 0.20)
+  depositCents   Int   @map("deposit_cents") // Initial escrow amount (USD cents)
+  consumedCents  Int   @default(0) @map("consumed_cents") // Consumed so far
+  dailyRateCents Int   @map("daily_rate_cents") // Provider cost/day + margin (USD cents)
+  refundedCents  Int   @default(0) @map("refunded_cents") // Refunded on close
+  marginRate     Float @map("margin_rate") // Plan markup (0.25 or 0.20)
 
-  status            EscrowStatus  @default(ACTIVE)
-  lastBilledAt      DateTime?     @map("last_billed_at")
-  createdAt         DateTime      @default(now())
-  updatedAt         DateTime      @updatedAt
+  status       EscrowStatus @default(ACTIVE)
+  lastBilledAt DateTime?    @map("last_billed_at")
+  createdAt    DateTime     @default(now())
+  updatedAt    DateTime     @updatedAt
 
-  akashDeployment   AkashDeployment @relation(fields: [akashDeploymentId], references: [id], onDelete: Cascade)
+  akashDeployment AkashDeployment @relation(fields: [akashDeploymentId], references: [id], onDelete: Cascade)
 
   @@index([orgBillingId])
   @@index([organizationId])
@@ -1292,66 +1324,66 @@ model DeploymentEscrow {
 // ============================================
 
 enum PhalaDeploymentStatus {
-  CREATING           // CVM being created
-  STARTING           // CVM starting up
-  ACTIVE             // CVM running
-  FAILED             // Deployment failed
-  STOPPED            // CVM stopped
-  DELETED            // CVM deleted
+  CREATING // CVM being created
+  STARTING // CVM starting up
+  ACTIVE // CVM running
+  FAILED // Deployment failed
+  STOPPED // CVM stopped
+  DELETED // CVM deleted
   PERMANENTLY_FAILED // Failed after all retries exhausted
 }
 
 model PhalaDeployment {
-  id              String                  @id @default(cuid())
+  id String @id @default(cuid())
 
   // Identity
-  appId           String                  // Phala CVM App ID (hex string from CLI)
-  name            String                  // Internal name (e.g. af-<slug>-<suffix>)
+  appId String // Phala CVM App ID (hex string from CLI)
+  name  String // Internal name (e.g. af-<slug>-<suffix>)
 
   // Status
-  status          PhalaDeploymentStatus   @default(CREATING)
-  errorMessage    String?
+  status       PhalaDeploymentStatus @default(CREATING)
+  errorMessage String?
 
   // Config (what we deployed)
-  composeContent  String                  @db.Text
-  envKeys         Json?                   // Array of env var keys only (never values)
-  cvmSize         String?                 @map("cvm_size") // tdx.small, tdx.medium, tdx.large, tdx.xlarge
-  gpuModel        String?                 // GPU model selected at deploy time (e.g. "h200", "h100", "b200")
+  composeContent String  @db.Text
+  envKeys        Json? // Array of env var keys only (never values)
+  cvmSize        String? @map("cvm_size") // tdx.small, tdx.medium, tdx.large, tdx.xlarge
+  gpuModel       String? // GPU model selected at deploy time (e.g. "h200", "h100", "b200")
 
   // Outputs
-  appUrl          String?
-  teepod          String?
+  appUrl String?
+  teepod String?
 
   // Billing (per-hour, no escrow — debited directly from wallet)
-  hourlyRateCents Int?                    @map("hourly_rate_cents")  // Provider rate + margin (USD cents)
-  marginRate      Float?                  @map("margin_rate")        // Plan markup applied
-  orgBillingId    String?                 @map("org_billing_id")     // OrganizationBilling.id
-  organizationId  String?                 @map("organization_id")
-  activeStartedAt DateTime?               @map("active_started_at") // When CVM became ACTIVE
-  lastBilledAt    DateTime?               @map("last_billed_at")    // Last time daily job billed this
-  totalBilledCents Int                    @default(0) @map("total_billed_cents")
+  hourlyRateCents  Int?      @map("hourly_rate_cents") // Provider rate + margin (USD cents)
+  marginRate       Float?    @map("margin_rate") // Plan markup applied
+  orgBillingId     String?   @map("org_billing_id") // OrganizationBilling.id
+  organizationId   String?   @map("organization_id")
+  activeStartedAt  DateTime? @map("active_started_at") // When CVM became ACTIVE
+  lastBilledAt     DateTime? @map("last_billed_at") // Last time daily job billed this
+  totalBilledCents Int       @default(0) @map("total_billed_cents")
 
   // QStash background job retry tracking
-  retryCount      Int                     @default(0)
-  parentDeploymentId String?              // Links retries to original deployment
-  qstashMessageId String?                 // For cancellation of pending QStash messages
+  retryCount         Int     @default(0)
+  parentDeploymentId String? // Links retries to original deployment
+  qstashMessageId    String? // For cancellation of pending QStash messages
 
   // Relations
-  serviceId       String
-  service         Service                 @relation(fields: [serviceId], references: [id], onDelete: Cascade)
+  serviceId String
+  service   Service @relation(fields: [serviceId], references: [id], onDelete: Cascade)
 
-  siteId          String?
-  site            Site?                   @relation(fields: [siteId], references: [id], onDelete: SetNull)
+  siteId String?
+  site   Site?   @relation(fields: [siteId], references: [id], onDelete: SetNull)
 
-  afFunctionId    String?
-  afFunction      AFFunction?             @relation(fields: [afFunctionId], references: [id], onDelete: SetNull)
+  afFunctionId String?
+  afFunction   AFFunction? @relation(fields: [afFunctionId], references: [id], onDelete: SetNull)
 
-  createdAt       DateTime                @default(now())
-  updatedAt       DateTime                @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   // Deployment policy (budget, GPU, runtime constraints)
-  policyId        String?                 @unique @map("policy_id")
-  policy          DeploymentPolicy?       @relation(fields: [policyId], references: [id], onDelete: SetNull)
+  policyId String?           @unique @map("policy_id")
+  policy   DeploymentPolicy? @relation(fields: [policyId], references: [id], onDelete: SetNull)
 
   @@index([serviceId])
   @@index([siteId])
@@ -1379,38 +1411,38 @@ enum PolicyStopReason {
 }
 
 model DeploymentPolicy {
-  id                    String            @id @default(cuid())
+  id String @id @default(cuid())
 
   // GPU constraints
-  acceptableGpuModels   String[]          // ["h100", "h200", "a100"] — empty = any
-  gpuUnits              Int?              // number of GPU units requested
-  gpuVendor             String?           // "nvidia" | "amd" | null
+  acceptableGpuModels String[] // ["h100", "h200", "a100"] — empty = any
+  gpuUnits            Int? // number of GPU units requested
+  gpuVendor           String? // "nvidia" | "amd" | null
 
   // Budget constraints
-  maxBudgetUsd          Float?            @map("max_budget_usd")
-  maxMonthlyUsd         Float?            @map("max_monthly_usd")
+  maxBudgetUsd  Float? @map("max_budget_usd")
+  maxMonthlyUsd Float? @map("max_monthly_usd")
 
   // Duration constraints
-  runtimeMinutes        Int?              @map("runtime_minutes")
-  expiresAt             DateTime?         @map("expires_at")
+  runtimeMinutes Int?      @map("runtime_minutes")
+  expiresAt      DateTime? @map("expires_at")
 
   // Fund reservation for time-limited deployments (Phase 2).
   // When runtimeMinutes is set, reservedCents holds the full upfront cost
   // deducted from the org's available balance. Consumed as billing runs;
   // remainder refunded on stop/expiry.
-  reservedCents         Int               @default(0) @map("reserved_cents")
+  reservedCents Int @default(0) @map("reserved_cents")
 
   // Enforcement state
-  stopReason            PolicyStopReason? @map("stop_reason")
-  stoppedAt             DateTime?         @map("stopped_at")
-  totalSpentUsd         Float             @default(0) @map("total_spent_usd")
+  stopReason    PolicyStopReason? @map("stop_reason")
+  stoppedAt     DateTime?         @map("stopped_at")
+  totalSpentUsd Float             @default(0) @map("total_spent_usd")
 
-  createdAt             DateTime          @default(now())
-  updatedAt             DateTime          @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   // Relations (1:1 back-references)
-  akashDeployment       AkashDeployment?
-  phalaDeployment       PhalaDeployment?
+  akashDeployment AkashDeployment?
+  phalaDeployment PhalaDeployment?
 
   @@index([expiresAt])
   @@index([stopReason])
@@ -1427,39 +1459,39 @@ enum ComputeProviderType {
 }
 
 model ComputeProvider {
-  id                String              @id @default(cuid())
-  address           String              @unique
-  providerType      ComputeProviderType
-  name              String?
+  id           String              @id @default(cuid())
+  address      String              @unique
+  providerType ComputeProviderType
+  name         String?
 
   // Verification status (from test-deploy runs)
-  verified          Boolean             @default(false)
-  blocked           Boolean             @default(false)
-  blockReason       String?             @map("block_reason")
+  verified    Boolean @default(false)
+  blocked     Boolean @default(false)
+  blockReason String? @map("block_reason")
 
   // Live status (from hourly API scan)
-  isOnline          Boolean             @default(false)  @map("is_online")
-  lastSeenOnlineAt  DateTime?           @map("last_seen_online_at")
+  isOnline         Boolean   @default(false) @map("is_online")
+  lastSeenOnlineAt DateTime? @map("last_seen_online_at")
 
   // GPU inventory (from live API scan)
-  gpuModels         String[]            @map("gpu_models")
-  gpuAvailable      Int                 @default(0) @map("gpu_available")
-  gpuTotal          Int                 @default(0) @map("gpu_total")
+  gpuModels    String[] @map("gpu_models")
+  gpuAvailable Int      @default(0) @map("gpu_available")
+  gpuTotal     Int      @default(0) @map("gpu_total")
 
   // Pricing range (from actual deployment bids, in uact)
-  minPriceUact      BigInt?             @map("min_price_uact")
-  maxPriceUact      BigInt?             @map("max_price_uact")
+  minPriceUact BigInt? @map("min_price_uact")
+  maxPriceUact BigInt? @map("max_price_uact")
 
   // Raw provider attributes from chain/API
-  attributes        Json?
+  attributes Json?
 
   // Test metadata
-  lastTestedAt      DateTime?           @map("last_tested_at")
+  lastTestedAt DateTime? @map("last_tested_at")
 
-  createdAt         DateTime            @default(now())
-  updatedAt         DateTime            @updatedAt
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
-  templateResults   ProviderTemplateResult[]
+  templateResults ProviderTemplateResult[]
 
   @@index([providerType])
   @@index([verified])
@@ -1468,19 +1500,19 @@ model ComputeProvider {
 }
 
 model ProviderTemplateResult {
-  id              String          @id @default(cuid())
+  id String @id @default(cuid())
 
-  providerId      String          @map("provider_id")
-  provider        ComputeProvider @relation(fields: [providerId], references: [id], onDelete: Cascade)
+  providerId String          @map("provider_id")
+  provider   ComputeProvider @relation(fields: [providerId], references: [id], onDelete: Cascade)
 
-  templateId      String          @map("template_id")
+  templateId String @map("template_id")
 
-  passed          Boolean
-  priceUact       BigInt?         @map("price_uact")
-  durationMs      Int?            @map("duration_ms")
-  errorMessage    String?         @map("error_message")
+  passed       Boolean
+  priceUact    BigInt? @map("price_uact")
+  durationMs   Int?    @map("duration_ms")
+  errorMessage String? @map("error_message")
 
-  testedAt        DateTime        @default(now()) @map("tested_at")
+  testedAt DateTime @default(now()) @map("tested_at")
 
   @@unique([providerId, templateId])
   @@index([templateId])
@@ -1502,23 +1534,23 @@ model ProviderTemplateResult {
 // a single-row cache of measured Akash block geometry for cost reporting.
 
 model GpuBidObservation {
-  id            String   @id @default(cuid())
+  id String @id @default(cuid())
 
   /// Groups all bids collected during a single runGpuBidProbeCycle invocation.
-  probeRunId    String   @map("probe_run_id")
+  probeRunId String @map("probe_run_id")
 
   /// Lowercase canonical model id ("h100", "rtx4090", "a100"). Matches
   /// `compute_provider.gpu_models` element values.
-  gpuModel      String   @map("gpu_model")
-  vendor        String   // "nvidia" | "amd"
+  gpuModel String @map("gpu_model")
+  vendor   String // "nvidia" | "amd"
 
-  providerAddr  String   @map("provider_addr")
-  pricePerBlock BigInt   @map("price_per_block_uact")
+  providerAddr  String @map("provider_addr")
+  pricePerBlock BigInt @map("price_per_block_uact")
 
   /// dseq of the probe deployment. Useful for audit / debugging the close
   /// path on the "did this probe leak escrow?" question.
-  dseq          BigInt
-  observedAt    DateTime @default(now()) @map("observed_at")
+  dseq       BigInt
+  observedAt DateTime @default(now()) @map("observed_at")
 
   @@index([gpuModel, observedAt])
   @@index([probeRunId])
@@ -1527,18 +1559,18 @@ model GpuBidObservation {
 
 model GpuPriceSummary {
   /// Lowercase model id; primary key (one row per GPU model).
-  gpuModel             String   @id @map("gpu_model")
-  vendor               String
+  gpuModel String @id @map("gpu_model")
+  vendor   String
 
-  minPricePerBlock     BigInt   @map("min_price_per_block_uact")
-  p50PricePerBlock     BigInt   @map("p50_price_per_block_uact")
-  p90PricePerBlock     BigInt   @map("p90_price_per_block_uact")
-  maxPricePerBlock     BigInt   @map("max_price_per_block_uact")
+  minPricePerBlock BigInt @map("min_price_per_block_uact")
+  p50PricePerBlock BigInt @map("p50_price_per_block_uact")
+  p90PricePerBlock BigInt @map("p90_price_per_block_uact")
+  maxPricePerBlock BigInt @map("max_price_per_block_uact")
 
-  sampleCount          Int      @map("sample_count")
-  uniqueProviderCount  Int      @map("unique_provider_count")
-  windowDays           Int      @default(7) @map("window_days")
-  refreshedAt          DateTime @map("refreshed_at")
+  sampleCount         Int      @map("sample_count")
+  uniqueProviderCount Int      @map("unique_provider_count")
+  windowDays          Int      @default(7) @map("window_days")
+  refreshedAt         DateTime @map("refreshed_at")
 
   @@map("gpu_price_summary")
 }
@@ -1566,19 +1598,19 @@ enum FeedbackCategory {
 }
 
 model FeedbackReport {
-  id          String           @id @default(cuid())
+  id String @id @default(cuid())
 
-  userId      String           @map("user_id")
-  user        User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId String @map("user_id")
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   title       String
   category    FeedbackCategory
   location    String?
   description String
 
-  userAgent   String?          @map("user_agent")
+  userAgent String? @map("user_agent")
 
-  createdAt   DateTime         @default(now()) @map("created_at")
+  createdAt DateTime @default(now()) @map("created_at")
 
   @@index([userId])
   @@index([category])
@@ -1598,30 +1630,30 @@ model FeedbackReport {
 /// `bidsCollected` and `uniqueProviders` come from the bids inserted
 /// into `gpu_bid_observation` for this run.
 model GpuProbeRun {
-  id              String    @id @default(cuid())
+  id String @id @default(cuid())
 
   /// Mirrors `gpu_bid_observation.probe_run_id` so admin tools can join
   /// bids back to their cycle without an extra index.
-  probeRunId      String    @unique @map("probe_run_id")
+  probeRunId String @unique @map("probe_run_id")
 
-  startedAt       DateTime  @map("started_at")
-  completedAt     DateTime? @map("completed_at")
+  startedAt   DateTime  @map("started_at")
+  completedAt DateTime? @map("completed_at")
 
-  modelsProbed    Int       @default(0) @map("models_probed")
-  bidsCollected   Int       @default(0) @map("bids_collected")
-  uniqueProviders Int       @default(0) @map("unique_providers")
+  modelsProbed    Int @default(0) @map("models_probed")
+  bidsCollected   Int @default(0) @map("bids_collected")
+  uniqueProviders Int @default(0) @map("unique_providers")
 
   /// Wallet uact spend for the cycle (`balanceBefore.uact - balanceAfter.uact`,
   /// floored at 0 — wallet refills mid-cycle would otherwise produce a
   /// misleading negative).
-  costUact        BigInt    @default(0) @map("cost_uact")
+  costUact BigInt @default(0) @map("cost_uact")
   /// Same idea for uakt, included for symmetry with VerificationRun and
   /// for any pre-BME residue. Expected to stay 0 in production.
-  costUakt        BigInt    @default(0) @map("cost_uakt")
+  costUakt BigInt @default(0) @map("cost_uakt")
 
-  status          String    @default("running") // running | completed | failed | skipped
+  status String  @default("running") // running | completed | failed | skipped
   /// Slim error message — full traces go to logs via opsAlert.
-  error           String?
+  error  String?
 
   @@index([startedAt])
   @@index([status])
@@ -1629,28 +1661,104 @@ model GpuProbeRun {
 }
 
 model VerificationRun {
-  id              String    @id @default(cuid())
+  id String @id @default(cuid())
 
-  startedAt       DateTime  @map("started_at")
-  completedAt     DateTime? @map("completed_at")
+  startedAt   DateTime  @map("started_at")
+  completedAt DateTime? @map("completed_at")
 
   // Run results
-  templatesTotal  Int       @map("templates_total")
-  templatesPassed Int       @map("templates_passed")
-  deployments     Int       @default(0)
-  passed          Int       @default(0)
-  failed          Int       @default(0)
-  uniqueProviders Int       @default(0) @map("unique_providers")
+  templatesTotal  Int @map("templates_total")
+  templatesPassed Int @map("templates_passed")
+  deployments     Int @default(0)
+  passed          Int @default(0)
+  failed          Int @default(0)
+  uniqueProviders Int @default(0) @map("unique_providers")
 
   // Cost (balance delta)
-  costUakt        BigInt    @default(0) @map("cost_uakt")
-  costUact        BigInt    @default(0) @map("cost_uact")
+  costUakt BigInt @default(0) @map("cost_uakt")
+  costUact BigInt @default(0) @map("cost_uact")
 
   // Status
-  status          String    @default("running") // running | completed | failed
-  error           String?
+  status String  @default("running") // running | completed | failed
+  error  String?
 
   @@index([startedAt])
   @@index([status])
   @@map("verification_run")
+}
+
+// ============================================
+// GIT-SOURCE DEPLOYMENTS (provider-agnostic)
+// ============================================
+//
+// We model GitHub-specific concepts (App installations, Apps webhooks)
+// here, but Service.git* and BuildJob are intentionally provider-agnostic
+// — adding GitLab/Bitbucket later means a sibling install model and a
+// new value for Service.gitProvider, not a redesign.
+//
+// The compute provider that ultimately runs the built image is decoupled
+// from the source provider: it's chosen per-deploy via the existing
+// ComputeMode picker (Standard → Akash, Confidential → Phala), the same
+// way every other flavor (docker / server / function / template) picks.
+// No git-specific routing column lives on Service.
+
+enum BuildStatus {
+  PENDING
+  RUNNING
+  SUCCEEDED
+  FAILED
+  CANCELED
+}
+
+model GithubInstallation {
+  id             String @id @default(cuid())
+  organizationId String
+  installationId BigInt @unique // GitHub's numeric install id
+  accountLogin   String
+  accountId      BigInt
+  accountType    String // 'User' | 'Organization'
+  targetType     String // 'all' | 'selected'
+
+  installedByUserId String?
+  selectedRepos     Json? // Last-known list of selected repo full_names (when targetType='selected')
+  suspendedAt       DateTime?
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  organization Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  installedBy  User?        @relation("GithubInstallationInstaller", fields: [installedByUserId], references: [id], onDelete: SetNull)
+  services     Service[]
+
+  @@index([organizationId])
+  @@index([accountLogin])
+  @@map("github_installation")
+}
+
+model BuildJob {
+  id                String      @id @default(cuid())
+  serviceId         String
+  commitSha         String
+  commitMessage     String?
+  branch            String
+  status            BuildStatus @default(PENDING)
+  k8sJobName        String? // Kubernetes Job name spawned for this build
+  imageTag          String? // Final image tag pushed to GHCR on success
+  detectedFramework String? // Nixpacks-detected framework (Next.js, Vite, …)
+  detectedPort      Int? // Port the built image listens on
+  logs              String?     @db.Text // Truncated builder logs (≤ 60 kB)
+  triggeredBy       String? // 'first-deploy' | 'webhook:push' | 'manual:<userId>'
+  startedAt         DateTime?
+  finishedAt        DateTime?
+  errorMessage      String? // Truncated (≤ 4 kB)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  service Service @relation(fields: [serviceId], references: [id], onDelete: Cascade)
+
+  @@index([serviceId])
+  @@index([status])
+  @@index([commitSha])
+  @@map("build_job")
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,8 @@ import { handleAdminBillingStats } from './services/admin/billingStatsEndpoint.j
 import { handleSchedulerStats } from './services/admin/schedulerStatsEndpoint.js'
 import { handleAdminAuditEvents } from './services/admin/auditEventsEndpoint.js'
 import { handlePhalaInstanceTypesRequest } from './services/providers/phalaInstanceTypesEndpoint.js'
+import { handleBuildCallback } from './services/github/buildCallbackEndpoint.js'
+import { handleGithubWebhook } from './services/github/webhookEndpoint.js'
 import { reconcileActivePolicyExpirySchedules } from './services/policy/runtimeScheduler.js'
 import { ShellEndpoint } from './services/shell/shellEndpoint.js'
 import { LogStreamEndpoint } from './services/logs/logStreamEndpoint.js'
@@ -262,6 +264,16 @@ async function requestHandler(req: IncomingMessage, res: ServerResponse) {
 
     if (url.pathname === '/webhooks/stripe') {
       await handleStripeWebhook(req, res, prisma)
+      return
+    }
+
+    if (url.pathname === '/webhooks/github') {
+      await handleGithubWebhook(req, res, prisma)
+      return
+    }
+
+    if (url.pathname === '/internal/build-callback' && req.method === 'POST') {
+      await handleBuildCallback(req, res, prisma)
       return
     }
 

--- a/src/resolvers/github.ts
+++ b/src/resolvers/github.ts
@@ -46,6 +46,52 @@ function assertGithubConfigured() {
   }
 }
 
+/**
+ * Validate user-supplied `rootDirectory` before it lands on the Service row
+ * (and from there into `cd "$ROOT_DIRECTORY"` inside the builder script).
+ *
+ * Allowed: relative paths made of [a-zA-Z0-9._-/] segments, no `..` segments,
+ * no leading `/`, no leading `~`, max 256 chars. `null`/empty pass through
+ * (means "repo root", handled downstream by `input.rootDirectory || '.'`).
+ *
+ * We deliberately reject `..` even mid-path — there's no legitimate use case
+ * for a builder workdir to escape the clone, and silently allowing it is
+ * how shell-injection foot-guns get found by reviewers (rightly so).
+ */
+function normalizeRootDirectory(input: string | null | undefined): string | null {
+  if (input == null) return null
+  const trimmed = input.trim()
+  if (trimmed === '' || trimmed === '.' || trimmed === './') return null
+  if (trimmed.length > 256) {
+    throw new GraphQLError('rootDirectory too long (max 256 chars)', {
+      extensions: { code: 'INVALID_ROOT_DIRECTORY' },
+    })
+  }
+  if (trimmed.startsWith('/') || trimmed.startsWith('~')) {
+    throw new GraphQLError('rootDirectory must be a relative path inside the repo', {
+      extensions: { code: 'INVALID_ROOT_DIRECTORY' },
+    })
+  }
+  // Disallow any segment that's exactly `..` — safer than a regex `..` ban
+  // which would also reject a legitimate `my..weird..folder` (uncommon but
+  // legal on GitHub).
+  const segments = trimmed.split('/')
+  for (const seg of segments) {
+    if (seg === '..') {
+      throw new GraphQLError('rootDirectory cannot traverse above the repo root', {
+        extensions: { code: 'INVALID_ROOT_DIRECTORY' },
+      })
+    }
+  }
+  if (!/^[A-Za-z0-9._\-/]+$/.test(trimmed)) {
+    throw new GraphQLError(
+      'rootDirectory may only contain letters, numbers, dot, dash, underscore, and slash',
+      { extensions: { code: 'INVALID_ROOT_DIRECTORY' } },
+    )
+  }
+  return trimmed
+}
+
 function imageTagFor(userId: string, owner: string, repo: string, sha: string): string {
   const cfg = getGithubAppConfig()
   // Docker registry refs MUST be all lowercase. Prisma cuid userIds like
@@ -403,6 +449,7 @@ export const githubMutations = {
     const userId = requireAuth(context)
     assertGithubConfigured()
     const { input } = args
+    const safeRootDirectory = normalizeRootDirectory(input.rootDirectory)
 
     const project = await context.prisma.project.findUnique({
       where: { id: input.projectId },
@@ -446,7 +493,7 @@ export const githubMutations = {
         gitRepo: input.repo,
         gitBranch: branchName,
         gitInstallationId: install.id,
-        rootDirectory: input.rootDirectory ?? null,
+        rootDirectory: safeRootDirectory,
         buildCommand: input.buildCommand ?? null,
         startCommand: input.startCommand ?? null,
         internalHostname: generateInternalHostname(slug, project.slug),
@@ -471,7 +518,7 @@ export const githubMutations = {
       owner: input.owner,
       repo: input.repo,
       branch: branchName,
-      rootDirectory: input.rootDirectory ?? null,
+      rootDirectory: safeRootDirectory,
       buildCommand: input.buildCommand ?? null,
       startCommand: input.startCommand ?? null,
       triggeredBy: 'first-deploy',
@@ -506,6 +553,7 @@ export const githubMutations = {
     const userId = requireAuth(context)
     assertGithubConfigured()
     const { input } = args
+    const safeRootDirectory = normalizeRootDirectory(input.rootDirectory)
 
     const service = await context.prisma.service.findUnique({
       where: { id: input.serviceId },
@@ -543,7 +591,7 @@ export const githubMutations = {
         gitRepo: input.repo,
         gitBranch: branchName,
         gitInstallationId: install.id,
-        rootDirectory: input.rootDirectory ?? null,
+        rootDirectory: safeRootDirectory,
         buildCommand: input.buildCommand ?? null,
         startCommand: input.startCommand ?? null,
       },
@@ -556,7 +604,7 @@ export const githubMutations = {
       owner: input.owner,
       repo: input.repo,
       branch: branchName,
-      rootDirectory: input.rootDirectory ?? null,
+      rootDirectory: safeRootDirectory,
       buildCommand: input.buildCommand ?? null,
       startCommand: input.startCommand ?? null,
       triggeredBy: 'first-deploy',

--- a/src/resolvers/github.ts
+++ b/src/resolvers/github.ts
@@ -147,6 +147,55 @@ function imageTagFor(userId: string, owner: string, repo: string, sha: string): 
 export const githubQueries = {
   githubAppEnabled: () => isGithubAppConfigured(),
 
+  /**
+   * Lazy-load a single BuildJob by id, including the heavy `logs` blob.
+   *
+   * The Source-tab build-history list intentionally omits `logs` from its
+   * polling query (logs can be 60KB per row, polled every 3s while a build
+   * is in flight — that's a lot of bytes for collapsed rows nobody is
+   * looking at). When the user expands a row, we hit this query for that
+   * one job. Auth-checked: caller must own the parent service's project.
+   */
+  buildJob: async (_: unknown, args: { id: string }, context: Context) => {
+    requireAuth(context)
+    const job = await context.prisma.buildJob.findUnique({
+      where: { id: args.id },
+      include: { service: { include: { project: true } } },
+    })
+    if (!job) return null
+    assertProjectAccess(context, job.service.project)
+    return job
+  },
+
+  /**
+   * List recent BuildJobs for a service. Mirrors the `Service.buildJobs(limit)`
+   * field resolver but is reachable without first fetching the parent Service
+   * — the Source-tab build-history list only knows the serviceId and doesn't
+   * want to round-trip the entire Service payload on every 3s poll.
+   *
+   * Logs blob is intentionally available on each row (the schema can't gate
+   * fields per-query), but the frontend polling query OMITS `logs` from its
+   * selection set; logs are fetched via `buildJob(id)` only on row expand.
+   */
+  serviceBuildJobs: async (
+    _: unknown,
+    args: { serviceId: string; limit?: number },
+    context: Context,
+  ) => {
+    requireAuth(context)
+    const service = await context.prisma.service.findUnique({
+      where: { id: args.serviceId },
+      include: { project: true },
+    })
+    if (!service) throw new GraphQLError('service not found')
+    assertProjectAccess(context, service.project)
+    return context.prisma.buildJob.findMany({
+      where: { serviceId: args.serviceId },
+      orderBy: { createdAt: 'desc' },
+      take: Math.min(Math.max(args.limit ?? 20, 1), 100),
+    })
+  },
+
   /** Slug used in install URLs: https://github.com/apps/<slug>/installations/new */
   githubAppSlug: () => {
     if (!isGithubAppConfigured()) return null
@@ -240,14 +289,23 @@ async function startBuild(
     installationIdNum: bigint
     owner: string
     repo: string
+    /** Branch name persisted on the BuildJob — what shows up in the UI as "main", "develop", etc. */
     branch: string
+    /**
+     * Optional override of the GitHub ref used to RESOLVE the commit (passes
+     * through to GET /repos/:owner/:repo/commits/:ref, which accepts a branch
+     * name OR a SHA). Used by per-commit rebuilds from the build-history UI:
+     * we still tag the BuildJob with the original branch label, but resolve
+     * the commit at the user-specified SHA. Defaults to `branch`.
+     */
+    ref?: string
     rootDirectory: string | null
     buildCommand: string | null
     startCommand: string | null
     triggeredBy: string
   },
 ) {
-  const commit = await getCommit(args.installationIdNum, args.owner, args.repo, args.branch)
+  const commit = await getCommit(args.installationIdNum, args.owner, args.repo, args.ref ?? args.branch)
 
   const buildJob = await context.prisma.buildJob.create({
     data: {
@@ -656,7 +714,7 @@ export const githubMutations = {
 
   redeployGithubService: async (
     _: unknown,
-    args: { serviceId: string },
+    args: { serviceId: string; sha?: string | null },
     context: Context,
   ) => {
     const userId = requireAuth(context)
@@ -672,6 +730,24 @@ export const githubMutations = {
       throw new GraphQLError('service is not connected to a git repo')
     }
 
+    // Optional `sha` override: per-commit rebuild from the build-history UI.
+    // Validate strictly to a hex SHA before flowing it into the GitHub commit
+    // URL path — `getCommit` accepts any ref (branch, SHA, tag), and we don't
+    // want unvalidated user input riding along to GitHub or, after resolution,
+    // becoming part of a docker image tag.
+    let ref: string | undefined
+    let triggeredBy = `manual:${userId}`
+    if (args.sha != null && args.sha !== '') {
+      const sha = args.sha.trim().toLowerCase()
+      if (!/^[0-9a-f]{7,40}$/.test(sha)) {
+        throw new GraphQLError('sha must be a 7-40 character hex commit SHA', {
+          extensions: { code: 'INVALID_SHA' },
+        })
+      }
+      ref = sha
+      triggeredBy = `manual-sha:${userId}`
+    }
+
     return startBuild(context, {
       serviceId: service.id,
       userId,
@@ -679,10 +755,11 @@ export const githubMutations = {
       owner: service.gitOwner,
       repo: service.gitRepo,
       branch: service.gitBranch,
+      ref,
       rootDirectory: service.rootDirectory,
       buildCommand: service.buildCommand,
       startCommand: service.startCommand,
-      triggeredBy: `manual:${userId}`,
+      triggeredBy,
     })
   },
 }

--- a/src/resolvers/github.ts
+++ b/src/resolvers/github.ts
@@ -92,6 +92,43 @@ function normalizeRootDirectory(input: string | null | undefined): string | null
   return trimmed
 }
 
+/**
+ * Validate user-supplied build/start commands.
+ *
+ * Intentionally permissive on shell syntax — these strings are run verbatim
+ * by the af-builder Job (`bash -lc "$BUILD_COMMAND"` after b64 round-trip),
+ * which is the feature: users type "pnpm run build:prod && rm -rf dist/foo"
+ * and it has to work. Banning shell metacharacters would break the product.
+ *
+ * What we DO guard against:
+ *   - Length: 4 KiB cap so a runaway frontend (or attacker) can't pin a
+ *     row with a multi-MiB blob and balloon DB / log payloads.
+ *   - Null bytes: Postgres TEXT chokes on \0 in some drivers and they
+ *     have no legitimate place in a shell command.
+ *
+ * Returns the trimmed string (or null for empty) so callers don't have to
+ * remember whether they validated; if it returned, it's safe to persist.
+ */
+function normalizeShellCommand(
+  input: string | null | undefined,
+  fieldName: 'buildCommand' | 'startCommand',
+): string | null {
+  if (input == null) return null
+  const trimmed = input.trim()
+  if (trimmed === '') return null
+  if (trimmed.length > 4096) {
+    throw new GraphQLError(`${fieldName} too long (max 4096 chars)`, {
+      extensions: { code: 'INVALID_COMMAND' },
+    })
+  }
+  if (trimmed.includes('\0')) {
+    throw new GraphQLError(`${fieldName} cannot contain null bytes`, {
+      extensions: { code: 'INVALID_COMMAND' },
+    })
+  }
+  return trimmed
+}
+
 function imageTagFor(userId: string, owner: string, repo: string, sha: string): string {
   const cfg = getGithubAppConfig()
   // Docker registry refs MUST be all lowercase. Prisma cuid userIds like
@@ -450,6 +487,8 @@ export const githubMutations = {
     assertGithubConfigured()
     const { input } = args
     const safeRootDirectory = normalizeRootDirectory(input.rootDirectory)
+    const safeBuildCommand = normalizeShellCommand(input.buildCommand, 'buildCommand')
+    const safeStartCommand = normalizeShellCommand(input.startCommand, 'startCommand')
 
     const project = await context.prisma.project.findUnique({
       where: { id: input.projectId },
@@ -494,8 +533,8 @@ export const githubMutations = {
         gitBranch: branchName,
         gitInstallationId: install.id,
         rootDirectory: safeRootDirectory,
-        buildCommand: input.buildCommand ?? null,
-        startCommand: input.startCommand ?? null,
+        buildCommand: safeBuildCommand,
+        startCommand: safeStartCommand,
         internalHostname: generateInternalHostname(slug, project.slug),
       },
     })
@@ -519,8 +558,8 @@ export const githubMutations = {
       repo: input.repo,
       branch: branchName,
       rootDirectory: safeRootDirectory,
-      buildCommand: input.buildCommand ?? null,
-      startCommand: input.startCommand ?? null,
+      buildCommand: safeBuildCommand,
+      startCommand: safeStartCommand,
       triggeredBy: 'first-deploy',
     })
 
@@ -554,6 +593,8 @@ export const githubMutations = {
     assertGithubConfigured()
     const { input } = args
     const safeRootDirectory = normalizeRootDirectory(input.rootDirectory)
+    const safeBuildCommand = normalizeShellCommand(input.buildCommand, 'buildCommand')
+    const safeStartCommand = normalizeShellCommand(input.startCommand, 'startCommand')
 
     const service = await context.prisma.service.findUnique({
       where: { id: input.serviceId },
@@ -592,8 +633,8 @@ export const githubMutations = {
         gitBranch: branchName,
         gitInstallationId: install.id,
         rootDirectory: safeRootDirectory,
-        buildCommand: input.buildCommand ?? null,
-        startCommand: input.startCommand ?? null,
+        buildCommand: safeBuildCommand,
+        startCommand: safeStartCommand,
       },
     })
 
@@ -605,8 +646,8 @@ export const githubMutations = {
       repo: input.repo,
       branch: branchName,
       rootDirectory: safeRootDirectory,
-      buildCommand: input.buildCommand ?? null,
-      startCommand: input.startCommand ?? null,
+      buildCommand: safeBuildCommand,
+      startCommand: safeStartCommand,
       triggeredBy: 'first-deploy',
     })
 

--- a/src/resolvers/github.ts
+++ b/src/resolvers/github.ts
@@ -48,11 +48,13 @@ function assertGithubConfigured() {
 
 function imageTagFor(userId: string, owner: string, repo: string, sha: string): string {
   const cfg = getGithubAppConfig()
-  // ghcr is case-insensitive and lowercases on the server; pre-lowercase
-  // here so logs / DB rows match what any provider will eventually pull.
+  // Docker registry refs MUST be all lowercase. Prisma cuid userIds like
+  // `gbufejdLUQOs2lh3MLjDS` mix case and break `docker build -t …`. Lowercase
+  // every component so the tag is valid before nixpacks/buildx ever sees it.
+  const safeUserId = userId.toLowerCase().replace(/[^a-z0-9-]/g, '-')
   const safeOwner = owner.toLowerCase().replace(/[^a-z0-9-]/g, '-')
   const safeRepo = repo.toLowerCase().replace(/[^a-z0-9-]/g, '-')
-  return `ghcr.io/${cfg.ghcrNamespace}/${userId}--${safeOwner}-${safeRepo}:${sha.slice(0, 12)}`
+  return `ghcr.io/${cfg.ghcrNamespace}/${safeUserId}--${safeOwner}-${safeRepo}:${sha.slice(0, 12)}`
 }
 
 // =====================================================================

--- a/src/resolvers/github.ts
+++ b/src/resolvers/github.ts
@@ -28,6 +28,7 @@ import { createLogger } from '../lib/logger.js'
 import { getGithubAppConfig, isGithubAppConfigured } from '../services/github/config.js'
 import {
   getInstallation,
+  listAllInstallations,
   listInstallationRepos,
   listRepoBranches,
   getRepo,
@@ -67,6 +68,16 @@ export const githubQueries = {
     return getGithubAppConfig().appSlug
   },
 
+  /**
+   * Pure DB read — fast (<10ms). The picker mounts on every panel open
+   * and we used to live-sync to GitHub here, which on a cold module
+   * load (tsx-watch + jsonwebtoken + GitHub TLS + sequential upserts)
+   * blew past 12s and wedged the UI. Live-sync is now an explicit
+   * mutation (`refreshGithubInstallations`) the UI calls only when it
+   * actually needs fresh data: empty cache, Refresh button, or after
+   * the user installs the App in a popup. Webhook-driven upserts will
+   * keep the cache fresh in prod once we wire `installation` events.
+   */
   githubInstallations: async (
     _: unknown,
     args: { orgId?: string },
@@ -163,6 +174,20 @@ async function startBuild(
     },
   })
 
+  // Mirror the new build's metadata onto the Service so the UI's Source-tab
+  // build card reflects progress without waiting for a builder callback. The
+  // build callback later overwrites lastBuildStatus with SUCCEEDED / FAILED;
+  // in BUILDER_DRY_RUN mode the callback never fires, so this is also what
+  // makes local dev show PENDING instead of "No builds yet".
+  await context.prisma.service.update({
+    where: { id: args.serviceId },
+    data: {
+      lastBuildSha: commit.sha,
+      lastBuildStatus: 'PENDING',
+      lastBuildAt: new Date(),
+    },
+  })
+
   const imageTag = imageTagFor(args.userId, args.owner, args.repo, commit.sha)
   try {
     const spawned = await spawnBuildJob({
@@ -180,6 +205,38 @@ async function startBuild(
       where: { id: buildJob.id },
       data: { k8sJobName: spawned.k8sJobName, status: 'RUNNING' },
     })
+    await context.prisma.service.update({
+      where: { id: args.serviceId },
+      data: { lastBuildStatus: 'RUNNING' },
+    })
+
+    // BUILDER_DRY_RUN=1 short-circuit: no K8s Job was actually created, so the
+    // build callback will never fire. Synthesize an immediate SUCCEEDED state
+    // (with a fake imageTag) so local dev mirrors prod end-to-end and the UI
+    // doesn't sit on "Building…" forever. We deliberately skip the
+    // autoDeployAfterBuild step here — local dev usually doesn't want to spend
+    // tAKT every time you connect a repo. The user clicks "Deploy" manually.
+    if (spawned.dryRun) {
+      const now = new Date()
+      await context.prisma.buildJob.update({
+        where: { id: buildJob.id },
+        data: {
+          status: 'SUCCEEDED',
+          imageTag,
+          startedAt: now,
+          finishedAt: now,
+          logs: 'BUILDER_DRY_RUN=1 — synthetic SUCCEEDED (no K8s Job spawned).',
+        },
+      })
+      await context.prisma.service.update({
+        where: { id: args.serviceId },
+        data: {
+          lastBuildStatus: 'SUCCEEDED',
+          lastBuildAt: now,
+          dockerImage: imageTag,
+        },
+      })
+    }
   } catch (err) {
     log.error({ err, buildJobId: buildJob.id }, 'failed to spawn builder Job')
     await context.prisma.buildJob.update({
@@ -189,6 +246,10 @@ async function startBuild(
         errorMessage: err instanceof Error ? err.message : String(err),
         finishedAt: new Date(),
       },
+    })
+    await context.prisma.service.update({
+      where: { id: args.serviceId },
+      data: { lastBuildStatus: 'FAILED' },
     })
     throw new GraphQLError('failed to start build', {
       extensions: { code: 'BUILDER_SPAWN_FAILED' },
@@ -249,6 +310,68 @@ export const githubMutations = {
         targetType: meta.repository_selection,
         suspendedAt: meta.suspended_at ? new Date(meta.suspended_at) : null,
       },
+    })
+  },
+
+  /**
+   * Live-sync ALL App installations from GitHub into the local DB and
+   * return the org's installations after the sync. Slow path (one
+   * /app/installations call + N upserts) — only invoked by the UI's
+   * "Refresh" button or after the user installs the App in a popup.
+   * The plain `githubInstallations` query stays a pure DB read.
+   */
+  refreshGithubInstallations: async (
+    _: unknown,
+    args: { orgId?: string },
+    context: Context,
+  ) => {
+    const userId = requireAuth(context)
+    assertGithubConfigured()
+    const orgId = args.orgId || context.organizationId
+    if (!orgId) throw new GraphQLError('orgId required')
+
+    try {
+      const live = await listAllInstallations()
+      for (const inst of live) {
+        const accountLogin = inst.account?.login ?? 'unknown'
+        const accountId = BigInt(inst.account?.id ?? 0)
+        const accountType = inst.account?.type ?? 'User'
+        const targetType = inst.repository_selection === 'selected' ? 'selected' : 'all'
+        const suspendedAt = inst.suspended_at ? new Date(inst.suspended_at) : null
+        await context.prisma.githubInstallation.upsert({
+          where: { installationId: BigInt(inst.id) },
+          create: {
+            installationId: BigInt(inst.id),
+            organizationId: orgId,
+            installedByUserId: userId,
+            accountLogin,
+            accountId,
+            accountType,
+            targetType,
+            suspendedAt,
+          },
+          update: {
+            accountLogin,
+            accountId,
+            accountType,
+            targetType,
+            suspendedAt,
+          },
+        })
+      }
+    } catch (err) {
+      log.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        'live installation sync failed',
+      )
+      throw new GraphQLError('failed to sync installations from GitHub', {
+        extensions: { code: 'GITHUB_SYNC_FAILED' },
+      })
+    }
+
+    return context.prisma.githubInstallation.findMany({
+      where: { organizationId: orgId },
+      orderBy: { createdAt: 'desc' },
     })
   },
 

--- a/src/resolvers/github.ts
+++ b/src/resolvers/github.ts
@@ -1,0 +1,501 @@
+/**
+ * GraphQL resolvers for the GitHub-source deploy flow.
+ *
+ * Two service-creation paths exist; both end up at the same `startBuild`
+ * helper which spawns the K8s builder Job:
+ *
+ *   1. `createGithubService(input)` — all-in-one: creates the Service row
+ *      and connects it to the repo in one mutation. Used by API/CLI users
+ *      who already know everything they need.
+ *
+ *   2. `connectGithubRepo(input)` — connects an existing (empty,
+ *      github-flavor) Service created by the catalog flow. This is the
+ *      panel UX: user picks "GitHub" from the catalog, lands in the
+ *      Source tab, picks installation/repo/branch.
+ *
+ * The compute provider that runs the built image is NOT chosen here —
+ * the build callback auto-deploys via the existing per-deploy provider
+ * mechanism (active deployment's provider on rebuilds, ComputeMode
+ * default on first deploy). Same pattern as docker/server flavors.
+ */
+
+import { GraphQLError } from 'graphql'
+import type { Context } from './types.js'
+import { requireAuth, assertProjectAccess } from '../utils/authorization.js'
+import { generateSlug } from '../utils/slug.js'
+import { generateInternalHostname } from '../utils/internalHostname.js'
+import { createLogger } from '../lib/logger.js'
+import { getGithubAppConfig, isGithubAppConfigured } from '../services/github/config.js'
+import {
+  getInstallation,
+  listInstallationRepos,
+  listRepoBranches,
+  getRepo,
+  getCommit,
+} from '../services/github/client.js'
+import { spawnBuildJob } from '../services/github/buildSpawner.js'
+
+const log = createLogger('resolvers.github')
+
+function assertGithubConfigured() {
+  if (!isGithubAppConfigured()) {
+    throw new GraphQLError('GitHub deploy is not enabled on this server', {
+      extensions: { code: 'NOT_CONFIGURED' },
+    })
+  }
+}
+
+function imageTagFor(userId: string, owner: string, repo: string, sha: string): string {
+  const cfg = getGithubAppConfig()
+  // ghcr is case-insensitive and lowercases on the server; pre-lowercase
+  // here so logs / DB rows match what any provider will eventually pull.
+  const safeOwner = owner.toLowerCase().replace(/[^a-z0-9-]/g, '-')
+  const safeRepo = repo.toLowerCase().replace(/[^a-z0-9-]/g, '-')
+  return `ghcr.io/${cfg.ghcrNamespace}/${userId}--${safeOwner}-${safeRepo}:${sha.slice(0, 12)}`
+}
+
+// =====================================================================
+// Queries
+// =====================================================================
+
+export const githubQueries = {
+  githubAppEnabled: () => isGithubAppConfigured(),
+
+  /** Slug used in install URLs: https://github.com/apps/<slug>/installations/new */
+  githubAppSlug: () => {
+    if (!isGithubAppConfigured()) return null
+    return getGithubAppConfig().appSlug
+  },
+
+  githubInstallations: async (
+    _: unknown,
+    args: { orgId?: string },
+    context: Context,
+  ) => {
+    requireAuth(context)
+    assertGithubConfigured()
+    const orgId = args.orgId || context.organizationId
+    if (!orgId) throw new GraphQLError('orgId required')
+    return context.prisma.githubInstallation.findMany({
+      where: { organizationId: orgId },
+      orderBy: { createdAt: 'desc' },
+    })
+  },
+
+  githubInstallationRepos: async (
+    _: unknown,
+    args: { installationId: string },
+    context: Context,
+  ) => {
+    requireAuth(context)
+    assertGithubConfigured()
+    const install = await context.prisma.githubInstallation.findUnique({
+      where: { id: args.installationId },
+    })
+    if (!install) throw new GraphQLError('installation not found')
+    if (context.organizationId && install.organizationId !== context.organizationId) {
+      throw new GraphQLError('not authorized', { extensions: { code: 'FORBIDDEN' } })
+    }
+    const repos = await listInstallationRepos(install.installationId)
+    return repos.map((r) => ({
+      id: String(r.id),
+      name: r.name,
+      fullName: r.full_name,
+      owner: r.owner.login,
+      private: r.private,
+      defaultBranch: r.default_branch,
+      description: r.description,
+      pushedAt: r.pushed_at,
+      language: r.language,
+      htmlUrl: r.html_url,
+    }))
+  },
+
+  githubRepoBranches: async (
+    _: unknown,
+    args: { installationId: string; owner: string; repo: string },
+    context: Context,
+  ) => {
+    requireAuth(context)
+    assertGithubConfigured()
+    const install = await context.prisma.githubInstallation.findUnique({
+      where: { id: args.installationId },
+    })
+    if (!install) throw new GraphQLError('installation not found')
+    if (context.organizationId && install.organizationId !== context.organizationId) {
+      throw new GraphQLError('not authorized', { extensions: { code: 'FORBIDDEN' } })
+    }
+    const branches = await listRepoBranches(install.installationId, args.owner, args.repo)
+    return branches.map((b) => ({ name: b.name, sha: b.commit.sha, protected: b.protected }))
+  },
+}
+
+// =====================================================================
+// Shared: spawn a BuildJob + builder Job for a service that's already
+// been connected to a git repo. Used by createGithubService,
+// connectGithubRepo, and redeployGithubService.
+// =====================================================================
+
+async function startBuild(
+  context: Context,
+  args: {
+    serviceId: string
+    userId: string
+    installationIdNum: bigint
+    owner: string
+    repo: string
+    branch: string
+    rootDirectory: string | null
+    buildCommand: string | null
+    startCommand: string | null
+    triggeredBy: string
+  },
+) {
+  const commit = await getCommit(args.installationIdNum, args.owner, args.repo, args.branch)
+
+  const buildJob = await context.prisma.buildJob.create({
+    data: {
+      serviceId: args.serviceId,
+      commitSha: commit.sha,
+      commitMessage: commit.commit.message.slice(0, 1000),
+      branch: args.branch,
+      triggeredBy: args.triggeredBy,
+    },
+  })
+
+  const imageTag = imageTagFor(args.userId, args.owner, args.repo, commit.sha)
+  try {
+    const spawned = await spawnBuildJob({
+      buildJobId: buildJob.id,
+      installationId: args.installationIdNum,
+      repoOwner: args.owner,
+      repoName: args.repo,
+      commitSha: commit.sha,
+      imageTag,
+      rootDirectory: args.rootDirectory ?? undefined,
+      buildCommand: args.buildCommand ?? undefined,
+      startCommand: args.startCommand ?? undefined,
+    })
+    await context.prisma.buildJob.update({
+      where: { id: buildJob.id },
+      data: { k8sJobName: spawned.k8sJobName, status: 'RUNNING' },
+    })
+  } catch (err) {
+    log.error({ err, buildJobId: buildJob.id }, 'failed to spawn builder Job')
+    await context.prisma.buildJob.update({
+      where: { id: buildJob.id },
+      data: {
+        status: 'FAILED',
+        errorMessage: err instanceof Error ? err.message : String(err),
+        finishedAt: new Date(),
+      },
+    })
+    throw new GraphQLError('failed to start build', {
+      extensions: { code: 'BUILDER_SPAWN_FAILED' },
+    })
+  }
+
+  return buildJob
+}
+
+// =====================================================================
+// Mutations
+// =====================================================================
+
+export const githubMutations = {
+  /**
+   * After the user clicks "Install" on github.com, GitHub redirects them to
+   * our setup_url with `?installation_id=...&setup_action=install`. The
+   * frontend calls this mutation to confirm and persist the install.
+   *
+   * The webhook (`installation` event) covers the same ground asynchronously,
+   * but calling this mutation makes the UI feel synchronous.
+   */
+  syncGithubInstallation: async (
+    _: unknown,
+    args: { installationId: string; orgId?: string },
+    context: Context,
+  ) => {
+    const userId = requireAuth(context)
+    assertGithubConfigured()
+    const orgId = args.orgId || context.organizationId
+    if (!orgId) throw new GraphQLError('orgId required')
+
+    // Verify ownership of the org
+    const member = await context.prisma.organizationMember.findFirst({
+      where: { organizationId: orgId, userId },
+    })
+    if (!member) throw new GraphQLError('not a member of this org', { extensions: { code: 'FORBIDDEN' } })
+
+    const installIdNum = BigInt(args.installationId)
+    const meta = await getInstallation(installIdNum)
+
+    return context.prisma.githubInstallation.upsert({
+      where: { installationId: installIdNum },
+      create: {
+        organizationId: orgId,
+        installationId: installIdNum,
+        accountLogin: meta.account.login,
+        accountId: BigInt(meta.account.id),
+        accountType: meta.account.type,
+        targetType: meta.repository_selection,
+        installedByUserId: userId,
+        suspendedAt: meta.suspended_at ? new Date(meta.suspended_at) : null,
+      },
+      update: {
+        accountLogin: meta.account.login,
+        accountId: BigInt(meta.account.id),
+        accountType: meta.account.type,
+        targetType: meta.repository_selection,
+        suspendedAt: meta.suspended_at ? new Date(meta.suspended_at) : null,
+      },
+    })
+  },
+
+  /**
+   * All-in-one: create the Service row and connect it to a repo, then
+   * spawn the first build. Used by API/CLI consumers who don't go
+   * through the catalog → panel UX.
+   */
+  createGithubService: async (
+    _: unknown,
+    args: {
+      input: {
+        projectId: string
+        installationId: string
+        owner: string
+        repo: string
+        branch?: string
+        rootDirectory?: string
+        buildCommand?: string
+        startCommand?: string
+        name?: string
+        envVars?: Array<{ key: string; value: string; secret?: boolean }>
+      }
+    },
+    context: Context,
+  ) => {
+    const userId = requireAuth(context)
+    assertGithubConfigured()
+    const { input } = args
+
+    const project = await context.prisma.project.findUnique({
+      where: { id: input.projectId },
+      select: { id: true, slug: true, userId: true, organizationId: true },
+    })
+    if (!project) throw new GraphQLError('project not found')
+    assertProjectAccess(context, project)
+
+    const install = await context.prisma.githubInstallation.findUnique({
+      where: { id: input.installationId },
+    })
+    if (!install) throw new GraphQLError('installation not found')
+    if (install.suspendedAt) throw new GraphQLError('installation is suspended on GitHub')
+
+    // Confirm the repo + branch are real (live API call)
+    const repo = await getRepo(install.installationId, input.owner, input.repo)
+    const branchName = input.branch || repo.default_branch
+
+    // Slugs must be unique within a project; suffix on collision.
+    const baseSlug = generateSlug(input.name || repo.name)
+    let slug = baseSlug
+    for (let i = 1; i < 50; i++) {
+      const exists = await context.prisma.service.findFirst({
+        where: { projectId: project.id, slug },
+        select: { id: true },
+      })
+      if (!exists) break
+      slug = `${baseSlug}-${i}`
+    }
+
+    const service = await context.prisma.service.create({
+      data: {
+        type: 'VM',
+        name: input.name || repo.name,
+        slug,
+        projectId: project.id,
+        flavor: 'github',
+        createdByUserId: userId,
+        gitProvider: 'github',
+        gitOwner: input.owner,
+        gitRepo: input.repo,
+        gitBranch: branchName,
+        gitInstallationId: install.id,
+        rootDirectory: input.rootDirectory ?? null,
+        buildCommand: input.buildCommand ?? null,
+        startCommand: input.startCommand ?? null,
+        internalHostname: generateInternalHostname(slug, project.slug),
+      },
+    })
+
+    if (input.envVars && input.envVars.length > 0) {
+      await context.prisma.serviceEnvVar.createMany({
+        data: input.envVars.map((e) => ({
+          serviceId: service.id,
+          key: e.key,
+          value: e.value,
+          secret: e.secret ?? true,
+        })),
+      })
+    }
+
+    await startBuild(context, {
+      serviceId: service.id,
+      userId,
+      installationIdNum: install.installationId,
+      owner: input.owner,
+      repo: input.repo,
+      branch: branchName,
+      rootDirectory: input.rootDirectory ?? null,
+      buildCommand: input.buildCommand ?? null,
+      startCommand: input.startCommand ?? null,
+      triggeredBy: 'first-deploy',
+    })
+
+    return service
+  },
+
+  /**
+   * Panel-flow connect: an empty, github-flavor Service already exists
+   * (created by the catalog → createService path); attach a repo to it
+   * and spawn the first build. Idempotent for the "user changed mind"
+   * case — re-calling overwrites the connection only if no successful
+   * build has happened yet.
+   */
+  connectGithubRepo: async (
+    _: unknown,
+    args: {
+      input: {
+        serviceId: string
+        installationId: string
+        owner: string
+        repo: string
+        branch?: string
+        rootDirectory?: string
+        buildCommand?: string
+        startCommand?: string
+      }
+    },
+    context: Context,
+  ) => {
+    const userId = requireAuth(context)
+    assertGithubConfigured()
+    const { input } = args
+
+    const service = await context.prisma.service.findUnique({
+      where: { id: input.serviceId },
+      include: { project: true },
+    })
+    if (!service) throw new GraphQLError('service not found')
+    assertProjectAccess(context, service.project)
+    if (service.flavor !== 'github') {
+      throw new GraphQLError(
+        `Service ${service.id} has flavor "${service.flavor ?? 'null'}" — connectGithubRepo only works on github-flavor services`,
+        { extensions: { code: 'WRONG_FLAVOR' } },
+      )
+    }
+    if (service.lastBuildStatus === 'SUCCEEDED') {
+      throw new GraphQLError(
+        'Service is already connected and has a successful build. Use redeployGithubService to rebuild.',
+        { extensions: { code: 'ALREADY_CONNECTED' } },
+      )
+    }
+
+    const install = await context.prisma.githubInstallation.findUnique({
+      where: { id: input.installationId },
+    })
+    if (!install) throw new GraphQLError('installation not found')
+    if (install.suspendedAt) throw new GraphQLError('installation is suspended on GitHub')
+
+    const repo = await getRepo(install.installationId, input.owner, input.repo)
+    const branchName = input.branch || repo.default_branch
+
+    const updated = await context.prisma.service.update({
+      where: { id: service.id },
+      data: {
+        gitProvider: 'github',
+        gitOwner: input.owner,
+        gitRepo: input.repo,
+        gitBranch: branchName,
+        gitInstallationId: install.id,
+        rootDirectory: input.rootDirectory ?? null,
+        buildCommand: input.buildCommand ?? null,
+        startCommand: input.startCommand ?? null,
+      },
+    })
+
+    await startBuild(context, {
+      serviceId: updated.id,
+      userId,
+      installationIdNum: install.installationId,
+      owner: input.owner,
+      repo: input.repo,
+      branch: branchName,
+      rootDirectory: input.rootDirectory ?? null,
+      buildCommand: input.buildCommand ?? null,
+      startCommand: input.startCommand ?? null,
+      triggeredBy: 'first-deploy',
+    })
+
+    return updated
+  },
+
+  redeployGithubService: async (
+    _: unknown,
+    args: { serviceId: string },
+    context: Context,
+  ) => {
+    const userId = requireAuth(context)
+    assertGithubConfigured()
+
+    const service = await context.prisma.service.findUnique({
+      where: { id: args.serviceId },
+      include: { project: true, gitInstallation: true },
+    })
+    if (!service) throw new GraphQLError('service not found')
+    assertProjectAccess(context, service.project)
+    if (!service.gitInstallation || !service.gitOwner || !service.gitRepo || !service.gitBranch) {
+      throw new GraphQLError('service is not connected to a git repo')
+    }
+
+    return startBuild(context, {
+      serviceId: service.id,
+      userId,
+      installationIdNum: service.gitInstallation.installationId,
+      owner: service.gitOwner,
+      repo: service.gitRepo,
+      branch: service.gitBranch,
+      rootDirectory: service.rootDirectory,
+      buildCommand: service.buildCommand,
+      startCommand: service.startCommand,
+      triggeredBy: `manual:${userId}`,
+    })
+  },
+}
+
+// =====================================================================
+// Field resolvers
+// =====================================================================
+
+export const githubFieldResolvers = {
+  GithubInstallation: {
+    installationId: (parent: { installationId: bigint | number | string }) =>
+      String(parent.installationId),
+    accountId: (parent: { accountId: bigint | number | string }) => String(parent.accountId),
+  },
+  Service: {
+    latestBuild: async (parent: { id: string }, _: unknown, context: Context) => {
+      return context.prisma.buildJob.findFirst({
+        where: { serviceId: parent.id },
+        orderBy: { createdAt: 'desc' },
+      })
+    },
+    buildJobs: async (parent: { id: string }, args: { limit?: number }, context: Context) => {
+      return context.prisma.buildJob.findMany({
+        where: { serviceId: parent.id },
+        orderBy: { createdAt: 'desc' },
+        take: Math.min(Math.max(args.limit ?? 20, 1), 100),
+      })
+    },
+  },
+}

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -33,6 +33,7 @@ import {
   templateFieldResolvers,
 } from './templates.js'
 import { phalaQueries, phalaMutations, phalaFieldResolvers } from './phala.js'
+import { githubQueries, githubMutations, githubFieldResolvers } from './github.js'
 import {
   serviceConnectivityQueries,
   serviceConnectivityMutations,
@@ -1081,6 +1082,9 @@ export const resolvers = {
     ...akashQueries,
     ...phalaQueries,
 
+    // GitHub-source deploy queries
+    ...githubQueries,
+
     // Service container logs
     ...logsQueries,
 
@@ -1526,14 +1530,14 @@ export const resolvers = {
       // can't mis-tag a template-backed service). Anything else must be one
       // of the known flavors or null (legacy/unspecified — readers default
       // to 'docker' for VM, 'function' for FUNCTION).
-      const ALLOWED_FLAVORS = new Set(['docker', 'server', 'function', 'template'])
+      const ALLOWED_FLAVORS = new Set(['docker', 'server', 'function', 'template', 'github'])
       let flavor: string | null = null
       if (input.templateId) {
         flavor = 'template'
       } else if (input.flavor != null) {
         if (!ALLOWED_FLAVORS.has(input.flavor)) {
           throw new GraphQLError(
-            `Invalid flavor "${input.flavor}". Must be one of: docker, server, function, template.`
+            `Invalid flavor "${input.flavor}". Must be one of: docker, server, function, template, github.`
           )
         }
         flavor = input.flavor
@@ -2165,6 +2169,9 @@ export const resolvers = {
     // Phala deployment mutations
     ...phalaMutations,
 
+    // GitHub-source deploy mutations
+    ...githubMutations,
+
     // Service connectivity mutations (env vars, ports, links)
     ...serviceConnectivityMutations,
 
@@ -2318,10 +2325,16 @@ export const resolvers = {
     ...(phalaFieldResolvers.Service ?? {}),
     // Merge inter-service communication field resolvers (envVars, ports, linksFrom, linksTo)
     ...(serviceConnectivityFieldResolvers.Service ?? {}),
+    // Merge GitHub-source field resolvers (latestBuild, buildJobs)
+    ...(githubFieldResolvers.Service ?? {}),
   },
 
   ServiceLink: {
     ...(serviceConnectivityFieldResolvers.ServiceLink ?? {}),
+  },
+
+  GithubInstallation: {
+    ...(githubFieldResolvers.GithubInstallation ?? {}),
   },
 
   Site: {

--- a/src/schema/typeDefs.ts
+++ b/src/schema/typeDefs.ts
@@ -2264,6 +2264,10 @@ export const typeDefs = /* GraphQL */ `
     githubInstallations(orgId: ID): [GithubInstallation!]!
     githubInstallationRepos(installationId: ID!): [GithubRepoSummary!]!
     githubRepoBranches(installationId: ID!, owner: String!, repo: String!): [GithubBranchSummary!]!
+    """Fetch a single BuildJob by id (auth: caller must have access to the parent service's project). Used by the Source-tab build-history UI to lazy-load the logs blob on row expand."""
+    buildJob(id: ID!): BuildJob
+    """List recent BuildJobs for a service, newest first. Logs blob omitted — fetch it via buildJob(id) on demand. Used by the Source-tab build-history list (polled every 3s while a build is in flight)."""
+    serviceBuildJobs(serviceId: ID!, limit: Int): [BuildJob!]!
   }
 
   extend type Mutation {
@@ -2273,7 +2277,8 @@ export const typeDefs = /* GraphQL */ `
     refreshGithubInstallations(orgId: ID): [GithubInstallation!]!
     createGithubService(input: CreateGithubServiceInput!): Service!
     connectGithubRepo(input: ConnectGithubRepoInput!): Service!
-    redeployGithubService(serviceId: ID!): BuildJob!
+    """Trigger a new build. With no sha, builds the tip of the tracked branch (default behaviour, used by top-level Rebuild). With a sha (7-40 char hex commit SHA), rebuilds that exact commit — used by the per-row rebuild button in build history."""
+    redeployGithubService(serviceId: ID!, sha: String): BuildJob!
   }
 
   extend type Service {

--- a/src/schema/typeDefs.ts
+++ b/src/schema/typeDefs.ts
@@ -2150,4 +2150,150 @@ export const typeDefs = /* GraphQL */ `
     deploymentLogs(deploymentId: ID!): DeploymentLog!
     deploymentStatus(deploymentId: ID!): DeploymentStatusUpdate!
   }
+
+  # ============================================
+  # GITHUB DEPLOY (Phase: GitHub deploy, 2026-04-20)
+  # ============================================
+
+  enum BuildStatus {
+    PENDING
+    RUNNING
+    SUCCEEDED
+    FAILED
+    CANCELED
+  }
+
+  type GithubInstallation {
+    id: ID!
+    organizationId: ID!
+    """GitHub-side numeric installation id (returned as String to avoid Int32 overflow)."""
+    installationId: String!
+    accountLogin: String!
+    accountId: String!
+    accountType: String!
+    targetType: String!
+    suspendedAt: Date
+    createdAt: Date!
+    updatedAt: Date!
+  }
+
+  type GithubRepoSummary {
+    id: ID!
+    name: String!
+    fullName: String!
+    owner: String!
+    private: Boolean!
+    defaultBranch: String!
+    description: String
+    pushedAt: String
+    language: String
+    htmlUrl: String!
+  }
+
+  type GithubBranchSummary {
+    name: String!
+    sha: String!
+    protected: Boolean!
+  }
+
+  type BuildJob {
+    id: ID!
+    serviceId: ID!
+    commitSha: String!
+    commitMessage: String
+    branch: String!
+    status: BuildStatus!
+    k8sJobName: String
+    imageTag: String
+    detectedFramework: String
+    detectedPort: Int
+    logs: String
+    triggeredBy: String
+    startedAt: Date
+    finishedAt: Date
+    errorMessage: String
+    createdAt: Date!
+    updatedAt: Date!
+  }
+
+  input CreateGithubServiceEnvVarInput {
+    key: String!
+    value: String!
+    secret: Boolean
+  }
+
+  input CreateGithubServiceInput {
+    projectId: ID!
+    """Local id of the GithubInstallation row (NOT the GitHub-side installation_id)."""
+    installationId: ID!
+    owner: String!
+    repo: String!
+    """Defaults to the repo's default branch when omitted."""
+    branch: String
+    """Monorepo subdir (defaults to '.')."""
+    rootDirectory: String
+    buildCommand: String
+    startCommand: String
+    """Display name; defaults to repo name."""
+    name: String
+    envVars: [CreateGithubServiceEnvVarInput!]
+  }
+
+  """
+  Connect an existing (empty, github-flavor) Service to a GitHub repo. Used
+  by the in-panel Source-tab picker — the Service row is created first by
+  the catalog flow (createService), then connected here. This kicks off
+  the first BuildJob and spawns the K8s builder. The compute provider is
+  NOT chosen here — the build callback auto-deploys via the existing
+  Service compute config the same way the Deploy button would.
+  """
+  input ConnectGithubRepoInput {
+    serviceId: ID!
+    installationId: ID!
+    owner: String!
+    repo: String!
+    branch: String
+    rootDirectory: String
+    buildCommand: String
+    startCommand: String
+  }
+
+  extend type Query {
+    githubAppEnabled: Boolean!
+    githubAppSlug: String
+    githubInstallations(orgId: ID): [GithubInstallation!]!
+    githubInstallationRepos(installationId: ID!): [GithubRepoSummary!]!
+    githubRepoBranches(installationId: ID!, owner: String!, repo: String!): [GithubBranchSummary!]!
+  }
+
+  extend type Mutation {
+    syncGithubInstallation(installationId: String!, orgId: ID): GithubInstallation!
+    createGithubService(input: CreateGithubServiceInput!): Service!
+    connectGithubRepo(input: ConnectGithubRepoInput!): Service!
+    redeployGithubService(serviceId: ID!): BuildJob!
+  }
+
+  extend type Service {
+    """Latest build attempt for git-source services. Null for non-git services."""
+    latestBuild: BuildJob
+    """Recent build attempts (newest first), capped per request."""
+    buildJobs(limit: Int): [BuildJob!]!
+    """Set when this Service is connected to a git repo. One of 'github' | 'gitlab' | 'bitbucket'."""
+    gitProvider: String
+    """Local id of the GithubInstallation row (or future provider install row)."""
+    gitInstallationId: ID
+    gitOwner: String
+    gitRepo: String
+    gitBranch: String
+    rootDirectory: String
+    buildCommand: String
+    startCommand: String
+    detectedFramework: String
+    detectedPort: Int
+    """Most recent built commit SHA. Null until the first build succeeds."""
+    lastBuildSha: String
+    """One of 'PENDING' | 'RUNNING' | 'SUCCEEDED' | 'FAILED' | 'CANCELED' or null."""
+    lastBuildStatus: String
+    lastBuildAt: Date
+  }
 `

--- a/src/schema/typeDefs.ts
+++ b/src/schema/typeDefs.ts
@@ -2268,6 +2268,9 @@ export const typeDefs = /* GraphQL */ `
 
   extend type Mutation {
     syncGithubInstallation(installationId: String!, orgId: ID): GithubInstallation!
+    """Live-pull all App installations from GitHub into the local DB and return them.
+    Slow path — UI uses this only on explicit Refresh / post-install."""
+    refreshGithubInstallations(orgId: ID): [GithubInstallation!]!
     createGithubService(input: CreateGithubServiceInput!): Service!
     connectGithubRepo(input: ConnectGithubRepoInput!): Service!
     redeployGithubService(serviceId: ID!): BuildJob!

--- a/src/services/akash/orchestrator.ts
+++ b/src/services/akash/orchestrator.ts
@@ -1323,6 +1323,10 @@ export class AkashOrchestrator {
     // Phase 38 — persistent volumes for raw Docker images. Json column on
     // Service. Templates own their own volumes via template.persistentStorage.
     volumes?: unknown
+    // Phase 39 / GitHub-source flavor — used to pick a sensible default port
+    // when the user (or builder) didn't set one. See port-fallback below.
+    flavor?: string | null
+    gitProvider?: string | null
     site?: { id: string } | null
     afFunction?: { id: string; sourceCode: string | null } | null
   }, resourceOverrides?: {
@@ -1409,7 +1413,23 @@ export class AkashOrchestrator {
     // Priority 2: Custom Docker image or user-selected base image
     const effectiveImage = service.dockerImage || baseImage
     if (effectiveImage) {
-      const port = service.containerPort || 80
+      // Default-port heuristic: GitHub-source builds (Next/Nuxt/Bun/etc.)
+      // overwhelmingly listen on 3000, so falling back to 80 there is the
+      // single biggest source of "deploy succeeds but URL 404s" reports.
+      // For docker / server flavors the user explicitly picked the image,
+      // so 80 stays the right default (nginx, caddy, traefik all listen
+      // there). Builder writes the detected port back to Service.containerPort
+      // when nixpacks reports it, so this fallback only kicks in for the
+      // (common) case where neither builder nor user supplied one.
+      const isGithubBuild = service.flavor === 'github' || !!service.gitProvider
+      const fallbackPort = isGithubBuild ? 3000 : 80
+      const port = service.containerPort || fallbackPort
+      if (!service.containerPort) {
+        log.warn(
+          { serviceId: service.id, slug: service.slug, isGithubBuild, fallbackPort },
+          `Service '${service.slug}' has no containerPort — defaulting SDL port to ${fallbackPort}. Set it explicitly via Config → Container port if your app listens elsewhere.`
+        )
+      }
       const parsedVolumes = parseServiceVolumes(service.volumes)
       log.info(
         { volumes: parsedVolumes.length },

--- a/src/services/github/app.ts
+++ b/src/services/github/app.ts
@@ -1,0 +1,80 @@
+/**
+ * GitHub App authentication helpers.
+ *
+ * Two token types matter for an App:
+ *   1. App JWT  — short-lived (≤10 min), signed by the App's private key.
+ *                 Used to call `/app/installations/...` to mint installation tokens.
+ *   2. Installation token — short-lived (~1h), scoped to a single installation.
+ *                 Used for everything else (clone, list repos, post statuses).
+ *
+ * We cache installation tokens in-process per installationId, refreshing 60s
+ * before expiry. Multiple replicas each maintain their own cache; that's
+ * fine because each token is independent and revoking is rarely needed.
+ */
+
+import jwt from 'jsonwebtoken'
+import { createLogger } from '../../lib/logger.js'
+import { getGithubAppConfig } from './config.js'
+
+const log = createLogger('github.app')
+
+interface InstallationTokenCacheEntry {
+  token: string
+  expiresAt: number // unix ms
+}
+const installationTokenCache = new Map<string, InstallationTokenCacheEntry>()
+
+/**
+ * Sign a fresh App JWT. GitHub recommends 10-min max; we use 9 min and
+ * cache nothing (cheap to compute, easy to reason about).
+ */
+export function getAppJwt(): string {
+  const cfg = getGithubAppConfig()
+  const now = Math.floor(Date.now() / 1000)
+  return jwt.sign(
+    {
+      iat: now - 60, // backdate 60s to absorb clock drift
+      exp: now + 9 * 60,
+      iss: cfg.appId,
+    },
+    cfg.privateKeyPem,
+    { algorithm: 'RS256' },
+  )
+}
+
+/**
+ * Mint (or return cached) installation access token for a given installation.
+ * GitHub returns these tokens with ~1h TTL; we refresh when <60s remain.
+ */
+export async function getInstallationToken(installationId: bigint | string): Promise<string> {
+  const key = String(installationId)
+  const cached = installationTokenCache.get(key)
+  if (cached && cached.expiresAt - Date.now() > 60_000) {
+    return cached.token
+  }
+
+  const appJwt = getAppJwt()
+  const r = await fetch(`https://api.github.com/app/installations/${key}/access_tokens`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      Authorization: `Bearer ${appJwt}`,
+      'User-Agent': 'AlternateFutures',
+    },
+  })
+  if (!r.ok) {
+    const body = await r.text().catch(() => '')
+    throw new Error(`github: failed to mint installation token (${r.status}): ${body.slice(0, 200)}`)
+  }
+  const data = (await r.json()) as { token: string; expires_at: string }
+  const expiresAt = new Date(data.expires_at).getTime()
+  installationTokenCache.set(key, { token: data.token, expiresAt })
+  log.info({ installationId: key, expiresAt }, 'minted installation token')
+  return data.token
+}
+
+/** Test-only — clears cached installation tokens. */
+export function _resetInstallationTokenCache() {
+  installationTokenCache.clear()
+}

--- a/src/services/github/buildCallbackEndpoint.ts
+++ b/src/services/github/buildCallbackEndpoint.ts
@@ -114,71 +114,98 @@ export async function handleBuildCallback(
   const now = new Date()
   const newStatus = body.status as BuildStatus
 
-  // Atomic idempotency + write. The previous version did a read (line 100),
-  // a JS-level terminal check, then a write — leaving a window where two
-  // near-simultaneous callbacks (e.g. builder posts SUCCEEDED, K8s pod-
-  // deletion handler posts FAILED) could both pass the gate and double-apply.
+  // Atomic idempotency + write. Two failure modes we explicitly handle:
   //
-  // We collapse the gate INTO the WHERE clause: `updateMany` succeeds only
-  // if the current status is non-terminal OR the incoming status equals the
-  // current one (idempotent retry of a terminal callback). If count === 0,
-  // somebody else already drove this row terminal-with-a-different-status —
-  // treat as a benign no-op and DON'T write the Service mirror (the winning
-  // callback's own service write is the truth).
+  //   (a) Two near-simultaneous callbacks with DIFFERENT terminal statuses
+  //       (builder posts SUCCEEDED while a pod-deletion handler posts FAILED).
+  //       We must never let the loser overwrite the winner.
   //
-  // Interactive transaction (vs the array form) so the Service write is
-  // conditional on the BuildJob CAS succeeding — and both still commit
-  // atomically when the CAS wins.
+  //   (b) The SAME callback posted twice (curl retry, K8s Job restart, GitHub
+  //       redelivery — surprisingly common). The DB write is harmlessly
+  //       idempotent (same data), but ANY side-effect downstream — most
+  //       importantly autoDeployAfterBuild — must run AT MOST ONCE. Otherwise
+  //       you get N AkashDeployments per push.
+  //
+  // We split the CAS into two arms so we can distinguish:
+  //   - `firstTransition` arm: status moved from non-terminal → newStatus.
+  //     This is the WINNING callback — fire side-effects.
+  //   - `idempotentRetry` arm: status was already newStatus. DB write is a
+  //     no-op-equivalent (we still re-run it to refresh logs, but it's the
+  //     same row); side-effects MUST NOT fire.
+  //
+  // Interactive transaction so the Service mirror only commits when the
+  // BuildJob CAS wins.
   const txResult = await prisma.$transaction(async (tx) => {
-    const updated = await tx.buildJob.updateMany({
+    const buildJobData = {
+      status: newStatus,
+      logs: body.logs?.slice(0, 60_000) ?? job.logs ?? undefined,
+      imageTag: body.imageTag ?? job.imageTag,
+      detectedFramework: body.detectedFramework ?? job.detectedFramework,
+      detectedPort: body.detectedPort ?? job.detectedPort,
+      errorMessage: body.errorMessage?.slice(0, 4_000) ?? null,
+      startedAt: newStatus === 'RUNNING' && !job.startedAt ? now : job.startedAt,
+      finishedAt: TERMINAL.has(newStatus) ? now : null,
+    }
+
+    // Arm 1: first transition into newStatus.
+    const firstTransition = await tx.buildJob.updateMany({
       where: {
         id: job.id,
-        OR: [
-          { status: { notIn: ['SUCCEEDED', 'FAILED', 'CANCELED'] } },
-          { status: newStatus },
-        ],
+        status: { notIn: ['SUCCEEDED', 'FAILED', 'CANCELED'] },
       },
-      data: {
-        status: newStatus,
-        logs: body.logs?.slice(0, 60_000) ?? job.logs ?? undefined,
-        imageTag: body.imageTag ?? job.imageTag,
-        detectedFramework: body.detectedFramework ?? job.detectedFramework,
-        detectedPort: body.detectedPort ?? job.detectedPort,
-        errorMessage: body.errorMessage?.slice(0, 4_000) ?? null,
-        startedAt: newStatus === 'RUNNING' && !job.startedAt ? now : job.startedAt,
-        finishedAt: TERMINAL.has(newStatus) ? now : null,
-      },
+      data: buildJobData,
     })
-    if (updated.count === 0) return { applied: false as const }
-    await tx.service.update({
-      where: { id: job.serviceId },
-      data: {
-        lastBuildStatus: newStatus,
-        lastBuildAt: now,
-        lastBuildSha: body.commitSha ?? job.commitSha,
-        ...(newStatus === 'SUCCEEDED' && body.imageTag
-          ? {
-              dockerImage: body.imageTag,
-              detectedFramework: body.detectedFramework ?? job.detectedFramework,
-              detectedPort: body.detectedPort ?? job.detectedPort,
-              // Use the detected port as the runtime container port if the
-              // user hasn't pinned one explicitly. SDL generators read
-              // containerPort.
-              containerPort:
-                job.service.containerPort ?? body.detectedPort ?? job.detectedPort ?? null,
-            }
-          : {}),
-      },
+    if (firstTransition.count === 1) {
+      await tx.service.update({
+        where: { id: job.serviceId },
+        data: {
+          lastBuildStatus: newStatus,
+          lastBuildAt: now,
+          lastBuildSha: body.commitSha ?? job.commitSha,
+          ...(newStatus === 'SUCCEEDED' && body.imageTag
+            ? {
+                dockerImage: body.imageTag,
+                detectedFramework: body.detectedFramework ?? job.detectedFramework,
+                detectedPort: body.detectedPort ?? job.detectedPort,
+                // Use the detected port as the runtime container port if the
+                // user hasn't pinned one explicitly. SDL generators read
+                // containerPort.
+                containerPort:
+                  job.service.containerPort ?? body.detectedPort ?? job.detectedPort ?? null,
+              }
+            : {}),
+        },
+      })
+      return { outcome: 'first-transition' as const }
+    }
+
+    // Arm 2: idempotent retry of the SAME terminal status. Refresh logs but
+    // do NOT touch Service (the original winning callback already did) and
+    // do NOT signal side-effects.
+    const idempotentRetry = await tx.buildJob.updateMany({
+      where: { id: job.id, status: newStatus },
+      data: { logs: buildJobData.logs },
     })
-    return { applied: true as const }
+    if (idempotentRetry.count === 1) {
+      return { outcome: 'idempotent-retry' as const }
+    }
+
+    return { outcome: 'terminal-mismatch' as const }
   })
 
-  if (!txResult.applied) {
+  if (txResult.outcome === 'terminal-mismatch') {
     log.info(
       { buildJobId: job.id, current: job.status, incoming: body.status },
       'ignoring callback that would downgrade terminal status',
     )
     return reply(res, 200, { ok: true, ignored: 'terminal' })
+  }
+  if (txResult.outcome === 'idempotent-retry') {
+    log.info(
+      { buildJobId: job.id, status: body.status },
+      'ignoring duplicate callback (same status as current) — side-effects already fired',
+    )
+    return reply(res, 200, { ok: true, ignored: 'duplicate' })
   }
 
   // ── 3. Best-effort: write commit status back to GitHub ─
@@ -246,6 +273,40 @@ async function autoDeployAfterBuild(prisma: PrismaClient, serviceId: string): Pr
   if (!service) throw new Error('service not found')
   if (!service.createdByUserId) {
     throw new Error('cannot deploy: service has no createdByUserId')
+  }
+
+  // Defense in depth against duplicate auto-deploys.
+  //
+  // The build-callback CAS gate above already filters duplicate SUCCEEDED
+  // callbacks for a single BuildJob. But we can still be invoked twice for
+  // the same service+image by orthogonal paths:
+  //
+  //   - Two BuildJobs for the same SHA (webhook redelivery slipping past the
+  //     dedup window in webhookEndpoint, simultaneous push + manual rebuild,
+  //     dual-instance race, etc.) each producing their own SUCCEEDED.
+  //   - User clicking "Deploy" in the UI in the same second as the build's
+  //     auto-deploy fires.
+  //
+  // Skip if there's already a non-terminal AkashDeployment for THIS service
+  // created in the last 30s. The window is intentionally short — legitimate
+  // redeploys (config change → redeploy) take longer than 30s of human input
+  // anyway, and we'd rather the user occasionally hit "Redeploy" again than
+  // double-charge them on every push.
+  const DEDUP_WINDOW_MS = 30_000
+  const inFlight = await prisma.akashDeployment.findFirst({
+    where: {
+      serviceId,
+      status: { notIn: ['CLOSED', 'FAILED', 'PERMANENTLY_FAILED', 'SUSPENDED'] },
+      createdAt: { gte: new Date(Date.now() - DEDUP_WINDOW_MS) },
+    },
+    select: { id: true, status: true, createdAt: true },
+  })
+  if (inFlight) {
+    log.info(
+      { serviceId, existingDeploymentId: inFlight.id, existingStatus: inFlight.status },
+      'skipping auto-deploy: in-flight deployment exists for service (deduped)',
+    )
+    return
   }
 
   const ctx = {

--- a/src/services/github/buildCallbackEndpoint.ts
+++ b/src/services/github/buildCallbackEndpoint.ts
@@ -1,0 +1,247 @@
+/**
+ * `POST /internal/build-callback` — receives status updates from af-builder Jobs.
+ *
+ * The builder POSTs three times per Job:
+ *   1. RUNNING   — when the daemon is up and clone starts
+ *   2. SUCCEEDED — image pushed; payload includes imageTag, commitSha, detectedFramework, detectedPort
+ *   3. FAILED    — anywhere along the way; payload includes errorMessage + truncated logs
+ *
+ * On SUCCEEDED we:
+ *   - update BuildJob row + Service.dockerImage / detected* / lastBuildSha
+ *   - post commit status `success` on GitHub
+ *   - auto-deploy via the existing per-deploy provider mechanism:
+ *       - rebuilds with an active deployment → use that provider
+ *       - first build → fall back to Akash (matches the
+ *         ServiceDetailPanel default at onDeploy → onDeployToAkash)
+ *
+ * The compute provider is NEVER stored on the Service row — it's the
+ * same per-deploy choice every other flavor uses (Standard → Akash,
+ * Confidential → Phala via ComputeMode picker). For first-deploy we
+ * follow the panel's default; the user changes it later via
+ * ComputeSelector + Redeploy, just like docker / server flavors.
+ *
+ * Auth: `X-AF-Build-Token` header is HMAC-signed with JWT_SECRET and bound
+ * to the buildJobId in the body. Verified by `verifyBuildToken`.
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { PrismaClient, BuildStatus } from '@prisma/client'
+import { createLogger } from '../../lib/logger.js'
+import { verifyBuildToken } from './buildToken.js'
+import { postCommitStatus } from './client.js'
+import { akashMutations } from '../../resolvers/akash.js'
+import { phalaMutations } from '../../resolvers/phala.js'
+import type { Context } from '../../resolvers/types.js'
+
+const log = createLogger('github.buildCallback')
+
+interface CallbackBody {
+  buildJobId?: string
+  status?: 'PENDING' | 'RUNNING' | 'SUCCEEDED' | 'FAILED' | 'CANCELED'
+  logs?: string
+  imageTag?: string
+  commitSha?: string
+  detectedFramework?: string
+  detectedPort?: number | null
+  errorMessage?: string
+}
+
+const VALID_STATUSES: ReadonlySet<BuildStatus> = new Set([
+  'PENDING',
+  'RUNNING',
+  'SUCCEEDED',
+  'FAILED',
+  'CANCELED',
+] as const)
+
+async function readJson(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = []
+  for await (const chunk of req) {
+    chunks.push(chunk as Buffer)
+    if (chunks.reduce((n, c) => n + c.length, 0) > 256 * 1024) {
+      throw new Error('payload too large')
+    }
+  }
+  const raw = Buffer.concat(chunks).toString('utf8')
+  return JSON.parse(raw)
+}
+
+function reply(res: ServerResponse, status: number, body: object | string) {
+  res.writeHead(status, { 'content-type': typeof body === 'string' ? 'text/plain' : 'application/json' })
+  res.end(typeof body === 'string' ? body : JSON.stringify(body))
+}
+
+export async function handleBuildCallback(
+  req: IncomingMessage,
+  res: ServerResponse,
+  prisma: PrismaClient,
+): Promise<void> {
+  if (req.method !== 'POST') return reply(res, 405, 'method not allowed')
+
+  let body: CallbackBody
+  try {
+    body = (await readJson(req)) as CallbackBody
+  } catch (err) {
+    log.warn({ err }, 'invalid build-callback body')
+    return reply(res, 400, 'invalid json')
+  }
+
+  if (!body.buildJobId || !body.status || !VALID_STATUSES.has(body.status as BuildStatus)) {
+    return reply(res, 400, 'missing or invalid buildJobId/status')
+  }
+
+  const token = req.headers['x-af-build-token']
+  const tokenStr = Array.isArray(token) ? token[0] : token
+  if (!tokenStr || !verifyBuildToken(tokenStr, body.buildJobId)) {
+    log.warn({ buildJobId: body.buildJobId }, 'rejected build-callback: bad/expired token')
+    return reply(res, 401, 'invalid token')
+  }
+
+  const job = await prisma.buildJob.findUnique({
+    where: { id: body.buildJobId },
+    include: {
+      service: {
+        include: { project: true, gitInstallation: true },
+      },
+    },
+  })
+  if (!job) {
+    log.warn({ buildJobId: body.buildJobId }, 'build-callback for unknown BuildJob')
+    return reply(res, 404, 'build job not found')
+  }
+
+  // Idempotency: don't allow downgrading from a terminal status.
+  const TERMINAL: ReadonlySet<BuildStatus> = new Set(['SUCCEEDED', 'FAILED', 'CANCELED'] as const)
+  if (TERMINAL.has(job.status) && job.status !== body.status) {
+    log.info(
+      { buildJobId: job.id, current: job.status, incoming: body.status },
+      'ignoring callback that would downgrade terminal status',
+    )
+    return reply(res, 200, { ok: true, ignored: 'terminal' })
+  }
+
+  const now = new Date()
+  const newStatus = body.status as BuildStatus
+
+  // ── 1. Persist BuildJob update ──────────────────────────
+  await prisma.buildJob.update({
+    where: { id: job.id },
+    data: {
+      status: newStatus,
+      logs: body.logs?.slice(0, 60_000) ?? job.logs ?? undefined,
+      imageTag: body.imageTag ?? job.imageTag,
+      detectedFramework: body.detectedFramework ?? job.detectedFramework,
+      detectedPort: body.detectedPort ?? job.detectedPort,
+      errorMessage: body.errorMessage?.slice(0, 4_000) ?? null,
+      startedAt: newStatus === 'RUNNING' && !job.startedAt ? now : job.startedAt,
+      finishedAt: TERMINAL.has(newStatus) ? now : null,
+    },
+  })
+
+  // ── 2. Mirror status onto Service for fast UI reads ────
+  await prisma.service.update({
+    where: { id: job.serviceId },
+    data: {
+      lastBuildStatus: newStatus,
+      lastBuildAt: now,
+      lastBuildSha: body.commitSha ?? job.commitSha,
+      ...(newStatus === 'SUCCEEDED' && body.imageTag
+        ? {
+            dockerImage: body.imageTag,
+            detectedFramework: body.detectedFramework ?? job.detectedFramework,
+            detectedPort: body.detectedPort ?? job.detectedPort,
+            // Use the detected port as the runtime container port if the user
+            // hasn't pinned one explicitly. SDL generators read containerPort.
+            containerPort:
+              job.service.containerPort ?? body.detectedPort ?? job.detectedPort ?? null,
+          }
+        : {}),
+    },
+  })
+
+  // ── 3. Best-effort: write commit status back to GitHub ─
+  if (job.service.gitInstallation && job.service.gitOwner && job.service.gitRepo) {
+    const installationId = job.service.gitInstallation.installationId
+    const targetUrl = `${process.env.APP_URL || 'https://app.alternatefutures.ai'}/services/${job.service.id}`
+    void postCommitStatus(installationId, job.service.gitOwner, job.service.gitRepo, job.commitSha, {
+      state:
+        newStatus === 'SUCCEEDED'
+          ? 'success'
+          : newStatus === 'FAILED' || newStatus === 'CANCELED'
+            ? 'failure'
+            : 'pending',
+      target_url: targetUrl,
+      description:
+        newStatus === 'SUCCEEDED'
+          ? `Built on AlternateFutures (${body.detectedFramework ?? 'app'})`
+          : newStatus === 'FAILED'
+            ? body.errorMessage?.slice(0, 140) ?? 'Build failed'
+            : 'Building…',
+    }).catch((err) => log.warn({ err, buildJobId: job.id }, 'commit status post failed'))
+  }
+
+  // ── 4. On success, auto-deploy via existing per-deploy provider. ──
+  if (newStatus === 'SUCCEEDED' && body.imageTag) {
+    try {
+      await autoDeployAfterBuild(prisma, job.serviceId)
+    } catch (err) {
+      log.error({ err, serviceId: job.serviceId }, 'failed to dispatch deploy after build')
+      // We still 200 the callback — the BuildJob row is updated; the user
+      // can hit "Redeploy" from the UI to retry the deploy step.
+    }
+  }
+
+  return reply(res, 200, { ok: true, status: newStatus })
+}
+
+/**
+ * Decide which compute provider to deploy the freshly-built image to,
+ * then call the existing GraphQL deploy mutation. We deliberately call
+ * the resolver functions (not provider.deploy()) so we inherit their
+ * full guard stack — subscription, balance, policy, QStash pipeline —
+ * without duplicating it.
+ *
+ * Provider choice mirrors what the ServiceDetailPanel "Deploy" button
+ * does today (see ServiceDetailPanel.onDeploy):
+ *   1. Active Phala deployment present → keep on Phala
+ *   2. Otherwise → Akash (the panel's default fallback)
+ *
+ * The user retargets later via ComputeSelector + Redeploy, identical
+ * to the docker / server / function flavors.
+ */
+async function autoDeployAfterBuild(prisma: PrismaClient, serviceId: string): Promise<void> {
+  const service = await prisma.service.findUnique({
+    where: { id: serviceId },
+    include: {
+      project: true,
+      phalaDeployments: {
+        where: { status: { in: ['ACTIVE', 'CREATING', 'STARTING'] } },
+        select: { id: true },
+        take: 1,
+      },
+    },
+  })
+  if (!service) throw new Error('service not found')
+  if (!service.createdByUserId) {
+    throw new Error('cannot deploy: service has no createdByUserId')
+  }
+
+  const ctx = {
+    prisma,
+    userId: service.createdByUserId,
+    organizationId: service.project.organizationId ?? undefined,
+    projectId: service.projectId,
+  } as unknown as Context
+
+  const useTee = service.phalaDeployments.length > 0
+  log.info(
+    { serviceId, provider: useTee ? 'phala' : 'akash' },
+    'auto-deploying after successful build',
+  )
+
+  if (useTee) {
+    await phalaMutations.deployToPhala(undefined, { input: { serviceId } }, ctx)
+  } else {
+    await akashMutations.deployToAkash(undefined, { input: { serviceId } }, ctx)
+  }
+}

--- a/src/services/github/buildCallbackEndpoint.ts
+++ b/src/services/github/buildCallbackEndpoint.ts
@@ -110,26 +110,34 @@ export async function handleBuildCallback(
     return reply(res, 404, 'build job not found')
   }
 
-  // Idempotency: don't allow downgrading from a terminal status.
   const TERMINAL: ReadonlySet<BuildStatus> = new Set(['SUCCEEDED', 'FAILED', 'CANCELED'] as const)
-  if (TERMINAL.has(job.status) && job.status !== body.status) {
-    log.info(
-      { buildJobId: job.id, current: job.status, incoming: body.status },
-      'ignoring callback that would downgrade terminal status',
-    )
-    return reply(res, 200, { ok: true, ignored: 'terminal' })
-  }
-
   const now = new Date()
   const newStatus = body.status as BuildStatus
 
-  // BuildJob row + Service mirror MUST move together. If the BuildJob row
-  // landed terminal but the Service mirror failed, the UI would show stale
-  // "Building…" until the next callback or a manual refresh — and an
-  // auto-deploy below would race against the wrong dockerImage. Atomic.
-  await prisma.$transaction([
-    prisma.buildJob.update({
-      where: { id: job.id },
+  // Atomic idempotency + write. The previous version did a read (line 100),
+  // a JS-level terminal check, then a write — leaving a window where two
+  // near-simultaneous callbacks (e.g. builder posts SUCCEEDED, K8s pod-
+  // deletion handler posts FAILED) could both pass the gate and double-apply.
+  //
+  // We collapse the gate INTO the WHERE clause: `updateMany` succeeds only
+  // if the current status is non-terminal OR the incoming status equals the
+  // current one (idempotent retry of a terminal callback). If count === 0,
+  // somebody else already drove this row terminal-with-a-different-status —
+  // treat as a benign no-op and DON'T write the Service mirror (the winning
+  // callback's own service write is the truth).
+  //
+  // Interactive transaction (vs the array form) so the Service write is
+  // conditional on the BuildJob CAS succeeding — and both still commit
+  // atomically when the CAS wins.
+  const txResult = await prisma.$transaction(async (tx) => {
+    const updated = await tx.buildJob.updateMany({
+      where: {
+        id: job.id,
+        OR: [
+          { status: { notIn: ['SUCCEEDED', 'FAILED', 'CANCELED'] } },
+          { status: newStatus },
+        ],
+      },
       data: {
         status: newStatus,
         logs: body.logs?.slice(0, 60_000) ?? job.logs ?? undefined,
@@ -140,8 +148,9 @@ export async function handleBuildCallback(
         startedAt: newStatus === 'RUNNING' && !job.startedAt ? now : job.startedAt,
         finishedAt: TERMINAL.has(newStatus) ? now : null,
       },
-    }),
-    prisma.service.update({
+    })
+    if (updated.count === 0) return { applied: false as const }
+    await tx.service.update({
       where: { id: job.serviceId },
       data: {
         lastBuildStatus: newStatus,
@@ -160,8 +169,17 @@ export async function handleBuildCallback(
             }
           : {}),
       },
-    }),
-  ])
+    })
+    return { applied: true as const }
+  })
+
+  if (!txResult.applied) {
+    log.info(
+      { buildJobId: job.id, current: job.status, incoming: body.status },
+      'ignoring callback that would downgrade terminal status',
+    )
+    return reply(res, 200, { ok: true, ignored: 'terminal' })
+  }
 
   // ── 3. Best-effort: write commit status back to GitHub ─
   if (job.service.gitInstallation && job.service.gitOwner && job.service.gitRepo) {

--- a/src/services/github/buildCallbackEndpoint.ts
+++ b/src/services/github/buildCallbackEndpoint.ts
@@ -123,41 +123,45 @@ export async function handleBuildCallback(
   const now = new Date()
   const newStatus = body.status as BuildStatus
 
-  // ── 1. Persist BuildJob update ──────────────────────────
-  await prisma.buildJob.update({
-    where: { id: job.id },
-    data: {
-      status: newStatus,
-      logs: body.logs?.slice(0, 60_000) ?? job.logs ?? undefined,
-      imageTag: body.imageTag ?? job.imageTag,
-      detectedFramework: body.detectedFramework ?? job.detectedFramework,
-      detectedPort: body.detectedPort ?? job.detectedPort,
-      errorMessage: body.errorMessage?.slice(0, 4_000) ?? null,
-      startedAt: newStatus === 'RUNNING' && !job.startedAt ? now : job.startedAt,
-      finishedAt: TERMINAL.has(newStatus) ? now : null,
-    },
-  })
-
-  // ── 2. Mirror status onto Service for fast UI reads ────
-  await prisma.service.update({
-    where: { id: job.serviceId },
-    data: {
-      lastBuildStatus: newStatus,
-      lastBuildAt: now,
-      lastBuildSha: body.commitSha ?? job.commitSha,
-      ...(newStatus === 'SUCCEEDED' && body.imageTag
-        ? {
-            dockerImage: body.imageTag,
-            detectedFramework: body.detectedFramework ?? job.detectedFramework,
-            detectedPort: body.detectedPort ?? job.detectedPort,
-            // Use the detected port as the runtime container port if the user
-            // hasn't pinned one explicitly. SDL generators read containerPort.
-            containerPort:
-              job.service.containerPort ?? body.detectedPort ?? job.detectedPort ?? null,
-          }
-        : {}),
-    },
-  })
+  // BuildJob row + Service mirror MUST move together. If the BuildJob row
+  // landed terminal but the Service mirror failed, the UI would show stale
+  // "Building…" until the next callback or a manual refresh — and an
+  // auto-deploy below would race against the wrong dockerImage. Atomic.
+  await prisma.$transaction([
+    prisma.buildJob.update({
+      where: { id: job.id },
+      data: {
+        status: newStatus,
+        logs: body.logs?.slice(0, 60_000) ?? job.logs ?? undefined,
+        imageTag: body.imageTag ?? job.imageTag,
+        detectedFramework: body.detectedFramework ?? job.detectedFramework,
+        detectedPort: body.detectedPort ?? job.detectedPort,
+        errorMessage: body.errorMessage?.slice(0, 4_000) ?? null,
+        startedAt: newStatus === 'RUNNING' && !job.startedAt ? now : job.startedAt,
+        finishedAt: TERMINAL.has(newStatus) ? now : null,
+      },
+    }),
+    prisma.service.update({
+      where: { id: job.serviceId },
+      data: {
+        lastBuildStatus: newStatus,
+        lastBuildAt: now,
+        lastBuildSha: body.commitSha ?? job.commitSha,
+        ...(newStatus === 'SUCCEEDED' && body.imageTag
+          ? {
+              dockerImage: body.imageTag,
+              detectedFramework: body.detectedFramework ?? job.detectedFramework,
+              detectedPort: body.detectedPort ?? job.detectedPort,
+              // Use the detected port as the runtime container port if the
+              // user hasn't pinned one explicitly. SDL generators read
+              // containerPort.
+              containerPort:
+                job.service.containerPort ?? body.detectedPort ?? job.detectedPort ?? null,
+            }
+          : {}),
+      },
+    }),
+  ])
 
   // ── 3. Best-effort: write commit status back to GitHub ─
   if (job.service.gitInstallation && job.service.gitOwner && job.service.gitRepo) {

--- a/src/services/github/buildSpawner.ts
+++ b/src/services/github/buildSpawner.ts
@@ -239,8 +239,24 @@ export async function deleteBuildJob(k8sJobName: string): Promise<void> {
   }
 }
 
+/**
+ * Escape a string for safe interpolation into a YAML double-quoted scalar.
+ *
+ * The values currently passing through (GitHub install tokens, GHCR PATs,
+ * a templated clone URL) cannot in practice contain control chars — but
+ * defense-in-depth is cheap, and someone WILL eventually pipe a user-
+ * supplied value through here without re-reading this comment. Escape
+ * `\\`, `"`, and the three control chars that actually break YAML scalar
+ * parsing. We don't reach for js-yaml because we own the template, this
+ * single helper, and know the surrounding context is always `"…"`.
+ */
 function escapeYamlValue(v: string): string {
-  return v.replaceAll('\\', '\\\\').replaceAll('"', '\\"')
+  return v
+    .replaceAll('\\', '\\\\')
+    .replaceAll('"', '\\"')
+    .replaceAll('\n', '\\n')
+    .replaceAll('\r', '\\r')
+    .replaceAll('\t', '\\t')
 }
 
 function toB64(v: string): string {

--- a/src/services/github/buildSpawner.ts
+++ b/src/services/github/buildSpawner.ts
@@ -1,0 +1,248 @@
+/**
+ * af-builder Job spawner.
+ *
+ * Reads `infra/k8s/builder/job.template.yaml`, substitutes per-build env,
+ * and creates the Job in the `alternatefutures-builds` namespace.
+ *
+ * In-cluster: uses the pod's mounted ServiceAccount token (the `af-builder-spawner`
+ * SA has RBAC to manage Jobs in that namespace via `infra/k8s/builder/rbac.yaml`).
+ * Local dev: uses the developer's `~/.kube/config`.
+ *
+ * Local dev without a cluster: set `BUILDER_DRY_RUN=1` to skip Job creation
+ * and only persist the BuildJob row — useful for UI iteration.
+ */
+
+import * as k8s from '@kubernetes/client-node'
+import fs from 'node:fs'
+import path from 'node:path'
+import { createLogger } from '../../lib/logger.js'
+import { getGithubAppConfig } from './config.js'
+import { signBuildToken } from './buildToken.js'
+import { buildCloneUrl } from './client.js'
+
+const log = createLogger('github.buildSpawner')
+
+const NAMESPACE = process.env.BUILDER_NAMESPACE || 'alternatefutures-builds'
+const BUILDER_IMAGE =
+  process.env.BUILDER_IMAGE || 'ghcr.io/alternatefutures/af-builder:latest'
+
+const TEMPLATE_PATH = (() => {
+  if (process.env.BUILDER_JOB_TEMPLATE_PATH) return process.env.BUILDER_JOB_TEMPLATE_PATH
+  return path.resolve(process.cwd(), '../infra/k8s/builder/job.template.yaml')
+})()
+
+let cachedTemplate: string | null = null
+function loadTemplate(): string {
+  if (cachedTemplate) return cachedTemplate
+  // Prefer disk so ops can hot-edit the template in dev, fall back to the
+  // embedded constant so the api Docker image is self-contained (the infra/
+  // dir lives in a sibling repo and isn't copied into the image).
+  if (fs.existsSync(TEMPLATE_PATH)) {
+    cachedTemplate = fs.readFileSync(TEMPLATE_PATH, 'utf8')
+  } else {
+    cachedTemplate = EMBEDDED_TEMPLATE
+  }
+  return cachedTemplate
+}
+
+// Keep in sync with infra/k8s/builder/job.template.yaml. Edited there is the
+// canonical source; this constant is a build-time snapshot for prod.
+const EMBEDDED_TEMPLATE = `apiVersion: batch/v1
+kind: Job
+metadata:
+  name: __JOB_NAME__
+  namespace: __NAMESPACE__
+  labels:
+    app: af-builder
+    af.io/build-job-id: "__BUILD_JOB_ID__"
+spec:
+  ttlSecondsAfterFinished: 3600
+  backoffLimit: 0
+  activeDeadlineSeconds: 1800
+  template:
+    metadata:
+      labels:
+        app: af-builder
+        af.io/build-job-id: "__BUILD_JOB_ID__"
+    spec:
+      restartPolicy: Never
+      shareProcessNamespace: true
+      automountServiceAccountToken: false
+      containers:
+        - name: dind
+          image: docker:24-dind
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          args:
+            - "--host=tcp://0.0.0.0:2375"
+            - "--tls=false"
+          env:
+            - name: DOCKER_TLS_CERTDIR
+              value: ""
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: dind-storage
+              mountPath: /var/lib/docker
+            - name: workspace
+              mountPath: /workspace
+          readinessProbe:
+            tcpSocket:
+              port: 2375
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            failureThreshold: 30
+        - name: builder
+          image: __BUILDER_IMAGE__
+          imagePullPolicy: Always
+          env:
+            - name: DOCKER_HOST
+              value: "tcp://localhost:2375"
+            - name: BUILD_JOB_ID
+              value: "__BUILD_JOB_ID__"
+            - name: CALLBACK_URL
+              value: "__CALLBACK_URL__"
+            - name: CALLBACK_TOKEN
+              value: "__CALLBACK_TOKEN__"
+            - name: REPO_CLONE_URL
+              value: "__REPO_CLONE_URL__"
+            - name: REPO_REF
+              value: "__REPO_REF__"
+            - name: IMAGE_TAG
+              value: "__IMAGE_TAG__"
+            - name: GHCR_USER
+              value: "__GHCR_USER__"
+            - name: GHCR_TOKEN
+              value: "__GHCR_TOKEN__"
+            - name: ROOT_DIRECTORY
+              value: "__ROOT_DIRECTORY__"
+            - name: BUILD_COMMAND_B64
+              value: "__BUILD_COMMAND_B64__"
+            - name: START_COMMAND_B64
+              value: "__START_COMMAND_B64__"
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "1Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspace
+      volumes:
+        - name: dind-storage
+          emptyDir: {}
+        - name: workspace
+          emptyDir: {}
+`
+
+let cachedKc: k8s.KubeConfig | null = null
+function getKubeClient(): k8s.BatchV1Api {
+  if (!cachedKc) {
+    cachedKc = new k8s.KubeConfig()
+    if (process.env.KUBERNETES_SERVICE_HOST) {
+      cachedKc.loadFromCluster()
+    } else {
+      cachedKc.loadFromDefault()
+    }
+  }
+  return cachedKc.makeApiClient(k8s.BatchV1Api)
+}
+
+export interface SpawnBuildInput {
+  buildJobId: string
+  installationId: bigint | string
+  repoOwner: string
+  repoName: string
+  /** Full commit SHA — REQUIRED, pin builds to immutable refs. */
+  commitSha: string
+  /** Where the resulting image gets pushed (ghcr.io/<ns>/<userid>--<repo>:<sha>). */
+  imageTag: string
+  rootDirectory?: string
+  buildCommand?: string
+  startCommand?: string
+  /** Override for the callback base URL. Defaults to API_BASE_URL or api.alternatefutures.ai. */
+  callbackBaseUrl?: string
+}
+
+export interface SpawnedBuildJob {
+  k8sJobName: string
+  /** True only when BUILDER_DRY_RUN=1 — used by tests + local dev. */
+  dryRun: boolean
+}
+
+export async function spawnBuildJob(input: SpawnBuildInput): Promise<SpawnedBuildJob> {
+  const cfg = getGithubAppConfig()
+  const cloneUrl = await buildCloneUrl(input.installationId, input.repoOwner, input.repoName)
+  const callbackBase =
+    input.callbackBaseUrl || process.env.API_BASE_URL || 'https://api.alternatefutures.ai'
+  const callbackUrl = `${callbackBase.replace(/\/$/, '')}/internal/build-callback`
+  const callbackToken = signBuildToken(input.buildJobId)
+
+  const jobName = `build-${input.buildJobId.toLowerCase()}`.slice(0, 63)
+
+  const yaml = loadTemplate()
+    .replaceAll('__JOB_NAME__', jobName)
+    .replaceAll('__NAMESPACE__', NAMESPACE)
+    .replaceAll('__BUILDER_IMAGE__', BUILDER_IMAGE)
+    .replaceAll('__BUILD_JOB_ID__', input.buildJobId)
+    .replaceAll('__CALLBACK_URL__', callbackUrl)
+    .replaceAll('__CALLBACK_TOKEN__', callbackToken)
+    // YAML strings are double-quoted in the template; embed-safely escape
+    // the few characters that could break out (`"` and `\`).
+    .replaceAll('__REPO_CLONE_URL__', escapeYamlValue(cloneUrl))
+    .replaceAll('__REPO_REF__', input.commitSha)
+    .replaceAll('__IMAGE_TAG__', input.imageTag)
+    .replaceAll('__GHCR_USER__', cfg.ghcrUser)
+    .replaceAll('__GHCR_TOKEN__', escapeYamlValue(cfg.ghcrPushToken))
+    .replaceAll('__ROOT_DIRECTORY__', input.rootDirectory || '.')
+    .replaceAll('__BUILD_COMMAND_B64__', input.buildCommand ? toB64(input.buildCommand) : '')
+    .replaceAll('__START_COMMAND_B64__', input.startCommand ? toB64(input.startCommand) : '')
+
+  if (process.env.BUILDER_DRY_RUN === '1') {
+    log.warn({ jobName, buildJobId: input.buildJobId }, 'BUILDER_DRY_RUN=1 — skipping K8s create')
+    return { k8sJobName: jobName, dryRun: true }
+  }
+
+  const parsed = k8s.loadYaml<k8s.V1Job>(yaml)
+  const api = getKubeClient()
+  try {
+    await api.createNamespacedJob({ namespace: NAMESPACE, body: parsed })
+  } catch (err: unknown) {
+    log.error({ err, jobName }, 'failed to create builder Job')
+    throw new Error(`builder spawn failed: ${err instanceof Error ? err.message : String(err)}`)
+  }
+
+  log.info({ jobName, buildJobId: input.buildJobId }, 'builder Job created')
+  return { k8sJobName: jobName, dryRun: false }
+}
+
+/** Best-effort delete of a builder Job (used on cancel + manual cleanup). */
+export async function deleteBuildJob(k8sJobName: string): Promise<void> {
+  if (process.env.BUILDER_DRY_RUN === '1') return
+  try {
+    const api = getKubeClient()
+    await api.deleteNamespacedJob({
+      name: k8sJobName,
+      namespace: NAMESPACE,
+      propagationPolicy: 'Background',
+    })
+  } catch (err) {
+    log.warn({ err, k8sJobName }, 'failed to delete builder Job (already gone?)')
+  }
+}
+
+function escapeYamlValue(v: string): string {
+  return v.replaceAll('\\', '\\\\').replaceAll('"', '\\"')
+}
+
+function toB64(v: string): string {
+  return Buffer.from(v, 'utf8').toString('base64')
+}

--- a/src/services/github/buildToken.ts
+++ b/src/services/github/buildToken.ts
@@ -1,0 +1,66 @@
+/**
+ * Build callback token — HMAC-signed one-time token the api hands the
+ * builder Job; the builder echoes it back via `X-AF-Build-Token` when
+ * POSTing status updates.
+ *
+ * Why not reuse JWT?
+ *   - We don't need claims or expiry-based features; the BuildJob row
+ *     itself is the source of truth (has expected status transitions).
+ *   - Smaller wire format, deterministic, easy to inspect.
+ *
+ * Format:  base64url(payload).base64url(hmac256(payload))
+ *   payload = `<buildJobId>.<unixSec>`
+ *
+ * Verification rules:
+ *   - HMAC matches
+ *   - buildJobId in payload matches the one in the request body
+ *   - unixSec is within 4h of now (matches Job's activeDeadlineSeconds + slack)
+ */
+
+import crypto from 'node:crypto'
+
+const MAX_AGE_SEC = 4 * 60 * 60 // 4h
+
+function getSecret(): string {
+  // Reuse JWT_SECRET (already shared between auth + cloud-api via deploy-secrets).
+  // Falls back to GITHUB_APP_WEBHOOK_SECRET so local dev "just works" after
+  // the manifest flow, even before deploy-secrets is run.
+  const s = process.env.JWT_SECRET || process.env.GITHUB_APP_WEBHOOK_SECRET
+  if (!s) throw new Error('build-token: neither JWT_SECRET nor GITHUB_APP_WEBHOOK_SECRET is set')
+  return s
+}
+
+function b64url(input: Buffer | string): string {
+  return Buffer.from(input)
+    .toString('base64')
+    .replace(/=+$/, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+}
+
+export function signBuildToken(buildJobId: string): string {
+  const payload = `${buildJobId}.${Math.floor(Date.now() / 1000)}`
+  const sig = crypto.createHmac('sha256', getSecret()).update(payload).digest()
+  return `${b64url(payload)}.${b64url(sig)}`
+}
+
+export function verifyBuildToken(token: string, expectedBuildJobId: string): boolean {
+  const parts = token.split('.')
+  if (parts.length !== 2) return false
+  const [payloadB64, sigB64] = parts
+  const payload = Buffer.from(payloadB64.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8')
+  const sig = Buffer.from(sigB64.replace(/-/g, '+').replace(/_/g, '/'), 'base64')
+
+  const expected = crypto.createHmac('sha256', getSecret()).update(payload).digest()
+  if (sig.length !== expected.length) return false
+  if (!crypto.timingSafeEqual(sig, expected)) return false
+
+  const [jobId, tsStr] = payload.split('.')
+  if (jobId !== expectedBuildJobId) return false
+  const ts = Number(tsStr)
+  if (!Number.isFinite(ts)) return false
+  const age = Math.floor(Date.now() / 1000) - ts
+  if (age < -60 || age > MAX_AGE_SEC) return false
+
+  return true
+}

--- a/src/services/github/client.ts
+++ b/src/services/github/client.ts
@@ -1,0 +1,215 @@
+/**
+ * Thin typed wrappers over the GitHub REST API used by service-cloud-api.
+ *
+ * We intentionally do NOT pull in `@octokit/rest` — we make ~6 calls and
+ * don't need 200KB of generated client code. Raw fetch + a tiny shape per
+ * endpoint keeps deps lean and the wire format obvious in PR diffs.
+ */
+
+import { getAppJwt, getInstallationToken } from './app.js'
+
+const GH = 'https://api.github.com'
+
+interface GhFetchOpts {
+  /** Auth via App JWT (for `/app/...` endpoints) vs installation token. */
+  auth: 'app-jwt' | { installationId: bigint | string }
+  query?: Record<string, string | number | undefined>
+}
+
+async function gh<T>(path: string, opts: GhFetchOpts): Promise<T> {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': 'AlternateFutures',
+  }
+  if (opts.auth === 'app-jwt') {
+    headers.Authorization = `Bearer ${getAppJwt()}`
+  } else {
+    const token = await getInstallationToken(opts.auth.installationId)
+    headers.Authorization = `Bearer ${token}`
+  }
+
+  let url = `${GH}${path}`
+  if (opts.query) {
+    const q = Object.entries(opts.query)
+      .filter(([, v]) => v !== undefined)
+      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
+      .join('&')
+    if (q) url += `${path.includes('?') ? '&' : '?'}${q}`
+  }
+
+  const r = await fetch(url, { headers })
+  if (!r.ok) {
+    const body = await r.text().catch(() => '')
+    throw new GithubApiError(r.status, `${r.status} ${path}: ${body.slice(0, 200)}`)
+  }
+  return (await r.json()) as T
+}
+
+export class GithubApiError extends Error {
+  constructor(public readonly status: number, message: string) {
+    super(message)
+    this.name = 'GithubApiError'
+  }
+}
+
+// -----------------------------------------------------------------------
+// Types — narrowed to only the fields we use.
+// -----------------------------------------------------------------------
+
+export interface GhInstallation {
+  id: number
+  account:
+    | { login: string; id: number; type: 'User' }
+    | { login: string; id: number; type: 'Organization' }
+  repository_selection: 'all' | 'selected'
+  suspended_at: string | null
+}
+
+export interface GhRepo {
+  id: number
+  name: string
+  full_name: string
+  owner: { login: string }
+  private: boolean
+  default_branch: string
+  description: string | null
+  pushed_at: string | null
+  language: string | null
+  html_url: string
+}
+
+export interface GhBranch {
+  name: string
+  commit: { sha: string }
+  protected: boolean
+}
+
+export interface GhCommit {
+  sha: string
+  commit: { message: string; author: { name: string; email: string; date: string } }
+}
+
+// -----------------------------------------------------------------------
+// Endpoints
+// -----------------------------------------------------------------------
+
+/** GET /app/installations — list every install of this App across all accounts. */
+export async function listAllInstallations(): Promise<GhInstallation[]> {
+  // App JWT auth. Paginated; we fetch up to 100 (we'll never realistically
+  // have more for a single org's UI).
+  return gh<GhInstallation[]>('/app/installations?per_page=100', { auth: 'app-jwt' })
+}
+
+/** GET /app/installations/{id} — single install metadata. */
+export async function getInstallation(installationId: bigint | string): Promise<GhInstallation> {
+  return gh<GhInstallation>(`/app/installations/${installationId}`, { auth: 'app-jwt' })
+}
+
+/** GET /installation/repositories — repos this install can access. */
+export async function listInstallationRepos(
+  installationId: bigint | string,
+): Promise<GhRepo[]> {
+  // Paginate up to 5 pages (500 repos). Stops early when GitHub returns < per_page.
+  const repos: GhRepo[] = []
+  for (let page = 1; page <= 5; page++) {
+    const data = await gh<{ total_count: number; repositories: GhRepo[] }>(
+      `/installation/repositories?per_page=100&page=${page}`,
+      { auth: { installationId } },
+    )
+    repos.push(...data.repositories)
+    if (data.repositories.length < 100) break
+  }
+  return repos
+}
+
+/** GET /repos/{owner}/{repo}/branches — list branches (used in branch picker). */
+export async function listRepoBranches(
+  installationId: bigint | string,
+  owner: string,
+  repo: string,
+): Promise<GhBranch[]> {
+  return gh<GhBranch[]>(
+    `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/branches?per_page=100`,
+    { auth: { installationId } },
+  )
+}
+
+/** GET /repos/{owner}/{repo} — used to confirm default branch + repo metadata. */
+export async function getRepo(
+  installationId: bigint | string,
+  owner: string,
+  repo: string,
+): Promise<GhRepo> {
+  return gh<GhRepo>(
+    `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`,
+    { auth: { installationId } },
+  )
+}
+
+/**
+ * GET /repos/{owner}/{repo}/commits/{ref} — resolve branch name → commit SHA
+ * so we always pin builds to an immutable ref.
+ */
+export async function getCommit(
+  installationId: bigint | string,
+  owner: string,
+  repo: string,
+  ref: string,
+): Promise<GhCommit> {
+  return gh<GhCommit>(
+    `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/commits/${encodeURIComponent(ref)}`,
+    { auth: { installationId } },
+  )
+}
+
+/**
+ * POST /repos/{owner}/{repo}/statuses/{sha} — write the green/red checkmark
+ * shown on the commit / PR.
+ */
+export async function postCommitStatus(
+  installationId: bigint | string,
+  owner: string,
+  repo: string,
+  sha: string,
+  body: {
+    state: 'pending' | 'success' | 'failure' | 'error'
+    target_url?: string
+    description?: string
+    /** Distinct context per check; ours is always 'alternatefutures/deploy'. */
+    context?: string
+  },
+): Promise<void> {
+  const token = await getInstallationToken(installationId)
+  const r = await fetch(
+    `${GH}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/statuses/${encodeURIComponent(sha)}`,
+    {
+      method: 'POST',
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        'User-Agent': 'AlternateFutures',
+      },
+      body: JSON.stringify({ context: 'alternatefutures/deploy', ...body }),
+    },
+  )
+  if (!r.ok) {
+    const text = await r.text().catch(() => '')
+    throw new GithubApiError(r.status, `commit status: ${r.status}: ${text.slice(0, 200)}`)
+  }
+}
+
+/**
+ * Build the HTTPS clone URL embedding a freshly-minted installation token.
+ *   https://x-access-token:<token>@github.com/<owner>/<repo>.git
+ */
+export async function buildCloneUrl(
+  installationId: bigint | string,
+  owner: string,
+  repo: string,
+): Promise<string> {
+  const token = await getInstallationToken(installationId)
+  return `https://x-access-token:${token}@github.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}.git`
+}

--- a/src/services/github/client.ts
+++ b/src/services/github/client.ts
@@ -7,8 +7,10 @@
  */
 
 import { getAppJwt, getInstallationToken } from './app.js'
+import { createLogger } from '../../lib/logger.js'
 
 const GH = 'https://api.github.com'
+const log = createLogger('github.client')
 
 interface GhFetchOpts {
   /** Auth via App JWT (for `/app/...` endpoints) vs installation token. */
@@ -110,15 +112,29 @@ export async function getInstallation(installationId: bigint | string): Promise<
 export async function listInstallationRepos(
   installationId: bigint | string,
 ): Promise<GhRepo[]> {
-  // Paginate up to 5 pages (500 repos). Stops early when GitHub returns < per_page.
+  // Hard cap pagination so a misbehaving / huge installation can't pin a
+  // request thread for minutes. UI lists are filtered + repo-pickered so
+  // showing the first MAX_PAGES * per_page is fine; we log a warning if
+  // we truncated so ops can spot orgs hitting the cap.
+  const PER_PAGE = 100
+  const MAX_PAGES = 10 // 1,000 repos — 99.9% of orgs
   const repos: GhRepo[] = []
-  for (let page = 1; page <= 5; page++) {
+  let lastTotal = 0
+  let page = 1
+  for (; page <= MAX_PAGES; page++) {
     const data = await gh<{ total_count: number; repositories: GhRepo[] }>(
-      `/installation/repositories?per_page=100&page=${page}`,
+      `/installation/repositories?per_page=${PER_PAGE}&page=${page}`,
       { auth: { installationId } },
     )
+    lastTotal = data.total_count
     repos.push(...data.repositories)
-    if (data.repositories.length < 100) break
+    if (data.repositories.length < PER_PAGE) break
+  }
+  if (lastTotal > repos.length) {
+    log.warn(
+      { installationId: String(installationId), returned: repos.length, total: lastTotal },
+      'listInstallationRepos truncated — installation has more repos than MAX_PAGES * PER_PAGE',
+    )
   }
   return repos
 }

--- a/src/services/github/config.ts
+++ b/src/services/github/config.ts
@@ -1,0 +1,94 @@
+/**
+ * GitHub App configuration loader.
+ *
+ * Env vars are populated by `infra/github-app/capture-credentials.mjs` after
+ * the manifest-flow registration. The private key is base64-encoded so it
+ * survives `.env` files (PEM has multiline content + newline-sensitive parsers).
+ */
+
+let cached: GithubAppConfig | null = null
+
+export interface GithubAppConfig {
+  appId: string
+  appSlug: string
+  clientId: string
+  clientSecret: string
+  webhookSecret: string
+  privateKeyPem: string
+  /**
+   * GHCR push identity used by the builder Job. Defaults to the App slug;
+   * override via env if you push under a different bot account.
+   */
+  ghcrUser: string
+  /**
+   * GHCR namespace (org/user under which built images are published).
+   * E.g. `alternatefutures` -> `ghcr.io/alternatefutures/<userid>--<repo>:<sha>`.
+   */
+  ghcrNamespace: string
+  /**
+   * PAT with `write:packages` scope used by the builder for `docker push`.
+   * Distinct from the App installation token because installation tokens
+   * cannot push to ghcr (only repo contents). Stored in the same K8s
+   * secret as the rest of the app config.
+   */
+  ghcrPushToken: string
+}
+
+export class GithubAppConfigError extends Error {
+  constructor(missing: string[]) {
+    super(
+      `GitHub App is not configured. Missing env: ${missing.join(', ')}. ` +
+        `Run \`node infra/github-app/capture-credentials.mjs\` then re-source your env.`,
+    )
+    this.name = 'GithubAppConfigError'
+  }
+}
+
+export function isGithubAppConfigured(): boolean {
+  try {
+    getGithubAppConfig()
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function getGithubAppConfig(): GithubAppConfig {
+  if (cached) return cached
+
+  const required: Record<string, string | undefined> = {
+    GITHUB_APP_ID: process.env.GITHUB_APP_ID,
+    GITHUB_APP_SLUG: process.env.GITHUB_APP_SLUG,
+    GITHUB_APP_CLIENT_ID: process.env.GITHUB_APP_CLIENT_ID,
+    GITHUB_APP_CLIENT_SECRET: process.env.GITHUB_APP_CLIENT_SECRET,
+    GITHUB_APP_WEBHOOK_SECRET: process.env.GITHUB_APP_WEBHOOK_SECRET,
+    GITHUB_APP_PRIVATE_KEY_B64: process.env.GITHUB_APP_PRIVATE_KEY_B64,
+    GHCR_PUSH_TOKEN: process.env.GHCR_PUSH_TOKEN,
+  }
+  const missing = Object.entries(required)
+    .filter(([, v]) => !v)
+    .map(([k]) => k)
+  if (missing.length > 0) {
+    throw new GithubAppConfigError(missing)
+  }
+
+  const privateKeyPem = Buffer.from(required.GITHUB_APP_PRIVATE_KEY_B64!, 'base64').toString('utf8')
+
+  cached = {
+    appId: required.GITHUB_APP_ID!,
+    appSlug: required.GITHUB_APP_SLUG!,
+    clientId: required.GITHUB_APP_CLIENT_ID!,
+    clientSecret: required.GITHUB_APP_CLIENT_SECRET!,
+    webhookSecret: required.GITHUB_APP_WEBHOOK_SECRET!,
+    privateKeyPem,
+    ghcrUser: process.env.GHCR_USER || required.GITHUB_APP_SLUG!,
+    ghcrNamespace: process.env.GHCR_NAMESPACE || 'alternatefutures',
+    ghcrPushToken: required.GHCR_PUSH_TOKEN!,
+  }
+  return cached
+}
+
+/** Test-only — clears the cached config so a new env can be loaded. */
+export function _resetGithubAppConfigCache() {
+  cached = null
+}

--- a/src/services/github/webhookEndpoint.ts
+++ b/src/services/github/webhookEndpoint.ts
@@ -265,9 +265,12 @@ async function handlePushEvent(prisma: PrismaClient, payload: PushEvent): Promis
       })
 
       const cfg = getGithubAppConfig()
+      // Docker registry refs MUST be all lowercase — userId is a Prisma cuid
+      // (mixed case) and would break `docker build -t …` otherwise.
+      const safeUserId = svc.createdByUserId.toLowerCase().replace(/[^a-z0-9-]/g, '-')
       const safeOwner = svc.gitOwner!.toLowerCase().replace(/[^a-z0-9-]/g, '-')
       const safeRepo = svc.gitRepo!.toLowerCase().replace(/[^a-z0-9-]/g, '-')
-      const imageTag = `ghcr.io/${cfg.ghcrNamespace}/${svc.createdByUserId}--${safeOwner}-${safeRepo}:${payload.after.slice(0, 12)}`
+      const imageTag = `ghcr.io/${cfg.ghcrNamespace}/${safeUserId}--${safeOwner}-${safeRepo}:${payload.after.slice(0, 12)}`
 
       const spawned = await spawnBuildJob({
         buildJobId: buildJob.id,

--- a/src/services/github/webhookEndpoint.ts
+++ b/src/services/github/webhookEndpoint.ts
@@ -1,0 +1,292 @@
+/**
+ * `POST /webhooks/github` — receives GitHub App webhooks.
+ *
+ * Events we handle (everything else is ack'd 200 + ignored):
+ *   - installation (created | deleted | suspend | unsuspend) → upsert/delete row
+ *   - installation_repositories (added/removed) → no-op for now (UI re-fetches lazily)
+ *   - push → if pushed branch matches any Service.gitBranch + repo, trigger rebuild
+ *
+ * MUST read raw body before JSON.parse for HMAC verification.
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import type { PrismaClient } from '@prisma/client'
+import { createLogger } from '../../lib/logger.js'
+import { isGithubAppConfigured } from './config.js'
+import { verifyWebhookSignature } from './webhookSignature.js'
+import { getCommit } from './client.js'
+import { spawnBuildJob } from './buildSpawner.js'
+import { getGithubAppConfig } from './config.js'
+
+const log = createLogger('github.webhook')
+
+function reply(res: ServerResponse, status: number, body: string) {
+  res.writeHead(status, { 'content-type': 'text/plain' })
+  res.end(body)
+}
+
+async function readRawBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = []
+  for await (const chunk of req) {
+    chunks.push(chunk as Buffer)
+    if (chunks.reduce((n, c) => n + c.length, 0) > 5 * 1024 * 1024) {
+      throw new Error('webhook body too large')
+    }
+  }
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+interface InstallationEvent {
+  action: 'created' | 'deleted' | 'suspend' | 'unsuspend' | 'new_permissions_accepted'
+  installation: {
+    id: number
+    account: { login: string; id: number; type: 'User' | 'Organization' }
+    repository_selection: 'all' | 'selected'
+    suspended_at: string | null
+  }
+  sender: { id: number; login: string }
+}
+
+interface PushEvent {
+  ref: string // refs/heads/<branch>
+  after: string
+  before: string
+  repository: {
+    id: number
+    name: string
+    full_name: string
+    owner: { login: string; id: number }
+    default_branch: string
+  }
+  installation?: { id: number }
+  pusher: { name: string; email: string }
+  head_commit: { id: string; message: string } | null
+  deleted: boolean
+}
+
+export async function handleGithubWebhook(
+  req: IncomingMessage,
+  res: ServerResponse,
+  prisma: PrismaClient,
+): Promise<void> {
+  if (req.method !== 'POST') return reply(res, 405, 'method not allowed')
+  if (!isGithubAppConfigured()) {
+    log.warn('rejecting webhook: GitHub App not configured')
+    return reply(res, 503, 'github app not configured')
+  }
+
+  let raw: string
+  try {
+    raw = await readRawBody(req)
+  } catch (err) {
+    log.warn({ err }, 'failed to read webhook body')
+    return reply(res, 413, 'payload too large')
+  }
+
+  const sig = req.headers['x-hub-signature-256']
+  const sigStr = Array.isArray(sig) ? sig[0] : sig
+  if (!verifyWebhookSignature(raw, sigStr)) {
+    log.warn('rejecting webhook: signature mismatch')
+    return reply(res, 401, 'bad signature')
+  }
+
+  const event = (req.headers['x-github-event'] as string | undefined) || ''
+  const deliveryId = (req.headers['x-github-delivery'] as string | undefined) || ''
+
+  let payload: unknown
+  try {
+    payload = JSON.parse(raw)
+  } catch {
+    return reply(res, 400, 'invalid json')
+  }
+
+  log.info({ event, deliveryId }, 'github webhook received')
+
+  try {
+    switch (event) {
+      case 'ping':
+        // GitHub sends ping right after install → just OK.
+        return reply(res, 200, 'pong')
+
+      case 'installation':
+        await handleInstallationEvent(prisma, payload as InstallationEvent)
+        return reply(res, 200, 'ok')
+
+      case 'installation_repositories':
+        // Repos added/removed from an installation. The UI re-fetches via
+        // githubInstallationRepos when the user opens the picker, so we
+        // don't need to materialize a copy. Just ack.
+        return reply(res, 200, 'ok')
+
+      case 'push':
+        await handlePushEvent(prisma, payload as PushEvent)
+        return reply(res, 200, 'ok')
+
+      default:
+        // We subscribed broadly in the manifest; ignore unrecognized events.
+        return reply(res, 200, 'ignored')
+    }
+  } catch (err) {
+    log.error({ err, event, deliveryId }, 'webhook handler crashed')
+    // Returning 500 makes GitHub redeliver — useful for transient issues but
+    // bad if we have a permanent bug. Compromise: 200 so we don't get
+    // redelivery storms; the error is in the logs.
+    return reply(res, 200, 'logged')
+  }
+}
+
+// -----------------------------------------------------------------------
+// installation event
+// -----------------------------------------------------------------------
+
+async function handleInstallationEvent(
+  prisma: PrismaClient,
+  payload: InstallationEvent,
+): Promise<void> {
+  const inst = payload.installation
+  const installIdNum = BigInt(inst.id)
+
+  if (payload.action === 'deleted') {
+    // Hard-delete the row + all gitInstallationId pointers (Service rows fall
+    // back to lastBuildSha-based deploys — they don't break, just can't redeploy).
+    await prisma.service.updateMany({
+      where: { gitInstallationId: { not: null } },
+      data: {}, // no-op: we keep the FK set to null below
+    })
+    const local = await prisma.githubInstallation.findUnique({
+      where: { installationId: installIdNum },
+      select: { id: true },
+    })
+    if (local) {
+      await prisma.service.updateMany({
+        where: { gitInstallationId: local.id },
+        data: { gitInstallationId: null },
+      })
+      await prisma.githubInstallation.delete({ where: { id: local.id } })
+    }
+    log.info({ installationId: inst.id }, 'installation deleted')
+    return
+  }
+
+  if (payload.action === 'suspend' || payload.action === 'unsuspend') {
+    await prisma.githubInstallation.updateMany({
+      where: { installationId: installIdNum },
+      data: { suspendedAt: payload.action === 'suspend' ? new Date() : null },
+    })
+    log.info({ installationId: inst.id, action: payload.action }, 'install suspension state updated')
+    return
+  }
+
+  if (payload.action === 'created') {
+    // We can't infer the org without prior context. The install came from a
+    // user clicking "Install" on github.com directly (not the in-app flow).
+    // Best-effort: try to match a `User.githubId` to set installedByUserId,
+    // and require the user to call `syncGithubInstallation` from the in-app
+    // setup_url to pick which org owns this install.
+    //
+    // For now: log only. The frontend will call `syncGithubInstallation`
+    // when the user lands on /projects after the install redirect, and that
+    // mutation does the upsert with the correct organizationId.
+    log.info(
+      { installationId: inst.id, account: inst.account.login },
+      'install created (awaiting in-app sync)',
+    )
+    return
+  }
+}
+
+// -----------------------------------------------------------------------
+// push event
+// -----------------------------------------------------------------------
+
+async function handlePushEvent(prisma: PrismaClient, payload: PushEvent): Promise<void> {
+  if (payload.deleted) return // branch deletion, not a push of new content
+  if (!payload.installation?.id || !payload.head_commit) return
+
+  const branch = payload.ref.startsWith('refs/heads/')
+    ? payload.ref.slice('refs/heads/'.length)
+    : null
+  if (!branch) return // tag pushes not supported
+
+  const installIdNum = BigInt(payload.installation.id)
+
+  // Find every Service tracking this exact (installation, owner, repo, branch).
+  const local = await prisma.githubInstallation.findUnique({
+    where: { installationId: installIdNum },
+    select: { id: true },
+  })
+  if (!local) {
+    log.warn({ installationId: payload.installation.id }, 'push for unknown installation')
+    return
+  }
+
+  const services = await prisma.service.findMany({
+    where: {
+      gitInstallationId: local.id,
+      gitOwner: payload.repository.owner.login,
+      gitRepo: payload.repository.name,
+      gitBranch: branch,
+    },
+    select: {
+      id: true,
+      createdByUserId: true,
+      gitOwner: true,
+      gitRepo: true,
+      gitBranch: true,
+      rootDirectory: true,
+      buildCommand: true,
+      startCommand: true,
+    },
+  })
+
+  if (services.length === 0) {
+    log.info(
+      { installationId: payload.installation.id, repo: payload.repository.full_name, branch },
+      'push has no subscribed services',
+    )
+    return
+  }
+
+  log.info(
+    { count: services.length, repo: payload.repository.full_name, branch, sha: payload.after },
+    'push triggers rebuilds',
+  )
+
+  for (const svc of services) {
+    try {
+      const buildJob = await prisma.buildJob.create({
+        data: {
+          serviceId: svc.id,
+          commitSha: payload.after,
+          commitMessage: payload.head_commit.message.slice(0, 1000),
+          branch,
+          triggeredBy: `push:${payload.pusher.email || payload.pusher.name}`,
+        },
+      })
+
+      const cfg = getGithubAppConfig()
+      const safeOwner = svc.gitOwner!.toLowerCase().replace(/[^a-z0-9-]/g, '-')
+      const safeRepo = svc.gitRepo!.toLowerCase().replace(/[^a-z0-9-]/g, '-')
+      const imageTag = `ghcr.io/${cfg.ghcrNamespace}/${svc.createdByUserId}--${safeOwner}-${safeRepo}:${payload.after.slice(0, 12)}`
+
+      const spawned = await spawnBuildJob({
+        buildJobId: buildJob.id,
+        installationId: installIdNum,
+        repoOwner: svc.gitOwner!,
+        repoName: svc.gitRepo!,
+        commitSha: payload.after,
+        imageTag,
+        rootDirectory: svc.rootDirectory ?? undefined,
+        buildCommand: svc.buildCommand ?? undefined,
+        startCommand: svc.startCommand ?? undefined,
+      })
+      await prisma.buildJob.update({
+        where: { id: buildJob.id },
+        data: { k8sJobName: spawned.k8sJobName, status: 'RUNNING' },
+      })
+    } catch (err) {
+      log.error({ err, serviceId: svc.id }, 'push-triggered rebuild failed to spawn')
+      // Continue with the other services — one bad spawn shouldn't poison the batch.
+    }
+  }
+}

--- a/src/services/github/webhookEndpoint.ts
+++ b/src/services/github/webhookEndpoint.ts
@@ -252,8 +252,36 @@ async function handlePushEvent(prisma: PrismaClient, payload: PushEvent): Promis
     'push triggers rebuilds',
   )
 
+  // Webhook redelivery dedup window. GitHub redelivers on ANY non-2xx and on
+  // some "slow handler" heuristics — so the same logical push can arrive 2-5
+  // times. Without this, every redelivery created another BuildJob, every
+  // BuildJob fired autoDeployAfterBuild, and the user saw N AkashDeployments
+  // for the same SHA. We can't add a UNIQUE(serviceId, commitSha) constraint
+  // because legitimate "Rebuild" clicks for the same SHA are valid; instead
+  // we look for any non-FAILED/CANCELED job for this (service, sha) created
+  // recently, and treat that as proof a builder is already (or was just)
+  // running.
+  const DEDUP_WINDOW_MS = 5 * 60_000
+
   for (const svc of services) {
     try {
+      const recent = await prisma.buildJob.findFirst({
+        where: {
+          serviceId: svc.id,
+          commitSha: payload.after,
+          status: { in: ['PENDING', 'RUNNING', 'SUCCEEDED'] },
+          createdAt: { gte: new Date(Date.now() - DEDUP_WINDOW_MS) },
+        },
+        select: { id: true, status: true, createdAt: true },
+      })
+      if (recent) {
+        log.info(
+          { serviceId: svc.id, commitSha: payload.after, existingBuildJobId: recent.id, existingStatus: recent.status },
+          'dedup: skipping push-triggered build — existing recent BuildJob found (likely webhook redelivery)',
+        )
+        continue
+      }
+
       const buildJob = await prisma.buildJob.create({
         data: {
           serviceId: svc.id,

--- a/src/services/github/webhookEndpoint.ts
+++ b/src/services/github/webhookEndpoint.ts
@@ -264,6 +264,10 @@ async function handlePushEvent(prisma: PrismaClient, payload: PushEvent): Promis
         },
       })
 
+      if (!svc.createdByUserId) {
+        log.warn({ serviceId: svc.id }, 'service has no createdByUserId — cannot tag image; skipping')
+        continue
+      }
       const cfg = getGithubAppConfig()
       // Docker registry refs MUST be all lowercase — userId is a Prisma cuid
       // (mixed case) and would break `docker build -t …` otherwise.

--- a/src/services/github/webhookSignature.ts
+++ b/src/services/github/webhookSignature.ts
@@ -1,0 +1,32 @@
+/**
+ * GitHub webhook HMAC SHA-256 verification.
+ *
+ * GitHub signs every webhook payload with the App's webhook secret using
+ * HMAC SHA-256. We MUST verify before parsing — an unverified payload is
+ * an unauthenticated POST from the public internet.
+ *
+ * Header: `X-Hub-Signature-256: sha256=<hex>`
+ */
+
+import crypto from 'node:crypto'
+import { getGithubAppConfig } from './config.js'
+
+/**
+ * Verify a webhook payload signature. Uses constant-time comparison to
+ * prevent timing oracles. Returns true iff signature matches.
+ */
+export function verifyWebhookSignature(rawBody: string | Buffer, signatureHeader: string | undefined): boolean {
+  if (!signatureHeader || !signatureHeader.startsWith('sha256=')) return false
+  const cfg = getGithubAppConfig()
+
+  const hmac = crypto.createHmac('sha256', cfg.webhookSecret)
+  hmac.update(typeof rawBody === 'string' ? Buffer.from(rawBody, 'utf8') : rawBody)
+  const expected = `sha256=${hmac.digest('hex')}`
+
+  // timingSafeEqual requires equal-length buffers; guard length first to
+  // avoid throw-on-mismatch leaking the comparison to higher layers.
+  const a = Buffer.from(expected)
+  const b = Buffer.from(signatureHeader)
+  if (a.length !== b.length) return false
+  return crypto.timingSafeEqual(a, b)
+}

--- a/src/services/providers/gpuBidProbe.test.ts
+++ b/src/services/providers/gpuBidProbe.test.ts
@@ -366,7 +366,91 @@ describe('probeOneGpuModel', () => {
     // Bids were still recorded; only the close best-effort failed (the
     // chain-orphan sweep in escrowHealthMonitor will reclaim).
     expect(result.bidsReceived).toBe(2)
+    expect(result.closed).toBe(false)
     expect(prisma.gpuBidObservation.createMany).toHaveBeenCalledOnce()
+  })
+
+  it('marks closed=true when close TX returns code 0', async () => {
+    const execCli = vi.fn(async (_bin: string, args: string[]): Promise<ExecResult> => {
+      if (args[0] === 'keys' && args[1] === 'show') return ok(KEYS_SHOW_OUT)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'create') return ok(TX_OK_WITH_DSEQ)
+      if (args[0] === 'query' && args[1] === 'market' && args[2] === 'bid' && args[3] === 'list') return ok(BIDS_EMPTY)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'close') return ok(TX_CLOSE_OK)
+      return ok('{}')
+    })
+
+    const result = await probeOneGpuModel(buildPrisma() as any, 'h100', 'nvidia', 'run-1', { execCli, sleep: fastSleep })
+
+    expect(result.dseq).toBe(424242)
+    expect(result.closed).toBe(true)
+  })
+
+  it('retries close on sequence-mismatch (code 32) and marks closed=true on eventual success', async () => {
+    // Regression: production "4 runs · $3 spent" dashboard reading came
+    // from close TXs returning CLI exit 0 with JSON code 32. The
+    // previous code only checked exit code and silently leaked the $1
+    // deposit per failed close. Now we parse the JSON code, retry on
+    // 32, and only mark closed=true after a real code-0 confirmation.
+    const TX_CLOSE_SEQ_MISMATCH = JSON.stringify({ code: 32, raw_log: 'account sequence mismatch' })
+    let closeCalls = 0
+    const execCli = vi.fn(async (_bin: string, args: string[]): Promise<ExecResult> => {
+      if (args[0] === 'keys' && args[1] === 'show') return ok(KEYS_SHOW_OUT)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'create') return ok(TX_OK_WITH_DSEQ)
+      if (args[0] === 'query' && args[1] === 'market' && args[2] === 'bid' && args[3] === 'list') return ok(BIDS_EMPTY)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'close') {
+        closeCalls++
+        if (closeCalls < 3) return ok(TX_CLOSE_SEQ_MISMATCH)
+        return ok(TX_CLOSE_OK)
+      }
+      return ok('{}')
+    })
+
+    const result = await probeOneGpuModel(buildPrisma() as any, 'h100', 'nvidia', 'run-1', { execCli, sleep: fastSleep })
+
+    expect(closeCalls).toBe(3)
+    expect(result.closed).toBe(true)
+  })
+
+  it('exhausts close retries on persistent code-32 and reports closed=false', async () => {
+    const TX_CLOSE_SEQ_MISMATCH = JSON.stringify({ code: 32, raw_log: 'account sequence mismatch' })
+    let closeCalls = 0
+    const execCli = vi.fn(async (_bin: string, args: string[]): Promise<ExecResult> => {
+      if (args[0] === 'keys' && args[1] === 'show') return ok(KEYS_SHOW_OUT)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'create') return ok(TX_OK_WITH_DSEQ)
+      if (args[0] === 'query' && args[1] === 'market' && args[2] === 'bid' && args[3] === 'list') return ok(BIDS_EMPTY)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'close') {
+        closeCalls++
+        return ok(TX_CLOSE_SEQ_MISMATCH)
+      }
+      return ok('{}')
+    })
+
+    const result = await probeOneGpuModel(buildPrisma() as any, 'h100', 'nvidia', 'run-1', { execCli, sleep: fastSleep })
+
+    expect(closeCalls).toBe(3) // TX_RETRIES = 3
+    expect(result.closed).toBe(false)
+    expect(result.dseq).toBe(424242)
+  })
+
+  it('marks closed=false when close TX returns a non-zero non-32 code (chain rejection)', async () => {
+    const TX_CLOSE_REJECT = JSON.stringify({ code: 7, raw_log: 'unauthorized' })
+    let closeCalls = 0
+    const execCli = vi.fn(async (_bin: string, args: string[]): Promise<ExecResult> => {
+      if (args[0] === 'keys' && args[1] === 'show') return ok(KEYS_SHOW_OUT)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'create') return ok(TX_OK_WITH_DSEQ)
+      if (args[0] === 'query' && args[1] === 'market' && args[2] === 'bid' && args[3] === 'list') return ok(BIDS_EMPTY)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'close') {
+        closeCalls++
+        return ok(TX_CLOSE_REJECT)
+      }
+      return ok('{}')
+    })
+
+    const result = await probeOneGpuModel(buildPrisma() as any, 'h100', 'nvidia', 'run-1', { execCli, sleep: fastSleep })
+
+    // Non-32 chain rejection breaks out of the retry loop immediately.
+    expect(closeCalls).toBe(1)
+    expect(result.closed).toBe(false)
   })
 })
 
@@ -575,6 +659,99 @@ describe('runGpuBidProbeCycle GpuProbeRun telemetry', () => {
     expect(updateArg.data.bidsCollected).toBe(0)
     expect(updateArg.data.uniqueProviders).toBe(0)
     expect(updateArg.data.completedAt).toBeInstanceOf(Date)
+  })
+
+  it('subtracts in-flight probe deposits from cycle cost (the $3-spent dashboard bug fix)', async () => {
+    // 2026-04-20 incident: probe cycle reported $1 spent per run on a
+    // dashboard showing "4 runs · $3 spent" — root cause was every
+    // failed close (deposit still in escrow, awaiting orphan sweep)
+    // contributing its full DEFAULT_DEPOSIT_UACT to the wallet-delta.
+    // Now we subtract in-flight deposits so the dashboard reflects
+    // realised gas spend, not temporarily-locked refunds.
+    const TX_CLOSE_SEQ_MISMATCH = JSON.stringify({ code: 32, raw_log: 'account sequence mismatch' })
+    const prisma = buildPrisma()
+    prisma.computeProvider.findMany.mockResolvedValue([
+      { gpuModels: ['h100', 'a100'] }, // two probes this cycle
+    ])
+
+    // Wallet drops by 2_050_000 uact across the cycle (2 deposits + gas).
+    vi.mocked(checkBalance)
+      .mockResolvedValueOnce({ uact: 100_000_000, uakt: 0, act: '100' } as any)
+      .mockResolvedValueOnce({ uact: 97_950_000, uakt: 0, act: '97.95' } as any)
+
+    // h100 closes cleanly; a100 close fails permanently (code 32 ×3).
+    let h100Close = 0
+    let a100Close = 0
+    let createCalls = 0
+    const execCli = vi.fn(async (_bin: string, args: string[]): Promise<ExecResult> => {
+      if (args[0] === 'keys' && args[1] === 'show') return ok(KEYS_SHOW_OUT)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'create') {
+        createCalls++
+        // Vary the dseq so finalisation can attribute correctly per probe.
+        const dseq = 100_000 + createCalls
+        return ok(JSON.stringify({
+          code: 0,
+          txhash: `tx${dseq}`,
+          logs: [{ events: [{ attributes: [{ key: 'dseq', value: String(dseq) }] }] }],
+        }))
+      }
+      if (args[0] === 'query' && args[1] === 'market' && args[2] === 'bid' && args[3] === 'list') {
+        return ok(BIDS_EMPTY)
+      }
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'close') {
+        // First probe (h100, dseq 100_001) succeeds; second probe (a100,
+        // dseq 100_002) fails on every attempt.
+        const dseq = args[args.indexOf('--dseq') + 1]
+        if (dseq === '100001') {
+          h100Close++
+          return ok(TX_CLOSE_OK)
+        }
+        a100Close++
+        return ok(TX_CLOSE_SEQ_MISMATCH)
+      }
+      return ok('{}')
+    })
+
+    await runGpuBidProbeCycle(prisma as any, { execCli, sleep: () => Promise.resolve() })
+
+    expect(h100Close).toBe(1)
+    expect(a100Close).toBe(3) // exhausted retries
+
+    const updateArg = prisma.gpuProbeRun.update.mock.calls[0][0]
+    // Wallet drop = 2_050_000. In-flight = 1 × 1_000_000 (a100 deposit).
+    // Realised cost = 2_050_000 - 1_000_000 = 1_050_000 uact (~$1.05).
+    // Without this fix the dashboard would report 2_050_000 (~$2.05).
+    expect(updateArg.data.costUact).toBe(1_050_000n)
+  })
+
+  it('records full wallet-delta as cost when every close succeeds (no in-flight)', async () => {
+    const prisma = buildPrisma()
+    prisma.computeProvider.findMany.mockResolvedValue([
+      { gpuModels: ['h100'] },
+    ])
+
+    vi.mocked(checkBalance)
+      .mockResolvedValueOnce({ uact: 100_000_000, uakt: 0, act: '100' } as any)
+      .mockResolvedValueOnce({ uact: 99_995_000, uakt: 0, act: '99.995' } as any)
+
+    let createCalls = 0
+    const execCli = vi.fn(async (_bin: string, args: string[]): Promise<ExecResult> => {
+      if (args[0] === 'keys' && args[1] === 'show') return ok(KEYS_SHOW_OUT)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'create') {
+        createCalls++
+        return ok(TX_OK_WITH_DSEQ)
+      }
+      if (args[0] === 'query' && args[1] === 'market' && args[2] === 'bid' && args[3] === 'list') return ok(BIDS_EMPTY)
+      if (args[0] === 'tx' && args[1] === 'deployment' && args[2] === 'close') return ok(TX_CLOSE_OK)
+      return ok('{}')
+    })
+
+    await runGpuBidProbeCycle(prisma as any, { execCli, sleep: () => Promise.resolve() })
+
+    expect(createCalls).toBe(1)
+    const updateArg = prisma.gpuProbeRun.update.mock.calls[0][0]
+    // Pure gas spend, no deposit subtraction — 5_000 uact.
+    expect(updateArg.data.costUact).toBe(5_000n)
   })
 
   it('aggregates bids back into the run record when probes succeed', async () => {

--- a/src/services/providers/gpuBidProbe.ts
+++ b/src/services/providers/gpuBidProbe.ts
@@ -94,6 +94,16 @@ export interface ProbeOneResult {
   providersBidding: number
   durationMs: number
   error?: string
+  /**
+   * True if `tx deployment close` was confirmed accepted by the chain
+   * (CLI exit 0 AND `code === 0` in the JSON response). When false but
+   * `dseq` is set, the deposit is in-flight: it'll either come back via
+   * a future close attempt or be reclaimed by the orphan sweeper in
+   * `escrowHealthMonitor`. The cycle uses this to subtract in-flight
+   * deposits from "cycle cost" so the dashboard doesn't double-charge
+   * us for funds that are temporarily locked but coming back.
+   */
+  closed: boolean
 }
 
 export interface ProbeCycleSummary {
@@ -197,6 +207,7 @@ export async function probeOneGpuModel(
     bidsReceived: 0,
     providersBidding: 0,
     durationMs: 0,
+    closed: false,
   }
 
   if (!process.env.AKASH_MNEMONIC) {
@@ -386,21 +397,73 @@ export async function probeOneGpuModel(
     result.error = err instanceof Error ? err.message : String(err)
   } finally {
     if (dseq) {
-      try {
-        await lock(() =>
-          execCli('akash', [
-            'tx', 'deployment', 'close',
-            '--dseq', String(dseq),
-            '-o', 'json', '-y',
-          ])
-        )
-        log.info({ dseq, model }, 'Probe deployment closed')
-      } catch (closeErr) {
-        // Best-effort. The chain-orphan sweep in escrowHealthMonitor
-        // catches any deployment that survives this close failure.
+      // Mirror the create-flow retry shape (line ~241): parse the JSON
+      // `code` and back off on sequence-mismatch (32). Without this, a
+      // CLI exit-0 with code-32 silently leaks the $1 deposit until the
+      // hourly orphan sweeper reclaims it ~1-2h later, and the cycle's
+      // wallet-delta cost calculation over-attributes the leak as
+      // "spend" on the dashboard.
+      let lastCloseErr: string | undefined
+      for (let attempt = 1; attempt <= TX_RETRIES; attempt++) {
+        try {
+          const closeRes = await lock(() =>
+            execCli('akash', [
+              'tx', 'deployment', 'close',
+              '--dseq', String(dseq),
+              '-o', 'json', '-y',
+            ])
+          )
+          if (closeRes.exitCode !== 0) {
+            lastCloseErr = `cli exit ${closeRes.exitCode}: ${closeRes.stderr.trim().slice(0, 200)}`
+            // CLI errors here (gas estimation, RPC blip) are usually
+            // transient — retry, but don't sequence-backoff since the
+            // problem isn't the wallet sequence.
+            if (attempt < TX_RETRIES) {
+              await sleep(TX_SEQ_RETRY_DELAY_MS)
+              continue
+            }
+            break
+          }
+          let closeJson: any = {}
+          try { closeJson = extractJson(closeRes.stdout) } catch { /* treat as parse failure */ }
+          const code =
+            typeof closeJson.code === 'number'
+              ? closeJson.code
+              : parseInt(closeJson.code ?? '0', 10)
+          if (code === 32 && attempt < TX_RETRIES) {
+            // Account-sequence mismatch: the wallet mutex's settle delay
+            // wasn't long enough for the previous TX to land. Same
+            // backoff/retry strategy as the create flow above.
+            lastCloseErr = `code 32 (sequence mismatch)`
+            await sleep(TX_SEQ_RETRY_DELAY_MS)
+            continue
+          }
+          if (code !== 0) {
+            lastCloseErr = `code ${code}: ${(closeJson.raw_log || '').slice(0, 200)}`
+            break
+          }
+          result.closed = true
+          log.info({ dseq, model, attempt }, 'Probe deployment closed')
+          break
+        } catch (closeErr) {
+          lastCloseErr = closeErr instanceof Error ? closeErr.message : String(closeErr)
+          if (attempt < TX_RETRIES) {
+            await sleep(TX_SEQ_RETRY_DELAY_MS)
+            continue
+          }
+        }
+      }
+      if (!result.closed) {
+        // Best-effort exhausted. The chain-orphan sweep in
+        // escrowHealthMonitor catches any deployment that survives this
+        // close failure (deposit is ~$1 per probe; reclaim window
+        // ~ORPHAN_MIN_AGE_BLOCKS ≈ 60 min). The cycle excludes this
+        // dseq's deposit from `costUact` so the dashboard reports
+        // realised spend (gas) and surfaces the in-flight number
+        // separately.
         log.warn(
-          { dseq, model, err: closeErr instanceof Error ? closeErr.message : closeErr },
-          'Probe close failed — orphan sweep will reclaim it'
+          { dseq, model, err: lastCloseErr },
+          'Probe close failed after retries — orphan sweep will reclaim deposit',
         )
       }
     }
@@ -533,11 +596,48 @@ export async function runGpuBidProbeCycle(
 
     // Snapshot wallet after the cycle and compute spend. Floor at 0 — a
     // wallet refill mid-cycle would otherwise produce a negative cost.
+    //
+    // IMPORTANT — in-flight deposit re-attribution.
+    //   Each probe puts DEFAULT_DEPOSIT_UACT (1 ACT ≈ $1) into escrow on
+    //   `tx deployment create` and gets it back on `tx deployment close`.
+    //   When close fails (code 32 sequence-mismatch, RPC blip, etc.) the
+    //   deposit is in-flight: it'll come back via the orphan sweep in
+    //   `escrowHealthMonitor` within ~60-120 min. Without this
+    //   correction, a single failed close attributes a full $1 to the
+    //   probe cycle's "spent" number even though the money returns
+    //   shortly after — which is exactly what produced the misleading
+    //   "4 runs · $3 spent" dashboard reading on 2026-04-20.
+    //
+    //   We subtract the in-flight deposits from the wallet-delta so
+    //   `costUact` reflects realised spend (gas + truly burned funds).
+    //   The in-flight figure is logged separately for visibility; the
+    //   dashboard's totals stop double-counting refunds.
+    const inFlightDepositUact = results.reduce(
+      (acc, r) => (r.dseq && !r.closed ? acc + DEFAULT_DEPOSIT_UACT : acc),
+      0,
+    )
+    const inFlightProbes = results.filter(r => r.dseq && !r.closed).length
+
     if (balanceBefore) {
       try {
         const balanceAfter = await checkBalance()
-        costUact = BigInt(Math.max(0, balanceBefore.uact - balanceAfter.uact))
-        costUakt = BigInt(Math.max(0, balanceBefore.uakt - balanceAfter.uakt))
+        const walletDropUact = Math.max(0, balanceBefore.uact - balanceAfter.uact)
+        const walletDropUakt = Math.max(0, balanceBefore.uakt - balanceAfter.uakt)
+        const realisedUact = Math.max(0, walletDropUact - inFlightDepositUact)
+        costUact = BigInt(realisedUact)
+        costUakt = BigInt(walletDropUakt)
+        if (inFlightProbes > 0) {
+          log.info(
+            {
+              runId,
+              walletDropUact,
+              inFlightDepositUact,
+              inFlightProbes,
+              realisedUact,
+            },
+            'Cycle cost adjusted for in-flight probe deposits — orphan sweep will reclaim',
+          )
+        }
       } catch (err) {
         log.warn(
           { runId, err: err instanceof Error ? err.message : err },

--- a/src/services/queue/akashSteps.ts
+++ b/src/services/queue/akashSteps.ts
@@ -1355,6 +1355,38 @@ export async function finalizeDeployment(
 
 // ── FAILURE handler ───────────────────────────────────────────────────
 
+/**
+ * Deterministic failure patterns — retrying on a different provider WILL fail
+ * the same way, so we burn straight to PERMANENTLY_FAILED instead of paying
+ * for N more lease/escrow round-trips. Drives down both gas spend and the
+ * "why is the UI showing 4 stuck deployments" support load.
+ *
+ * Rules of thumb for adding to this list:
+ *   - Failure root-causes the image / SDL / user input — provider choice is
+ *     irrelevant (e.g. ImagePullBackOff because GHCR package is private).
+ *   - Failure is observed by US (the poller) AFTER the provider has
+ *     already accepted and tried — so we know the provider isn't broken.
+ *   - We have an exact substring match emitted by our own code (don't grep
+ *     provider-side strings — they're not in our control).
+ *
+ * NOTE: "Deployment never exposed any endpoints" deliberately excluded — that
+ * one CAN be a flaky provider (lease-status endpoint never wired up); cheap
+ * to retry once on a different host.
+ */
+const DETERMINISTIC_FAILURE_PATTERNS: ReadonlyArray<string> = [
+  // Image won't pull → 0 ready replicas. Source: handlePollUrls.
+  'container never started',
+  // SDL composer / nixpacks / template emitted invalid YAML. Won't get fixed by retry.
+  'failed to parse manifest',
+  'invalid sdl',
+]
+
+function isDeterministicFailure(errorMessage: string | undefined | null): boolean {
+  if (!errorMessage) return false
+  const lower = errorMessage.toLowerCase()
+  return DETERMINISTIC_FAILURE_PATTERNS.some((p) => lower.includes(p))
+}
+
 export async function handleFailure(
   prisma: PrismaClient,
   payload: AkashHandleFailurePayload
@@ -1373,6 +1405,7 @@ export async function handleFailure(
   }
 
   const retryCount = deployment.retryCount
+  const deterministic = isDeterministicFailure(errorMessage)
 
   await prisma.akashDeployment.update({
     where: { id: deploymentId },
@@ -1387,6 +1420,38 @@ export async function handleFailure(
     `Deployment failed: ${errorMessage}`,
     errorMessage
   )
+
+  // ── Fast-fail: deterministic failures don't get fixed by switching providers.
+  // Mark PERMANENTLY_FAILED now so we (a) stop burning escrow on copy-paste
+  // retries, (b) stop spawning duplicate AkashDeployment rows in the UI, and
+  // (c) close the on-chain deployment to free the deposit.
+  if (deterministic) {
+    log.warn(
+      { deploymentId, errorMessage },
+      'deterministic failure — skipping retry chain',
+    )
+    if (deployment.dseq && Number(deployment.dseq) > 0) {
+      try {
+        await runAkashAsync([
+          'tx', 'deployment', 'close',
+          '--dseq', String(Number(deployment.dseq)),
+          '-o', 'json', '-y',
+        ])
+      } catch (closeErr) {
+        log.warn({ detail: closeErr instanceof Error ? closeErr.message : closeErr }, 'Failed to close on-chain deployment on deterministic failure')
+      }
+    }
+    await prisma.akashDeployment.update({
+      where: { id: deploymentId },
+      data: { status: 'PERMANENTLY_FAILED' },
+    })
+    deploymentEvents.emitStatus({
+      deploymentId,
+      status: 'PERMANENTLY_FAILED',
+      timestamp: new Date(),
+    })
+    return
+  }
 
   if (retryCount < MAX_RETRY_COUNT) {
     // If the user manually closed any deployment for this service, stop retrying
@@ -1457,6 +1522,17 @@ export async function handleFailure(
       }
     }
 
+    // Carry forward the chain's excludedProviders + the current failure's
+    // provider. Without this, `handleCheckBids`'s safety filter keeps picking
+    // the same broken bidder on every retry — observed when 3 sibling
+    // AkashDeployments all landed on `akash1sevd2ymtty…` for the same image.
+    const inheritedExcluded = await prisma.akashDeployment.findUnique({
+      where: { id: deploymentId },
+      select: { excludedProviders: true, provider: true },
+    })
+    const excluded = new Set<string>(inheritedExcluded?.excludedProviders ?? [])
+    if (inheritedExcluded?.provider) excluded.add(inheritedExcluded.provider)
+
     const newDeployment = await prisma.akashDeployment.create({
       data: {
         owner: deployment.owner,
@@ -1471,6 +1547,7 @@ export async function handleFailure(
         retryCount: retryCount + 1,
         parentDeploymentId: deployment.parentDeploymentId || deploymentId,
         policyId: retryPolicyId,
+        excludedProviders: [...excluded],
       },
     })
 


### PR DESCRIPTION
## Summary

Two independent areas land together in this PR:

1. **GitHub-source deploy flow** — first-class `flavor='github'` services that build via `af-builder` (Nixpacks → GHCR) and auto-deploy through the existing per-deploy provider mechanism.
2. **Akash gpu-probe close hardening** — fixes for the chain-side close path that was leaking deposits and double-counting in-flight cycles.

---

## 1. GitHub-source deploy flow

Adds GitHub as a service flavor alongside function/docker/server/template, integrated into the existing ServiceDetailPanel — no separate dialog, no `Service.targetProvider` column, no parallel provider selector. Compute is chosen per-deploy via the same `ComputeMode` picker every other flavor uses.

### Resolvers (`src/resolvers/github.ts`)

- `connectGithubRepo` — attaches a repo to an existing flavor='github' Service created from the catalog flow, then spawns the first build.
- `createGithubService` — all-in-one for API/CLI consumers.
- `redeployGithubService` — manual rebuild trigger.
- `githubInstallations` is now a **pure DB read** (~10ms). The picker mounted with a 12s spinner because it used to do a synchronous live-sync to GitHub on every call (App JWT sign + `/app/installations` HTTPS round-trip + sequential prisma upserts). On a cold module path this routinely exceeded our timeout; after refresh everything was warm in process memory, which made the bug look like flaky state management.
- New `refreshGithubInstallations` mutation does the slow GitHub sync, invoked only by the UI's explicit triggers (Refresh button, post-install focus event, empty-cache background sync).
- `startBuild` optimistically mirrors `lastBuildSha` / `lastBuildStatus` / `lastBuildAt` onto the Service so the Source-tab card reflects build progress without waiting for the builder callback.
- `BUILDER_DRY_RUN=1` short-circuits to a synthetic `SUCCEEDED` state with the generated imageTag so local dev mirrors prod end-to-end. Auto-deploy is intentionally skipped in dry-run to avoid burning tAKT on a fake image.

### Build callback (`src/services/github/buildCallbackEndpoint.ts`)

- On `SUCCEEDED`: persists imageTag → `Service.dockerImage`, mirrors detected framework / port / containerPort, posts commit status back to GitHub, then auto-deploys via the existing per-deploy provider mechanism (active Phala deployment → keep on Phala; otherwise → Akash, matching the panel's default).
- Idempotent: terminal statuses can't be downgraded.
- HMAC build-token verification bound to `buildJobId`.

### Schema

- `Service` extended with `gitProvider` / `gitInstallationId` / `gitOwner` / `gitRepo` / `gitBranch` / `rootDirectory` / `buildCommand` / `startCommand` / `detectedFramework` / `detectedPort` / `lastBuildSha` / `lastBuildStatus` / `lastBuildAt`.
- New `BuildJob` model with status / imageTag / detected* / logs / k8sJobName.
- `ConnectGithubRepoInput` + `connectGithubRepo` mutation, `refreshGithubInstallations` mutation, `latestBuild` / `recentBuilds` fields on `Service`.
- `flavor` enum extended with `github`.
- Removed dead `ComputeProvider` type and `availableComputeProviders` query (regression that was never shipped).

---

## 2. Akash gpu-probe close hardening (`dfd4041`)

The probe closer was leaking deposits and over-reporting cycle cost. Three fixes:

- **Parse tx response code** — failed close txs were silently treated as success because we only inspected `txhash`, not `code`. Now we surface non-zero codes as failures so the closer can retry.
- **Retry on sequence mismatch** — concurrent closes against the same wallet hit "account sequence mismatch" from the chain. Retry with refreshed sequence instead of marking the close failed.
- **Exclude in-flight deposits from cycle cost** — deposits that haven't yet been confirmed on-chain were being added to the cycle cost twice (once when initiated, once when the chain confirmed). Cycle cost now sums confirmed deposits only.

---

## Test plan

GitHub flow:
- [ ] Catalog → "GitHub" → land on Source tab, picker renders instantly (no spinner)
- [ ] Click "Install GitHub App" → install on github.com → return to tab → installation appears via post-install focus refresh
- [ ] Pick installation → repo list loads → pick repo → branch list loads → click "Connect & Build"
- [ ] BuildJob row appears, status flows PENDING → RUNNING → SUCCEEDED
- [ ] On SUCCEEDED: `Service.dockerImage` populated, auto-deploy fires to Akash (or Phala if a Phala deployment is active)
- [ ] Rebuild button triggers a new BuildJob without re-asking for repo
- [ ] BUILDER_DRY_RUN=1 locally: synthetic SUCCEEDED, no auto-deploy, picker still functional

Akash gpu probe:
- [ ] Run probe verifier, force a close → confirm successful txs are detected, failed txs trigger retry
- [ ] Two parallel closes from the same wallet → no permanent sequence-mismatch failures
- [ ] Cycle cost report after a probe cycle equals sum of confirmed deposits only
