### PR TITLE
fix: use uakt for escrow deposits after BME migration

### DIFF
--- a/src/resolvers/akash.ts
+++ b/src/resolvers/akash.ts
@@ -6,7 +6,7 @@
  */
 
 import { GraphQLError } from 'graphql'
-import { getAkashOrchestrator, DEFAULT_DEPOSIT_UACT } from '../services/akash/orchestrator.js'
+import { getAkashOrchestrator, DEFAULT_DEPOSIT_UAKT } from '../services/akash/orchestrator.js'
 import { getEscrowService } from '../services/billing/escrowService.js'
 import { settleAkashEscrowToTime } from '../services/billing/deploymentSettlement.js'
 import { assertSubscriptionActive } from './subscriptionCheck.js'
@@ -531,7 +531,7 @@ export const akashMutations = {
       const orchestrator = getAkashOrchestrator(context.prisma)
 
       const deploymentId = await orchestrator.deployService(func.serviceId, {
-        deposit: input.depositUakt || DEFAULT_DEPOSIT_UACT,
+        deposit: input.depositUakt || DEFAULT_DEPOSIT_UAKT,
       })
 
       // Fetch the created deployment

--- a/src/schema/typeDefs.ts
+++ b/src/schema/typeDefs.ts
@@ -693,7 +693,7 @@ export const typeDefs = /* GraphQL */ `
   input DeployToAkashInput {
     # The canonical service ID from the Service registry
     serviceId: ID!
-    # Deposit amount in uact (default: 500000 = 0.5 ACT)
+    # Deposit amount in uakt (default: 500000 = 0.5 AKT)
     depositUakt: Int
     # Optional custom SDL content (if not provided, will be auto-generated based on service type)
     sdlContent: String

--- a/src/services/akash/orchestrator.ts
+++ b/src/services/akash/orchestrator.ts
@@ -34,8 +34,9 @@ const BID_POLL_MAX_ATTEMPTS = 10
 const SERVICE_POLL_INTERVAL_MS = 5000
 const SERVICE_POLL_MAX_ATTEMPTS = 24
 
-/** Default Akash deposit in uact (1 ACT — buffer for bid/lease process). */
-export const DEFAULT_DEPOSIT_UACT = 1_000_000
+/** Default Akash deposit in uakt (1 AKT — buffer for bid/lease process).
+ *  Escrow deposits use AKT (uakt), not ACT (uact). SDL pricing uses uact. */
+export const DEFAULT_DEPOSIT_UAKT = 1_000_000
 
 /**
  * Phase 38 — persistent volume attached to a raw Docker image. Mirrors the
@@ -448,7 +449,7 @@ export class AkashOrchestrator {
     const { broadcast, confirmed, txhash } = await runAkashTxAsync(
       [
         'tx', 'deployment', 'create', sdlPath,
-        '--deposit', `${deposit}uact`,
+        '--deposit', `${deposit}uakt`,
       ],
       { op: 'createDeployment', meta: { deposit } },
     )
@@ -530,7 +531,7 @@ export class AkashOrchestrator {
     const { txhash } = await runAkashTxAsync(
       [
         'tx', 'escrow', 'deposit', 'deployment',
-        `${amountUact}uact`,
+        `${amountUact}uakt`,
         '--dseq', String(dseq),
       ],
       { op: 'topUpDeploymentDeposit', meta: { dseq, amountUact } },
@@ -1179,7 +1180,7 @@ export class AkashOrchestrator {
       baseImage?: string
     } = {}
   ): Promise<string> {
-    const deposit = options.deposit || DEFAULT_DEPOSIT_UACT
+    const deposit = options.deposit || DEFAULT_DEPOSIT_UAKT
 
     const service = await this.prisma.service.findUnique({
       where: { id: serviceId },
@@ -1295,7 +1296,7 @@ export class AkashOrchestrator {
     functionId: string,
     sourceCode: string,
     functionName: string,
-    deposit = DEFAULT_DEPOSIT_UACT
+    deposit = DEFAULT_DEPOSIT_UAKT
   ): Promise<string> {
     const func = await this.prisma.aFFunction.findUnique({
       where: { id: functionId },

--- a/src/services/billing/escrowHealthMonitor.test.ts
+++ b/src/services/billing/escrowHealthMonitor.test.ts
@@ -140,12 +140,12 @@ function installAkashCli(overrides: {
       return Promise.resolve(`${overrides.walletAddress ?? 'akash1owner'}\n`)
     }
 
-    // query bank balances → wallet ACT balance
+    // query bank balances → wallet AKT balance (deposits require uakt)
     if (args[0] === 'query' && args[1] === 'bank' && args[2] === 'balances') {
       return Promise.resolve(
         JSON.stringify({
           balances: [
-            { denom: 'uact', amount: String(overrides.walletUactBalance ?? 100_000_000) },
+            { denom: 'uakt', amount: String(overrides.walletUactBalance ?? 100_000_000) },
           ],
         }),
       )
@@ -214,7 +214,7 @@ describe('EscrowHealthMonitor', () => {
     )
     expect(depositCall).toBeDefined()
     // Refill amount: ppb * BLOCKS_PER_HOUR * REFILL_HOURS = 1000 * 588 * 1 = 588_000
-    expect(depositCall![1]).toContain('588000uact')
+    expect(depositCall![1]).toContain('588000uakt')
     expect(depositCall![1]).toContain('--dseq')
     expect(depositCall![1]).toContain('100')
   })
@@ -342,7 +342,7 @@ describe('EscrowHealthMonitor', () => {
       if (args[0] === 'keys') return Promise.resolve('akash1owner\n')
       if (args[0] === 'query' && args[1] === 'bank') {
         return Promise.resolve(
-          JSON.stringify({ balances: [{ denom: 'uact', amount: '100000000' }] }),
+          JSON.stringify({ balances: [{ denom: 'uakt', amount: '100000000' }] }),
         )
       }
       return Promise.resolve('{}')
@@ -442,7 +442,7 @@ describe('EscrowHealthMonitor', () => {
       if (args[0] === 'keys') return Promise.resolve('akash1owner\n')
       if (args[0] === 'query' && args[1] === 'bank') {
         return Promise.resolve(
-          JSON.stringify({ balances: [{ denom: 'uact', amount: '100000000' }] }),
+          JSON.stringify({ balances: [{ denom: 'uakt', amount: '100000000' }] }),
         )
       }
       if (args[0] === 'query' && args[1] === 'deployment' && args[2] === 'list') {

--- a/src/services/billing/escrowHealthMonitor.ts
+++ b/src/services/billing/escrowHealthMonitor.ts
@@ -38,8 +38,8 @@ const REFILL_HOURS = 1
 /** Safety-net cron — hourly at :30 (30 min after billing cycle at :00). */
 const ESCROW_CHECK_CRON = '30 * * * *'
 
-/** Warn when deployer wallet ACT balance falls below this (5 ACT). */
-const LOW_WALLET_THRESHOLD_UACT = 5_000_000
+/** Warn when deployer wallet AKT balance falls below this (5 AKT). Deposits require uakt. */
+const LOW_WALLET_THRESHOLD_UAKT = 5_000_000
 
 /**
  * Minimum on-chain age before we consider a deployment a sweep-able orphan.
@@ -74,17 +74,17 @@ const ORPHAN_MIN_AGE_BLOCKS = (() => {
  * the runbook (Section M of AF_INCIDENT_RUNBOOKS.md — "Akash Hot-Wallet
  * Cap Exceeded / Key Rotation"; §L is the unrelated failover-loop runbook).
  *
- * Override in production via `AKASH_HOT_WALLET_CAP_UACT` if the
+ * Override in production via `AKASH_HOT_WALLET_CAP_UAKT` if the
  * default is too tight for current usage.
  */
-const DEFAULT_HOT_WALLET_CAP_UACT = 50_000_000 // 50 ACT
-const HOT_WALLET_CAP_UACT = (() => {
-  const raw = process.env.AKASH_HOT_WALLET_CAP_UACT
-  if (!raw) return DEFAULT_HOT_WALLET_CAP_UACT
+const DEFAULT_HOT_WALLET_CAP_UAKT = 50_000_000 // 50 AKT
+const HOT_WALLET_CAP_UAKT = (() => {
+  const raw = process.env.AKASH_HOT_WALLET_CAP_UAKT
+  if (!raw) return DEFAULT_HOT_WALLET_CAP_UAKT
   const parsed = parseInt(raw, 10)
-  return Number.isFinite(parsed) && parsed > LOW_WALLET_THRESHOLD_UACT
+  return Number.isFinite(parsed) && parsed > LOW_WALLET_THRESHOLD_UAKT
     ? parsed
-    : DEFAULT_HOT_WALLET_CAP_UACT
+    : DEFAULT_HOT_WALLET_CAP_UAKT
 })()
 
 async function runAkashCmd(args: string[], timeout = AKASH_CLI_TIMEOUT_MS): Promise<string> {
@@ -461,27 +461,27 @@ export class EscrowHealthMonitor {
         '-o', 'json',
       ])
       const data = JSON.parse(output)
-      const uactBal = data?.balances?.find((b: { denom: string }) => b.denom === 'uact')
-      const balance = parseInt(uactBal?.amount || '0', 10)
-      const balanceAct = (balance / 1_000_000).toFixed(4)
+      const uaktBal = data?.balances?.find((b: { denom: string }) => b.denom === 'uakt')
+      const balance = parseInt(uaktBal?.amount || '0', 10)
+      const balanceAkt = (balance / 1_000_000).toFixed(4)
 
-      if (balance < LOW_WALLET_THRESHOLD_UACT) {
+      if (balance < LOW_WALLET_THRESHOLD_UAKT) {
         log.warn(
-          { balanceUact: balance, balanceAct },
-          'CRITICAL: Deployer wallet ACT balance is low — escrow refills will fail soon'
+          { balanceUakt: balance, balanceAkt },
+          'CRITICAL: Deployer wallet AKT balance is low — escrow refills will fail soon'
         )
         await opsAlert({
           key: 'deployer-wallet-low-balance',
           severity: 'critical',
-          title: 'Deployer wallet ACT balance low',
+          title: 'Deployer wallet AKT balance low',
           message:
-            `Deployer wallet is below the ${(LOW_WALLET_THRESHOLD_UACT / 1_000_000).toFixed(0)} ACT threshold. ` +
+            `Deployer wallet is below the ${(LOW_WALLET_THRESHOLD_UAKT / 1_000_000).toFixed(0)} AKT threshold. ` +
             `On-chain escrow top-ups will start failing; deployments will be closed by providers and the platform will eat the uncovered time.`,
           context: {
             address,
-            balanceAct,
-            balanceUact: String(balance),
-            thresholdUact: String(LOW_WALLET_THRESHOLD_UACT),
+            balanceAkt,
+            balanceUakt: String(balance),
+            thresholdUakt: String(LOW_WALLET_THRESHOLD_UAKT),
           },
           // Alert hourly (matches the health-monitor cadence), not every 10 min.
           suppressMs: 55 * 60 * 1000,
@@ -492,9 +492,9 @@ export class EscrowHealthMonitor {
       // Hot-Wallet Cap Exceeded / Key Rotation"). The deployer wallet is
       // online — keeping it lean limits blast radius if the pod / key is
       // ever compromised.
-      if (balance > HOT_WALLET_CAP_UACT) {
+      if (balance > HOT_WALLET_CAP_UAKT) {
         log.warn(
-          { balanceUact: balance, balanceAct, capUact: HOT_WALLET_CAP_UACT },
+          { balanceUakt: balance, balanceAkt, capUakt: HOT_WALLET_CAP_UAKT },
           'Deployer hot wallet exceeds configured cap — sweep excess to cold storage',
         )
         await opsAlert({
@@ -502,14 +502,14 @@ export class EscrowHealthMonitor {
           severity: 'warning',
           title: 'Deployer hot wallet over cap',
           message:
-            `Deployer wallet holds ${balanceAct} ACT, above the ${(HOT_WALLET_CAP_UACT / 1_000_000).toFixed(0)} ACT hot-wallet cap. ` +
+            `Deployer wallet holds ${balanceAkt} AKT, above the ${(HOT_WALLET_CAP_UAKT / 1_000_000).toFixed(0)} AKT hot-wallet cap. ` +
             `Sweep the excess back to cold storage per AF_INCIDENT_RUNBOOKS.md §M. ` +
-            `Override the cap by setting AKASH_HOT_WALLET_CAP_UACT if usage justifies a larger float.`,
+            `Override the cap by setting AKASH_HOT_WALLET_CAP_UAKT if usage justifies a larger float.`,
           context: {
             address,
-            balanceAct,
-            balanceUact: String(balance),
-            capUact: String(HOT_WALLET_CAP_UACT),
+            balanceAkt,
+            balanceUakt: String(balance),
+            capUakt: String(HOT_WALLET_CAP_UAKT),
             excessUact: String(balance - HOT_WALLET_CAP_UACT),
           },
           // Daily nudge — over-cap is a slow-burn risk, not a page-now event.
@@ -676,7 +676,7 @@ export class EscrowHealthMonitor {
         'escrow',
         'deposit',
         'deployment',
-        `${refillUact}uact`,
+        `${refillUact}uakt`,
         '--dseq',
         dseq,
         '-y',

--- a/src/services/providers/gpuBidProbe.test.ts
+++ b/src/services/providers/gpuBidProbe.test.ts
@@ -17,7 +17,7 @@ vi.mock('../akash/walletMutex.js', () => ({
 }))
 
 vi.mock('../akash/orchestrator.js', () => ({
-  DEFAULT_DEPOSIT_UACT: 1_000_000,
+  DEFAULT_DEPOSIT_UAKT: 1_000_000,
 }))
 
 // Stub the wallet-balance helper used by the cycle telemetry path —
@@ -665,7 +665,7 @@ describe('runGpuBidProbeCycle GpuProbeRun telemetry', () => {
     // 2026-04-20 incident: probe cycle reported $1 spent per run on a
     // dashboard showing "4 runs · $3 spent" — root cause was every
     // failed close (deposit still in escrow, awaiting orphan sweep)
-    // contributing its full DEFAULT_DEPOSIT_UACT to the wallet-delta.
+    // contributing its full DEFAULT_DEPOSIT_UAKT to the wallet-delta.
     // Now we subtract in-flight deposits so the dashboard reflects
     // realised gas spend, not temporarily-locked refunds.
     const TX_CLOSE_SEQ_MISMATCH = JSON.stringify({ code: 32, raw_log: 'account sequence mismatch' })

--- a/src/services/providers/gpuBidProbe.ts
+++ b/src/services/providers/gpuBidProbe.ts
@@ -30,7 +30,7 @@ import { join } from 'path'
 import type { PrismaClient } from '@prisma/client'
 import { getAkashEnv as getAkashEnvBase } from '../../lib/akashEnv.js'
 import { withWalletLock } from '../akash/walletMutex.js'
-import { DEFAULT_DEPOSIT_UACT } from '../akash/orchestrator.js'
+import { DEFAULT_DEPOSIT_UAKT } from '../akash/orchestrator.js'
 import { createLogger } from '../../lib/logger.js'
 import { buildProbeSdl, PROBE_PRICING_CEILING_UACT, type GpuVendor } from './probeBidSdl.js'
 import { checkBalance, type WalletBalance } from './providerVerification.js'
@@ -253,7 +253,7 @@ export async function probeOneGpuModel(
       const txRes = await lock(() =>
         execCli('akash', [
           'tx', 'deployment', 'create', sdlPath,
-          '--deposit', `${DEFAULT_DEPOSIT_UACT}uact`,
+          '--deposit', `${DEFAULT_DEPOSIT_UAKT}uakt`,
           '-o', 'json', '-y',
         ])
       )
@@ -598,7 +598,7 @@ export async function runGpuBidProbeCycle(
     // wallet refill mid-cycle would otherwise produce a negative cost.
     //
     // IMPORTANT — in-flight deposit re-attribution.
-    //   Each probe puts DEFAULT_DEPOSIT_UACT (1 ACT ≈ $1) into escrow on
+    //   Each probe puts DEFAULT_DEPOSIT_UAKT (1 ACT ≈ $1) into escrow on
     //   `tx deployment create` and gets it back on `tx deployment close`.
     //   When close fails (code 32 sequence-mismatch, RPC blip, etc.) the
     //   deposit is in-flight: it'll come back via the orphan sweep in
@@ -613,7 +613,7 @@ export async function runGpuBidProbeCycle(
     //   The in-flight figure is logged separately for visibility; the
     //   dashboard's totals stop double-counting refunds.
     const inFlightDepositUact = results.reduce(
-      (acc, r) => (r.dseq && !r.closed ? acc + DEFAULT_DEPOSIT_UACT : acc),
+      (acc, r) => (r.dseq && !r.closed ? acc + DEFAULT_DEPOSIT_UAKT : acc),
       0,
     )
     const inFlightProbes = results.filter(r => r.dseq && !r.closed).length

--- a/src/services/providers/providerVerification.ts
+++ b/src/services/providers/providerVerification.ts
@@ -19,7 +19,7 @@ import { join } from 'path'
 import type { PrismaClient, ComputeProviderType } from '@prisma/client'
 import { getAkashEnv as getAkashEnvBase } from '../../lib/akashEnv.js'
 import { getAllTemplates } from '../../templates/registry.js'
-import { DEFAULT_DEPOSIT_UACT } from '../akash/orchestrator.js'
+import { DEFAULT_DEPOSIT_UAKT } from '../akash/orchestrator.js'
 import { withWalletLock } from '../akash/walletMutex.js'
 import { generateSDLFromTemplate } from '../../templates/sdl.js'
 import { createLogger } from '../../lib/logger.js'
@@ -236,7 +236,7 @@ async function testSingleTemplate(
       const txResult = await withWalletLock(() =>
         execCli('akash', [
           'tx', 'deployment', 'create', sdlPath,
-          '--deposit', `${DEFAULT_DEPOSIT_UACT}uact`, '-o', 'json', '-y',
+          '--deposit', `${DEFAULT_DEPOSIT_UAKT}uakt`, '-o', 'json', '-y',
         ])
       )
       if (txResult.exitCode !== 0) return mkFail(txResult.stderr.trim().slice(0, 300))

--- a/src/services/queue/akashSteps.ts
+++ b/src/services/queue/akashSteps.ts
@@ -12,7 +12,7 @@ import { tmpdir } from 'os'
 import { publishJob, isQStashEnabled } from './qstashClient.js'
 import { deploymentEvents } from '../events/deploymentEvents.js'
 import { providerSelector } from '../akash/providerSelector.js'
-import { DEFAULT_DEPOSIT_UACT, getAkashOrchestrator } from '../akash/orchestrator.js'
+import { DEFAULT_DEPOSIT_UAKT, getAkashOrchestrator } from '../akash/orchestrator.js'
 import { getEscrowService } from '../billing/escrowService.js'
 import { getBillingApiClient } from '../billing/billingApiClient.js'
 import { scheduleOrEnforcePolicyExpiry } from '../policy/runtimeScheduler.js'
@@ -302,14 +302,14 @@ export async function handleSubmitTx(
   try {
     const deposit = deployment.depositUakt
       ? Number(deployment.depositUakt)
-      : DEFAULT_DEPOSIT_UACT
+      : DEFAULT_DEPOSIT_UAKT
     const output = await runAkashAsync([
       'tx',
       'deployment',
       'create',
       sdlPath,
       '--deposit',
-      `${deposit}uact`,
+      `${deposit}uakt`,
       '-o',
       'json',
       '-y',


### PR DESCRIPTION
## Summary

Fixes the "Mismatched denominations (uact != uakt): Deposit invalid" error that breaks all Akash deployments and escrow refills since the BME migration.

- Akash Mainnet 17 (BME, March 2026) introduced ACT token (`uact`) for SDL pricing, but **escrow deposits still require AKT (`uakt`)**
- Hayk's initial BME commit (`fcab618`) changed ALL denominations to `uact`, including deposit commands
- This fix corrects all deposit/escrow commands to use `uakt` while keeping SDL pricing references as `uact`

### Files changed (9):
- `orchestrator.ts` — deposit + topUp commands + constant rename
- `akashSteps.ts` — queue worker deposit command
- `gpuBidProbe.ts` — probe deployment deposit
- `providerVerification.ts` — verification deployment deposit
- `escrowHealthMonitor.ts` — refill deposit + wallet balance check (critical: line 679 was sending `uact` for refills)
- `typeDefs.ts` — deposit field comment correction
- Corresponding test files updated

### Denomination rules post-BME:
| Context | Denomination |
|---------|-------------|
| Escrow deposits (`tx escrow deposit`) | `uakt` (AKT) |
| SDL pricing (`denom` in deploy.yaml) | `uact` (ACT) |
| Wallet balance for deposit capability | Check `uakt` |
| On-chain escrow funds/transferred | `uact` (lease denomination) |

Closes #204

## Test plan

- [ ] Verify `pnpm test` passes (test mocks updated)
- [ ] Deploy a test service via CLI — should no longer get "Mismatched denominations" error
- [ ] Verify escrow refill cycle works (escrowHealthMonitor sends `uakt` for deposits)
- [ ] Verify GPU bid probes create/close successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)