### PR TITLE
Add fly io builder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -216,3 +216,14 @@ FLY_BUILDER_MEMORY_MB=4096
 # the K8s Job needs a publicly-reachable URL too unless you're running
 # the api inside the same cluster.
 # API_BASE_URL=
+
+# ── CALLBACK_BASE_URL ───────────────────────────────────────────────
+# Where the builder (Fly Machine OR K8s Job) POSTs the build-status
+# callback. Takes precedence over API_BASE_URL when set. Needed
+# primarily when API_BASE_URL is an internal URL the builder can't
+# reach — specifically: BUILD_EXECUTOR=fly always needs a public URL
+# here because Fly machines can't resolve *.svc.cluster.local.
+# Production:   https://api.alternatefutures.ai
+# Staging:      https://api.staging.alternatefutures.ai
+# Local dev:    your cloudflared tunnel URL (if BUILD_EXECUTOR=fly)
+# CALLBACK_BASE_URL=

--- a/.env.example
+++ b/.env.example
@@ -112,13 +112,107 @@ GITHUB_APP_PRIVATE_KEY_B64=
 # PAT (or App-installation token) with packages:write that the af-builder Job
 # uses to push the produced image to GHCR.
 GHCR_PUSH_TOKEN=
+# Optional: dedicated read-only PAT (scopes: `read:packages`) used solely
+# to pull user-built images on Akash providers. Injected into the SDL as
+# per-service `credentials:` so providers can pull private GHCR images
+# without us fighting GitHub org visibility policies. Falls back to
+# GHCR_PUSH_TOKEN if unset, but you REALLY want a read-only token in
+# production because whatever value we put here is shipped to the
+# winning provider with each lease manifest — a malicious provider
+# could exfiltrate it. Read-only scope caps the blast radius to
+# "pull from our GHCR" instead of "push to our GHCR".
+# GHCR_PULL_TOKEN=
 # Optional overrides — defaults are sane.
 # GHCR_USER=alternatefutures-deploy
 # GHCR_NAMESPACE=alternatefutures
 # BUILDER_IMAGE=ghcr.io/alternatefutures/af-builder:latest
 # BUILDER_NAMESPACE=alternatefutures-builds
-# Local dev only: skip K8s Job creation, only persist the BuildJob row.
+# Local dev only: skip both K8s Job creation AND Fly machine spawn; only
+# persist the BuildJob row. Useful for iterating on UI without the build
+# pipeline running. Honoured by buildSpawner regardless of BUILD_EXECUTOR.
 # BUILDER_DRY_RUN=1
-# Override the URL af-builder Jobs POST status callbacks to (defaults to
-# API_BASE_URL or https://api.alternatefutures.ai).
-# API_BASE_URL=http://service-cloud-api:4000
+
+# =============================================================================
+# Build executor — where af-builder actually runs
+# =============================================================================
+# Selects the backend buildSpawner.ts dispatches new BuildJobs to:
+#   - `k8s` (default): spawn a Kubernetes Job in BUILDER_NAMESPACE on the
+#     cluster pointed to by KUBERNETES_SERVICE_HOST / ~/.kube/config.
+#     Pairs builder + dind sidecar via shareProcessNamespace.
+#   - `fly`: spawn a single ephemeral Fly Machine running the Fly variant
+#     of service-builder (Dockerfile.fly, dockerd embedded). Costs pennies
+#     per build, isolates blast radius, doesn't burn cluster CPU.
+# Production currently runs `k8s`; staging is the canary on `fly`.
+# Local dev: leave `k8s` until you've started the cloudflared tunnel +
+# pointed API_BASE_URL at it (Fly machines need a publicly-reachable
+# CALLBACK_URL or the build will succeed silently and never update the UI).
+BUILD_EXECUTOR=k8s
+# When BUILD_EXECUTOR=fly, by default we fall back to k8s if the Fly API
+# call fails (token expired, app missing, region down). Set to 1 to fail
+# closed instead — useful in staging when you want to detect Fly outages
+# rather than mask them with a silent k8s rebid.
+# BUILD_EXECUTOR_NO_FALLBACK=1
+
+# =============================================================================
+# Fly.io builder pool (only consulted when BUILD_EXECUTOR=fly)
+# =============================================================================
+# API token created with: flyctl tokens create deploy -a af-builders \
+#                           --name "service-cloud-api builders" --expiry 0
+# Production reads this from the `fly-credentials` K8s secret; locally it
+# lives here. The same token works for both staging and prod since Fly
+# tokens are app-scoped, not env-scoped.
+FLY_API_TOKEN=
+# Fly app the spawned machines live under. We pre-created `af-builders`
+# in the angela-steffens org as a billing/ACL boundary. The app stays in
+# "Pending" state forever in the Fly dashboard — that's fine, machines
+# show up under the Machines tab as builds run.
+FLY_BUILDER_APP=af-builders
+# Region machines are placed in. `ord` (Chicago) is closest to AWS us-east-1
+# (where the cluster lives) so callbacks have minimal latency.
+FLY_BUILDER_REGION=ord
+# The image Fly pulls into each machine. MUST be public on GHCR — Fly
+# pulls without our org credentials. Built from service-builder/Dockerfile.fly.
+FLY_BUILDER_IMAGE=ghcr.io/alternatefutures/af-builder:fly-latest
+# Machine size. `performance` CPUs are 2-3x faster than `shared` for the
+# CPU-bound nixpacks/docker build phase and worth the extra ~$0.001/min.
+FLY_BUILDER_CPU_KIND=performance
+FLY_BUILDER_CPUS=2
+FLY_BUILDER_MEMORY_MB=4096
+# Persistent buildkit/dockerd cache volume. Attach an already-created
+# Fly Volume (same app + region as the builders) to every spawned
+# machine so base images, pnpm/pip/cargo stores, and buildkit
+# snapshotter state survive machine reaps. This is what makes repeat
+# builds ~15-30s instead of 5+ minutes. Create once with:
+#   fly volumes create af_build_cache_0 -a af-builders --region ord --size 20
+# then paste the returned id below. Leave unset to fall back to
+# ephemeral per-machine state (correct, just slow).
+# FLY_BUILDER_CACHE_VOLUME=vol_xxxxxxxxxxxxxxxx
+# FLY_BUILDER_CACHE_MOUNT=/var/lib/af-cache
+# Advanced overrides — leave unset to use defaults baked into flyioBuilder.ts.
+# FLY_API_BASE=https://api.machines.dev/v1
+# FLY_API_TIMEOUT_MS=30000
+
+# =============================================================================
+# Build callback base URL (af-builder → service-cloud-api)
+# =============================================================================
+# Override the URL af-builder Jobs/Machines POST status callbacks to
+# (defaults to https://api.alternatefutures.ai). Builders need a
+# PUBLICLY-REACHABLE URL — `localhost`, `127.0.0.1`, and any
+# `*.local.alternatefutures.ai` hostname will fail silently from a Fly
+# machine because they only resolve on the operator's laptop.
+#
+# In-cluster (K8s executor): set to the in-cluster Service URL so the
+# builder pod hits the api directly without leaving the namespace.
+#   API_BASE_URL=http://service-cloud-api:4000
+#
+# Local dev with BUILD_EXECUTOR=fly: start a tunnel and paste its
+# public hostname here, then restart the api so buildSpawner picks
+# up the new value:
+#   cloudflared tunnel --url http://localhost:1602
+#   # → https://<random>.trycloudflare.com
+#   API_BASE_URL=https://<random>.trycloudflare.com
+#
+# Local dev with BUILD_EXECUTOR=k8s + a real cluster: same as above,
+# the K8s Job needs a publicly-reachable URL too unless you're running
+# the api inside the same cluster.
+# API_BASE_URL=

--- a/src/resolvers/github.ts
+++ b/src/resolvers/github.ts
@@ -346,7 +346,11 @@ async function startBuild(
     })
     await context.prisma.buildJob.update({
       where: { id: buildJob.id },
-      data: { k8sJobName: spawned.k8sJobName, status: 'RUNNING' },
+      data: {
+        k8sJobName: spawned.k8sJobName,
+        status: 'RUNNING',
+        logs: spawned.initialLog,
+      },
     })
     await context.prisma.service.update({
       where: { id: args.serviceId },

--- a/src/services/akash/buildGhcrCredentialsBlock.test.ts
+++ b/src/services/akash/buildGhcrCredentialsBlock.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { buildGhcrCredentialsBlock } from './orchestrator.js'
+
+/**
+ * `buildGhcrCredentialsBlock` is the only thing standing between a
+ * private GHCR image and an `ImagePullBackOff` on every Akash provider
+ * we deploy to. The exact YAML shape is dictated by the Akash SDL
+ * "Private Container Registries" spec — see the comment in orchestrator.ts.
+ *
+ * We pin three things explicitly:
+ *   1. Non-GHCR images get NO `credentials:` block (we don't leak our
+ *      PAT to dockerhub.io or arbitrary registries).
+ *   2. `GHCR_PULL_TOKEN` is preferred when set; `GHCR_PUSH_TOKEN` is the
+ *      fallback. Mis-ordering this is a security regression because the
+ *      push token has `write:packages`.
+ *   3. The emitted block's `host:` includes the `https://` scheme. Akash
+ *      providers silently ignore credentials when scheme is missing.
+ */
+describe('buildGhcrCredentialsBlock', () => {
+  const originalPull = process.env.GHCR_PULL_TOKEN
+  const originalPush = process.env.GHCR_PUSH_TOKEN
+
+  beforeEach(() => {
+    delete process.env.GHCR_PULL_TOKEN
+    delete process.env.GHCR_PUSH_TOKEN
+  })
+
+  afterEach(() => {
+    if (originalPull === undefined) delete process.env.GHCR_PULL_TOKEN
+    else process.env.GHCR_PULL_TOKEN = originalPull
+    if (originalPush === undefined) delete process.env.GHCR_PUSH_TOKEN
+    else process.env.GHCR_PUSH_TOKEN = originalPush
+  })
+
+  it('returns empty for non-GHCR images, even with a token configured', () => {
+    process.env.GHCR_PULL_TOKEN = 'ghp_anything'
+    expect(buildGhcrCredentialsBlock('docker.io/library/nginx:latest')).toBe('')
+    expect(buildGhcrCredentialsBlock('quay.io/foo/bar:1')).toBe('')
+    expect(buildGhcrCredentialsBlock('registry.example.com/x:y')).toBe('')
+  })
+
+  it('returns empty for GHCR images when no tokens are configured', () => {
+    expect(buildGhcrCredentialsBlock('ghcr.io/alternatefutures/x:1')).toBe('')
+  })
+
+  it('uses GHCR_PULL_TOKEN when present', () => {
+    process.env.GHCR_PULL_TOKEN = 'ghp_pull_only_token'
+    process.env.GHCR_PUSH_TOKEN = 'ghp_push_token_should_be_ignored'
+    const out = buildGhcrCredentialsBlock('ghcr.io/alternatefutures/svc:abc')
+    expect(out).toContain('password: ghp_pull_only_token')
+    expect(out).not.toContain('ghp_push_token_should_be_ignored')
+  })
+
+  it('falls back to GHCR_PUSH_TOKEN when GHCR_PULL_TOKEN is absent', () => {
+    process.env.GHCR_PUSH_TOKEN = 'ghp_push_token_fallback'
+    const out = buildGhcrCredentialsBlock('ghcr.io/alternatefutures/svc:abc')
+    expect(out).toContain('password: ghp_push_token_fallback')
+  })
+
+  it('emits the host with the https:// scheme (Akash spec compliance)', () => {
+    process.env.GHCR_PULL_TOKEN = 'ghp_pull'
+    const out = buildGhcrCredentialsBlock('ghcr.io/alternatefutures/svc:abc')
+    expect(out).toContain('host: https://ghcr.io')
+    // Sanity: no scheme-less variant slipped in
+    expect(out).not.toMatch(/host:\s+ghcr\.io\b/)
+  })
+
+  it('uses a neutral username (does not leak the PAT owner identity)', () => {
+    process.env.GHCR_PULL_TOKEN = 'ghp_pull'
+    const out = buildGhcrCredentialsBlock('ghcr.io/alternatefutures/svc:abc')
+    expect(out).toContain('username: af-deploy')
+  })
+
+  it('emits a properly indented `credentials:` block consumable by the SDL renderer', () => {
+    process.env.GHCR_PULL_TOKEN = 'ghp_pull'
+    const out = buildGhcrCredentialsBlock('ghcr.io/alternatefutures/svc:abc')
+    // Block is intended to be prepended inside `services.<name>:` so the
+    // four-space lead matters — anything else and the YAML parser will
+    // either reject the SDL or silently mis-attribute the keys.
+    expect(out.startsWith('    credentials:')).toBe(true)
+    expect(out).toContain('      host: https://ghcr.io')
+    expect(out).toContain('      username: af-deploy')
+    expect(out).toContain('      password: ')
+  })
+})

--- a/src/services/akash/orchestrator.ts
+++ b/src/services/akash/orchestrator.ts
@@ -408,6 +408,66 @@ function hasAnyServiceUris(serviceUrls: unknown): boolean {
   )
 }
 
+/**
+ * Emit an Akash SDL `credentials:` block (indented for nesting under
+ * `services.<name>:`) for GHCR-hosted images. Returns the empty string
+ * for images on other registries or when no token is configured — in
+ * that case we fall back to the "image is public" assumption (either
+ * intentionally, for templates pulling public base images, or as a
+ * graceful failure mode that a human will notice in the provider logs).
+ *
+ * Security posture: the emitted token is shipped to the *winning
+ * provider only* inside the manifest payload (NOT on-chain), but a
+ * malicious provider can still exfiltrate whatever password we hand
+ * them. We therefore STRONGLY prefer a dedicated read-only PAT
+ * (`GHCR_PULL_TOKEN`). If we have to fall back to `GHCR_PUSH_TOKEN`
+ * (which has `write:packages`), we log a loud warning so ops sees it.
+ *
+ * Usage site: prepended to the body of the service block in
+ * generateCustomDockerSDL (and, if we extend it, the template generator).
+ */
+function buildGhcrCredentialsBlock(image: string): string {
+  if (!image.startsWith('ghcr.io/')) return ''
+
+  const pullToken = process.env.GHCR_PULL_TOKEN || process.env.GHCR_PUSH_TOKEN
+  if (!pullToken) {
+    log.warn(
+      { image },
+      'GHCR image used but no GHCR_PULL_TOKEN/GHCR_PUSH_TOKEN configured — provider pulls will fail for private packages',
+    )
+    return ''
+  }
+
+  if (!process.env.GHCR_PULL_TOKEN && process.env.GHCR_PUSH_TOKEN) {
+    // Rate-limited warning: log once per unique image, not every SDL
+    // regeneration, to avoid flooding logs on busy deploys. Keyed on
+    // the image ref because same image = same leak surface.
+    if (!ghcrPullFallbackWarned.has(image)) {
+      ghcrPullFallbackWarned.add(image)
+      log.warn(
+        { image },
+        'Using GHCR_PUSH_TOKEN as pull credential — provider would gain write access if exfiltrated. Provision a read-only GHCR_PULL_TOKEN.',
+      )
+    }
+  }
+
+  // Username for GHCR PAT auth is a nonce; the token carries all the
+  // auth signal. We use a neutral literal rather than leaking a human
+  // identity (e.g. the owner of the push token).
+  // `host:` must include the scheme per Akash SDL spec (see SDL Advanced
+  // Features docs → "Private Container Registries"). Dropping the
+  // `https://` prefix makes providers silently treat the manifest as
+  // "no auth required" and ImagePullBackOff right back where we started.
+  return `    credentials:
+      host: https://ghcr.io
+      username: af-deploy
+      password: ${pullToken}
+`
+}
+
+/** Module-level set so the GHCR_PUSH_TOKEN fallback warning doesn't spam logs. */
+const ghcrPullFallbackWarned = new Set<string>()
+
 export class AkashOrchestrator {
   constructor(private prisma: PrismaClient) {}
 
@@ -1593,6 +1653,20 @@ export class AkashOrchestrator {
 `
       : ''
 
+    // ── Registry auth ───────────────────────────────────────────────
+    // GitHub-source builds push to GHCR as private packages (team-plan
+    // orgs can't flip container visibility via REST API; this was the
+    // previous unblocker and it's fragile as fuck). Akash SDL supports
+    // per-service `credentials:` which the provider uses as an
+    // imagePullSecret when scheduling the pod — private images pull
+    // fine and we never touch GitHub package visibility.
+    //
+    // The token ends up in the manifest that is sent to the *winning
+    // provider only* (not on-chain), so scope it minimally. We
+    // explicitly require a read-only PAT (GHCR_PULL_TOKEN); falling
+    // back to GHCR_PUSH_TOKEN works but leaks write access — log loud.
+    const credentialsBlock = buildGhcrCredentialsBlock(image)
+
     const cpu = resourceOverrides?.cpu ?? 0.5
     const memory = resourceOverrides?.memory ?? '512Mi'
     const ephemeralStorage = resourceOverrides?.storage ?? '1Gi'
@@ -1646,7 +1720,7 @@ version: "2.0"
 services:
   ${name}:
     image: ${image}
-${argsBlock}    expose:
+${credentialsBlock}${argsBlock}    expose:
       - port: ${containerPort}
         as: 80
         to:

--- a/src/services/akash/orchestrator.ts
+++ b/src/services/akash/orchestrator.ts
@@ -426,7 +426,7 @@ function hasAnyServiceUris(serviceUrls: unknown): boolean {
  * Usage site: prepended to the body of the service block in
  * generateCustomDockerSDL (and, if we extend it, the template generator).
  */
-function buildGhcrCredentialsBlock(image: string): string {
+export function buildGhcrCredentialsBlock(image: string): string {
   if (!image.startsWith('ghcr.io/')) return ''
 
   const pullToken = process.env.GHCR_PULL_TOKEN || process.env.GHCR_PUSH_TOKEN
@@ -439,11 +439,27 @@ function buildGhcrCredentialsBlock(image: string): string {
   }
 
   if (!process.env.GHCR_PULL_TOKEN && process.env.GHCR_PUSH_TOKEN) {
-    // Rate-limited warning: log once per unique image, not every SDL
-    // regeneration, to avoid flooding logs on busy deploys. Keyed on
-    // the image ref because same image = same leak surface.
-    if (!ghcrPullFallbackWarned.has(image)) {
-      ghcrPullFallbackWarned.add(image)
+    // Rate-limited warning: log at most once per image per TTL window,
+    // not every SDL regeneration, to avoid flooding logs on busy deploys.
+    // Keyed on the image ref because same image = same leak surface.
+    // Bounded with a TTL + size cap so we don't grow unbounded if a
+    // misconfigured env stays broken for weeks across many image refs.
+    const now = Date.now()
+    const lastWarned = ghcrPullFallbackWarned.get(image)
+    if (!lastWarned || now - lastWarned > GHCR_WARN_TTL_MS) {
+      // Opportunistic eviction: drop expired entries when we touch the map,
+      // and hard-cap size to prevent pathological growth in degraded mode.
+      if (ghcrPullFallbackWarned.size > GHCR_WARN_MAX_ENTRIES) {
+        for (const [k, ts] of ghcrPullFallbackWarned) {
+          if (now - ts > GHCR_WARN_TTL_MS) ghcrPullFallbackWarned.delete(k)
+        }
+        // If still over cap after expiry sweep, clear the oldest half by
+        // simply clearing the whole thing — re-warning is cheap.
+        if (ghcrPullFallbackWarned.size > GHCR_WARN_MAX_ENTRIES) {
+          ghcrPullFallbackWarned.clear()
+        }
+      }
+      ghcrPullFallbackWarned.set(image, now)
       log.warn(
         { image },
         'Using GHCR_PUSH_TOKEN as pull credential — provider would gain write access if exfiltrated. Provision a read-only GHCR_PULL_TOKEN.',
@@ -465,8 +481,14 @@ function buildGhcrCredentialsBlock(image: string): string {
 `
 }
 
-/** Module-level set so the GHCR_PUSH_TOKEN fallback warning doesn't spam logs. */
-const ghcrPullFallbackWarned = new Set<string>()
+/**
+ * Bounded TTL map so the GHCR_PUSH_TOKEN fallback warning doesn't spam logs
+ * AND doesn't grow unbounded across many image refs in long-running
+ * processes. Values are timestamps (ms epoch) of the last warn for that key.
+ */
+const GHCR_WARN_TTL_MS = 60 * 60 * 1000 // 1 hour
+const GHCR_WARN_MAX_ENTRIES = 1000
+const ghcrPullFallbackWarned = new Map<string, number>()
 
 export class AkashOrchestrator {
   constructor(private prisma: PrismaClient) {}

--- a/src/services/github/buildSpawner.test.ts
+++ b/src/services/github/buildSpawner.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { escapeYamlValue } from './buildSpawner.js'
+
+/**
+ * `escapeYamlValue` is interpolated into a YAML *double-quoted scalar*
+ * inside `infra/k8s/builder/job.template.yaml` — `value: "<here>"`.
+ *
+ * The threat model isn't generic YAML safety; it's specifically:
+ *   1. closing the quote and injecting a sibling key (`"; injected: …`)
+ *   2. embedding a literal newline that aborts scalar parsing mid-string
+ *   3. backslash sequences that confuse the YAML escape decoder
+ *
+ * Tests below pin the contract explicitly so a future refactor doesn't
+ * silently regress the escape semantics that the GHCR/clone-URL plumbing
+ * depends on.
+ */
+describe('escapeYamlValue', () => {
+  it('escapes embedded double quotes so the surrounding scalar stays well-formed', () => {
+    expect(escapeYamlValue('foo"bar')).toBe('foo\\"bar')
+  })
+
+  it('escapes backslashes BEFORE other escapes so we never double-escape', () => {
+    // The order matters: if `\\` were escaped after `\"`, then a literal
+    // input of `\"` would get turned into `\\\\"` instead of `\\\"`.
+    expect(escapeYamlValue('a\\b')).toBe('a\\\\b')
+    expect(escapeYamlValue('a\\"b')).toBe('a\\\\\\"b')
+  })
+
+  it('escapes newlines and carriage returns into their YAML escape sequences', () => {
+    expect(escapeYamlValue('line1\nline2')).toBe('line1\\nline2')
+    expect(escapeYamlValue('line1\r\nline2')).toBe('line1\\r\\nline2')
+  })
+
+  it('escapes tabs', () => {
+    expect(escapeYamlValue('col1\tcol2')).toBe('col1\\tcol2')
+  })
+
+  it('passes through plain values unchanged', () => {
+    expect(escapeYamlValue('ghp_abcDEF1234567890')).toBe('ghp_abcDEF1234567890')
+    expect(escapeYamlValue('https://x-access-token:abc@github.com/o/r.git')).toBe(
+      'https://x-access-token:abc@github.com/o/r.git',
+    )
+  })
+
+  it('handles the empty string without throwing', () => {
+    expect(escapeYamlValue('')).toBe('')
+  })
+
+  it('blocks the obvious YAML-scalar injection vector', () => {
+    // An adversary who controls a token tries to close our quote and
+    // inject a sibling key. After escaping, the closing-quote character
+    // must still be neutralized so the YAML parser sees a single scalar.
+    const malicious = '"; injected: pwned'
+    const escaped = escapeYamlValue(malicious)
+    // Most importantly, no UNESCAPED double-quote remains. Every `"` in
+    // the output must be preceded by a backslash.
+    for (let i = 0; i < escaped.length; i += 1) {
+      if (escaped[i] === '"') {
+        expect(escaped[i - 1]).toBe('\\')
+      }
+    }
+  })
+})

--- a/src/services/github/buildSpawner.ts
+++ b/src/services/github/buildSpawner.ts
@@ -432,7 +432,7 @@ export async function deleteBuildJob(k8sJobName: string): Promise<void> {
  * parsing. We don't reach for js-yaml because we own the template, this
  * single helper, and know the surrounding context is always `"…"`.
  */
-function escapeYamlValue(v: string): string {
+export function escapeYamlValue(v: string): string {
   return v
     .replaceAll('\\', '\\\\')
     .replaceAll('"', '\\"')

--- a/src/services/github/buildSpawner.ts
+++ b/src/services/github/buildSpawner.ts
@@ -153,6 +153,12 @@ spec:
               value: "__BUILD_COMMAND_B64__"
             - name: START_COMMAND_B64
               value: "__START_COMMAND_B64__"
+            - name: REPO_SOURCE_URL
+              value: "__REPO_SOURCE_URL__"
+            - name: REPO_OWNER
+              value: "__REPO_OWNER__"
+            - name: REPO_NAME
+              value: "__REPO_NAME__"
           resources:
             requests:
               cpu: "500m"
@@ -234,6 +240,22 @@ function buildEnvFor(
     ROOT_DIRECTORY: input.rootDirectory || '.',
     BUILD_COMMAND_B64: input.buildCommand ? toB64(input.buildCommand) : '',
     START_COMMAND_B64: input.startCommand ? toB64(input.startCommand) : '',
+    /**
+     * Canonical GitHub URL for the source repository. `build.sh` stamps
+     * this into the built image as the `org.opencontainers.image.source`
+     * label; GHCR reads that label on push and auto-links the container
+     * package to this repository. Without a linked repo, the REST API
+     * refuses to change package visibility (PATCH /orgs/.../visibility
+     * returns 404 for any target value), which is exactly the failure
+     * mode that leaves Akash pulls stuck on a private/internal image.
+     *
+     * Passed as the clean https URL — NOT the authenticated clone URL
+     * (that has a token embedded; the OCI label would leak it into
+     * every built image's manifest).
+     */
+    REPO_SOURCE_URL: `https://github.com/${input.repoOwner}/${input.repoName}`,
+    REPO_OWNER: input.repoOwner,
+    REPO_NAME: input.repoName,
   }
 }
 
@@ -301,6 +323,9 @@ function renderK8sJobYaml(args: { jobName: string; env: Record<string, string> }
     .replaceAll('__ROOT_DIRECTORY__', args.env.ROOT_DIRECTORY)
     .replaceAll('__BUILD_COMMAND_B64__', args.env.BUILD_COMMAND_B64)
     .replaceAll('__START_COMMAND_B64__', args.env.START_COMMAND_B64)
+    .replaceAll('__REPO_SOURCE_URL__', escapeYamlValue(args.env.REPO_SOURCE_URL))
+    .replaceAll('__REPO_OWNER__', args.env.REPO_OWNER)
+    .replaceAll('__REPO_NAME__', args.env.REPO_NAME)
 }
 
 async function spawnK8sBuilderJob(args: {

--- a/src/services/github/buildSpawner.ts
+++ b/src/services/github/buildSpawner.ts
@@ -1,15 +1,29 @@
 /**
- * af-builder Job spawner.
+ * af-builder spawner — dispatches a BuildJob to one of two backends:
  *
- * Reads `infra/k8s/builder/job.template.yaml`, substitutes per-build env,
- * and creates the Job in the `alternatefutures-builds` namespace.
+ *   - `k8s` (default): renders `infra/k8s/builder/job.template.yaml`,
+ *     creates a Job in `alternatefutures-builds`. The pod runs the
+ *     builder container alongside a privileged `docker:24-dind`
+ *     sidecar over a shared process namespace.
  *
- * In-cluster: uses the pod's mounted ServiceAccount token (the `af-builder-spawner`
- * SA has RBAC to manage Jobs in that namespace via `infra/k8s/builder/rbac.yaml`).
+ *   - `fly`: spawns a single ephemeral Fly Machine running the
+ *     `service-builder` Fly variant (`Dockerfile.fly`) which embeds
+ *     `dockerd` in-VM. Pay-per-second, auto-destroying, fully
+ *     isolated from our cluster. See `flyioBuilder.ts`.
+ *
+ * The active backend is selected via `BUILD_EXECUTOR=k8s|fly` (default
+ * `k8s` for safe rollback). The callback URL, HMAC token, env contract,
+ * and BuildJob row lifecycle are byte-identical across backends — this
+ * file is the only place that knows the difference.
+ *
+ * In-cluster (K8s path): uses the pod's mounted ServiceAccount token
+ * (the `af-builder-spawner` SA has RBAC to manage Jobs in the builds
+ * namespace via `infra/k8s/builder/rbac.yaml`).
  * Local dev: uses the developer's `~/.kube/config`.
  *
- * Local dev without a cluster: set `BUILDER_DRY_RUN=1` to skip Job creation
- * and only persist the BuildJob row — useful for UI iteration.
+ * Local dev without a cluster (any backend): set `BUILDER_DRY_RUN=1`
+ * to skip the spawn and only persist the BuildJob row — useful for
+ * UI iteration.
  */
 
 import * as k8s from '@kubernetes/client-node'
@@ -19,8 +33,21 @@ import { createLogger } from '../../lib/logger.js'
 import { getGithubAppConfig } from './config.js'
 import { signBuildToken } from './buildToken.js'
 import { buildCloneUrl } from './client.js'
+import { destroyFlyMachine, spawnFlyBuilder } from './flyioBuilder.js'
 
 const log = createLogger('github.buildSpawner')
+
+type BuildExecutor = 'k8s' | 'fly'
+
+/** `fly:<machine_id>` for Fly machines, raw `build-<jobid>` for K8s Jobs.
+ *  Stored verbatim into BuildJob.k8sJobName so deleteBuildJob can route. */
+const FLY_PREFIX = 'fly:'
+
+function getExecutor(): BuildExecutor {
+  const raw = (process.env.BUILD_EXECUTOR || 'k8s').toLowerCase()
+  if (raw === 'fly' || raw === 'flyio' || raw === 'fly.io') return 'fly'
+  return 'k8s'
+}
 
 const NAMESPACE = process.env.BUILDER_NAMESPACE || 'alternatefutures-builds'
 const BUILDER_IMAGE =
@@ -173,13 +200,44 @@ export interface SpawnBuildInput {
 }
 
 export interface SpawnedBuildJob {
+  /**
+   * Identifier we persist into `BuildJob.k8sJobName`. Despite the
+   * historical column name, this can be either a K8s Job name
+   * (`build-<jobId>`) OR a prefixed Fly machine handle
+   * (`fly:<machineId>`). `deleteBuildJob` routes on the prefix.
+   */
   k8sJobName: string
   /** True only when BUILDER_DRY_RUN=1 — used by tests + local dev. */
   dryRun: boolean
+  /** Which backend actually ran the build. Mirrored into logs/metrics. */
+  executor: BuildExecutor
+}
+
+/** Shared env contract for both K8s and Fly. The keys exactly match the
+ *  variables `service-builder/scripts/build.sh` reads. */
+function buildEnvFor(
+  input: SpawnBuildInput,
+  cloneUrl: string,
+  callbackUrl: string,
+  callbackToken: string,
+): Record<string, string> {
+  const cfg = getGithubAppConfig()
+  return {
+    BUILD_JOB_ID: input.buildJobId,
+    CALLBACK_URL: callbackUrl,
+    CALLBACK_TOKEN: callbackToken,
+    REPO_CLONE_URL: cloneUrl,
+    REPO_REF: input.commitSha,
+    IMAGE_TAG: input.imageTag,
+    GHCR_USER: cfg.ghcrUser,
+    GHCR_TOKEN: cfg.ghcrPushToken,
+    ROOT_DIRECTORY: input.rootDirectory || '.',
+    BUILD_COMMAND_B64: input.buildCommand ? toB64(input.buildCommand) : '',
+    START_COMMAND_B64: input.startCommand ? toB64(input.startCommand) : '',
+  }
 }
 
 export async function spawnBuildJob(input: SpawnBuildInput): Promise<SpawnedBuildJob> {
-  const cfg = getGithubAppConfig()
   const cloneUrl = await buildCloneUrl(input.installationId, input.repoOwner, input.repoName)
   const callbackBase =
     input.callbackBaseUrl || process.env.API_BASE_URL || 'https://api.alternatefutures.ai'
@@ -187,46 +245,97 @@ export async function spawnBuildJob(input: SpawnBuildInput): Promise<SpawnedBuil
   const callbackToken = signBuildToken(input.buildJobId)
 
   const jobName = `build-${input.buildJobId.toLowerCase()}`.slice(0, 63)
-
-  const yaml = loadTemplate()
-    .replaceAll('__JOB_NAME__', jobName)
-    .replaceAll('__NAMESPACE__', NAMESPACE)
-    .replaceAll('__BUILDER_IMAGE__', BUILDER_IMAGE)
-    .replaceAll('__BUILD_JOB_ID__', input.buildJobId)
-    .replaceAll('__CALLBACK_URL__', callbackUrl)
-    .replaceAll('__CALLBACK_TOKEN__', callbackToken)
-    // YAML strings are double-quoted in the template; embed-safely escape
-    // the few characters that could break out (`"` and `\`).
-    .replaceAll('__REPO_CLONE_URL__', escapeYamlValue(cloneUrl))
-    .replaceAll('__REPO_REF__', input.commitSha)
-    .replaceAll('__IMAGE_TAG__', input.imageTag)
-    .replaceAll('__GHCR_USER__', cfg.ghcrUser)
-    .replaceAll('__GHCR_TOKEN__', escapeYamlValue(cfg.ghcrPushToken))
-    .replaceAll('__ROOT_DIRECTORY__', input.rootDirectory || '.')
-    .replaceAll('__BUILD_COMMAND_B64__', input.buildCommand ? toB64(input.buildCommand) : '')
-    .replaceAll('__START_COMMAND_B64__', input.startCommand ? toB64(input.startCommand) : '')
+  const env = buildEnvFor(input, cloneUrl, callbackUrl, callbackToken)
+  const executor = getExecutor()
 
   if (process.env.BUILDER_DRY_RUN === '1') {
-    log.warn({ jobName, buildJobId: input.buildJobId }, 'BUILDER_DRY_RUN=1 — skipping K8s create')
-    return { k8sJobName: jobName, dryRun: true }
+    log.warn(
+      { jobName, buildJobId: input.buildJobId, executor },
+      'BUILDER_DRY_RUN=1 — skipping spawn',
+    )
+    return { k8sJobName: jobName, dryRun: true, executor }
   }
 
+  if (executor === 'fly') {
+    try {
+      const result = await spawnFlyBuilder({ name: jobName, env })
+      log.info(
+        { machineId: result.machineId, jobName, buildJobId: input.buildJobId, region: result.region },
+        'Fly builder machine launched',
+      )
+      return { k8sJobName: `${FLY_PREFIX}${result.machineId}`, dryRun: false, executor }
+    } catch (err) {
+      log.error(
+        { err, jobName, buildJobId: input.buildJobId },
+        'Fly builder spawn failed — falling back to K8s',
+      )
+      // Fall through to the K8s path so a Fly outage during cutover
+      // doesn't block builds entirely. Operators can disable the
+      // fallback by setting `BUILD_EXECUTOR_NO_FALLBACK=1`.
+      if (process.env.BUILD_EXECUTOR_NO_FALLBACK === '1') {
+        throw new Error(
+          `Fly builder spawn failed: ${err instanceof Error ? err.message : String(err)}`,
+        )
+      }
+    }
+  }
+
+  return spawnK8sBuilderJob({ jobName, env, buildJobId: input.buildJobId })
+}
+
+function renderK8sJobYaml(args: { jobName: string; env: Record<string, string> }): string {
+  return loadTemplate()
+    .replaceAll('__JOB_NAME__', args.jobName)
+    .replaceAll('__NAMESPACE__', NAMESPACE)
+    .replaceAll('__BUILDER_IMAGE__', BUILDER_IMAGE)
+    .replaceAll('__BUILD_JOB_ID__', args.env.BUILD_JOB_ID)
+    .replaceAll('__CALLBACK_URL__', args.env.CALLBACK_URL)
+    .replaceAll('__CALLBACK_TOKEN__', args.env.CALLBACK_TOKEN)
+    // YAML strings are double-quoted in the template; embed-safely escape
+    // the few characters that could break out (`"` and `\`).
+    .replaceAll('__REPO_CLONE_URL__', escapeYamlValue(args.env.REPO_CLONE_URL))
+    .replaceAll('__REPO_REF__', args.env.REPO_REF)
+    .replaceAll('__IMAGE_TAG__', args.env.IMAGE_TAG)
+    .replaceAll('__GHCR_USER__', args.env.GHCR_USER)
+    .replaceAll('__GHCR_TOKEN__', escapeYamlValue(args.env.GHCR_TOKEN))
+    .replaceAll('__ROOT_DIRECTORY__', args.env.ROOT_DIRECTORY)
+    .replaceAll('__BUILD_COMMAND_B64__', args.env.BUILD_COMMAND_B64)
+    .replaceAll('__START_COMMAND_B64__', args.env.START_COMMAND_B64)
+}
+
+async function spawnK8sBuilderJob(args: {
+  jobName: string
+  env: Record<string, string>
+  buildJobId: string
+}): Promise<SpawnedBuildJob> {
+  const yaml = renderK8sJobYaml({ jobName: args.jobName, env: args.env })
   const parsed = k8s.loadYaml<k8s.V1Job>(yaml)
   const api = getKubeClient()
   try {
     await api.createNamespacedJob({ namespace: NAMESPACE, body: parsed })
   } catch (err: unknown) {
-    log.error({ err, jobName }, 'failed to create builder Job')
+    log.error({ err, jobName: args.jobName }, 'failed to create builder Job')
     throw new Error(`builder spawn failed: ${err instanceof Error ? err.message : String(err)}`)
   }
 
-  log.info({ jobName, buildJobId: input.buildJobId }, 'builder Job created')
-  return { k8sJobName: jobName, dryRun: false }
+  log.info({ jobName: args.jobName, buildJobId: args.buildJobId }, 'builder Job created')
+  return { k8sJobName: args.jobName, dryRun: false, executor: 'k8s' }
 }
 
-/** Best-effort delete of a builder Job (used on cancel + manual cleanup). */
+/**
+ * Best-effort cancel of an in-flight build. Routes to the right backend
+ * based on the prefix we wrote in `spawnBuildJob` (Fly machines carry
+ * the `fly:` prefix; raw K8s job names do not).
+ */
 export async function deleteBuildJob(k8sJobName: string): Promise<void> {
   if (process.env.BUILDER_DRY_RUN === '1') return
+
+  if (k8sJobName.startsWith(FLY_PREFIX)) {
+    const machineId = k8sJobName.slice(FLY_PREFIX.length)
+    await destroyFlyMachine(machineId)
+    return
+  }
+
   try {
     const api = getKubeClient()
     await api.deleteNamespacedJob({

--- a/src/services/github/buildSpawner.ts
+++ b/src/services/github/buildSpawner.ts
@@ -217,6 +217,17 @@ export interface SpawnedBuildJob {
   dryRun: boolean
   /** Which backend actually ran the build. Mirrored into logs/metrics. */
   executor: BuildExecutor
+  /**
+   * One-shot log line the caller should write into `BuildJob.logs` alongside
+   * the RUNNING status transition. Bridges the ~15-20s window between
+   * "spawn returned" and "builder container starts streaming" — otherwise
+   * the UI shows "No logs yet — the builder hasn't started writing." for
+   * long enough that users assume the build is stuck. Fly machines are
+   * the worst offender (image pull ~17s on cold machines); K8s Jobs get
+   * their own line too for consistency so the UI never shows the blank
+   * placeholder for a successfully spawned build.
+   */
+  initialLog: string
 }
 
 /** Shared env contract for both K8s and Fly. The keys exactly match the
@@ -261,8 +272,21 @@ function buildEnvFor(
 
 export async function spawnBuildJob(input: SpawnBuildInput): Promise<SpawnedBuildJob> {
   const cloneUrl = await buildCloneUrl(input.installationId, input.repoOwner, input.repoName)
+  // Precedence: explicit per-call override → `CALLBACK_BASE_URL` (public
+  // ingress, required when BUILD_EXECUTOR=fly because Fly machines can't
+  // resolve K8s internal DNS) → `API_BASE_URL` (in-cluster URL, works for
+  // BUILD_EXECUTOR=k8s) → hardcoded production ingress. The reason
+  // CALLBACK_BASE_URL exists as its own var: `API_BASE_URL` is widely
+  // referenced for "this pod's own base URL" and is set to the in-cluster
+  // DNS in both environments. Overloading it to mean "where the *builder*
+  // should post back to" breaks Fly (unreachable) or pollutes internal
+  // service-to-service calls with an unnecessary round-trip through the
+  // ingress. Keep the two concerns separate.
   const callbackBase =
-    input.callbackBaseUrl || process.env.API_BASE_URL || 'https://api.alternatefutures.ai'
+    input.callbackBaseUrl ||
+    process.env.CALLBACK_BASE_URL ||
+    process.env.API_BASE_URL ||
+    'https://api.alternatefutures.ai'
   const callbackUrl = `${callbackBase.replace(/\/$/, '')}/internal/build-callback`
   const callbackToken = signBuildToken(input.buildJobId)
 
@@ -275,7 +299,12 @@ export async function spawnBuildJob(input: SpawnBuildInput): Promise<SpawnedBuil
       { jobName, buildJobId: input.buildJobId, executor },
       'BUILDER_DRY_RUN=1 — skipping spawn',
     )
-    return { k8sJobName: jobName, dryRun: true, executor }
+    return {
+      k8sJobName: jobName,
+      dryRun: true,
+      executor,
+      initialLog: `[spawner] BUILDER_DRY_RUN=1 — no builder spawned (executor=${executor})\n`,
+    }
   }
 
   if (executor === 'fly') {
@@ -285,7 +314,21 @@ export async function spawnBuildJob(input: SpawnBuildInput): Promise<SpawnedBuil
         { machineId: result.machineId, jobName, buildJobId: input.buildJobId, region: result.region },
         'Fly builder machine launched',
       )
-      return { k8sJobName: `${FLY_PREFIX}${result.machineId}`, dryRun: false, executor }
+      // The Fly Machine API returns ~immediately but the VM then does a
+      // ~15-20s image pull of af-builder before our build.sh starts
+      // streaming. Write a human-readable breadcrumb now so the UI has
+      // SOMETHING to show during that window — otherwise we look hung.
+      const ts = new Date().toISOString()
+      const initialLog =
+        `[${ts}] [spawner] Fly machine ${result.machineId} created in region=${result.region}\n` +
+        `[${ts}] [spawner] Waiting for Fly to pull the af-builder image (~15-20s on cold machines)…\n` +
+        `[${ts}] [spawner] Build logs will appear here once the container starts.\n`
+      return {
+        k8sJobName: `${FLY_PREFIX}${result.machineId}`,
+        dryRun: false,
+        executor,
+        initialLog,
+      }
     } catch (err) {
       log.error(
         { err, jobName, buildJobId: input.buildJobId },
@@ -344,7 +387,12 @@ async function spawnK8sBuilderJob(args: {
   }
 
   log.info({ jobName: args.jobName, buildJobId: args.buildJobId }, 'builder Job created')
-  return { k8sJobName: args.jobName, dryRun: false, executor: 'k8s' }
+  const ts = new Date().toISOString()
+  const initialLog =
+    `[${ts}] [spawner] Kubernetes Job ${args.jobName} created in namespace ${NAMESPACE}\n` +
+    `[${ts}] [spawner] Waiting for builder pod to start (dind + builder containers)…\n` +
+    `[${ts}] [spawner] Build logs will appear here once the builder container starts.\n`
+  return { k8sJobName: args.jobName, dryRun: false, executor: 'k8s', initialLog }
 }
 
 /**

--- a/src/services/github/flyioBuilder.ts
+++ b/src/services/github/flyioBuilder.ts
@@ -108,11 +108,16 @@ function getFlyConfig(): FlyConfig {
   }
 }
 
+/**
+ * Returns parsed JSON for 2xx-with-body responses, or `undefined` for
+ * 204 No Content. Callers that depend on a body should narrow with a
+ * runtime check rather than assuming non-null.
+ */
 async function flyFetch<T>(
   cfg: FlyConfig,
   pathSuffix: string,
   init: RequestInit & { method: 'GET' | 'POST' | 'DELETE' },
-): Promise<T> {
+): Promise<T | undefined> {
   const url = `${FLY_API_BASE}/apps/${encodeURIComponent(cfg.app)}${pathSuffix}`
   const controller = new AbortController()
   const timer = setTimeout(() => controller.abort(), FLY_TIMEOUT_MS)
@@ -131,7 +136,7 @@ async function flyFetch<T>(
       throw new Error(`Fly API ${init.method} ${pathSuffix} failed: ${res.status} ${body}`)
     }
     // DELETE returns 200 with `{ ok: true }`, GET/POST return JSON; both safe to parse.
-    if (res.status === 204) return undefined as unknown as T
+    if (res.status === 204) return undefined
     return (await res.json()) as T
   } finally {
     clearTimeout(timer)
@@ -190,15 +195,23 @@ export async function spawnFlyBuilder(input: FlySpawnInput): Promise<FlySpawnRes
   // Volume-attach race. If the previous builder machine is still in
   // `destroying`/`destroyed` state, its volume attachment lingers for
   // a few seconds. Fly returns 409 "volume already attached to machine
-  // X" or similar; only cure is to wait. Back off 2,4,8,16,30s.
-  const delays = [2000, 4000, 8000, 16000, 30000]
+  // X" or similar; only cure is to wait. Base backoff: 2,4,8,16,30s,
+  // each scaled by a random [0.75, 1.25] jitter factor so concurrent
+  // pushes (e.g. CI fan-out, queued webhooks) don't synchronize their
+  // retries and re-collide on the same Fly volume slot every time.
+  const baseDelays = [2000, 4000, 8000, 16000, 30000]
   let lastErr: unknown = null
-  for (let attempt = 0; attempt <= delays.length; attempt += 1) {
+  for (let attempt = 0; attempt <= baseDelays.length; attempt += 1) {
     try {
       const machine = await flyFetch<FlyMachineResponse>(cfg, '/machines', {
         method: 'POST',
         body: JSON.stringify(body),
       })
+      // POST /machines always returns a body on success; if it didn't, Fly
+      // changed its contract and we have no machine id to track.
+      if (!machine) {
+        throw new Error('Fly POST /machines returned no body — cannot track machine lifecycle')
+      }
       log.info(
         {
           machineId: machine.id,
@@ -217,13 +230,15 @@ export async function spawnFlyBuilder(input: FlySpawnInput): Promise<FlySpawnRes
       const retryable =
         cfg.cacheVolumeId !== null &&
         (msg.includes('volume') || msg.includes('409')) &&
-        attempt < delays.length
+        attempt < baseDelays.length
       if (!retryable) throw err
+      const jitter = 0.75 + Math.random() * 0.5 // [0.75, 1.25]
+      const delayMs = Math.round(baseDelays[attempt] * jitter)
       log.warn(
-        { attempt, delayMs: delays[attempt], err: msg },
+        { attempt, delayMs, err: msg },
         'Fly machine spawn rejected (volume busy) — retrying',
       )
-      await new Promise((r) => setTimeout(r, delays[attempt]))
+      await new Promise((r) => setTimeout(r, delayMs))
     }
   }
   throw lastErr instanceof Error ? lastErr : new Error('spawnFlyBuilder: exhausted retries')

--- a/src/services/github/flyioBuilder.ts
+++ b/src/services/github/flyioBuilder.ts
@@ -70,6 +70,23 @@ interface FlyConfig {
   cpus: number
   memoryMb: number
   apiToken: string
+  /**
+   * Fly Volume id (e.g. `vol_42kg90p00e8ywj14`) that backs the persistent
+   * buildkit/dockerd state. Set via FLY_BUILDER_CACHE_VOLUME. When set,
+   * every spawned machine attaches this volume at `cacheMountPath` and
+   * `build-fly.sh` points `dockerd --data-root` into a subdir of that
+   * mount. Result: base images, cache mounts (pnpm/pip/cargo stores),
+   * and buildkit snapshotter state all survive machine reaping.
+   *
+   * Fly Volumes are single-attach. We spawn machines with `auto_destroy:
+   * true`, so the previous machine's volume detaches when it exits —
+   * but there's a small window where the new machine's POST /machines
+   * returns 409 "volume in use." Spawn retries with exp backoff.
+   *
+   * Leaving this unset falls back to ephemeral state (slow but works).
+   */
+  cacheVolumeId: string | null
+  cacheMountPath: string
 }
 
 function getFlyConfig(): FlyConfig {
@@ -86,6 +103,8 @@ function getFlyConfig(): FlyConfig {
     cpuKind: (process.env.FLY_BUILDER_CPU_KIND as 'shared' | 'performance') || 'performance',
     cpus: Number(process.env.FLY_BUILDER_CPUS || 2),
     memoryMb: Number(process.env.FLY_BUILDER_MEMORY_MB || 4096),
+    cacheVolumeId: process.env.FLY_BUILDER_CACHE_VOLUME || null,
+    cacheMountPath: process.env.FLY_BUILDER_CACHE_MOUNT || '/var/lib/af-cache',
   }
 }
 
@@ -123,37 +142,91 @@ async function flyFetch<T>(
  * Spawn a one-shot Fly Machine that runs the builder image and exits.
  * The machine self-destructs on exit (`auto_destroy: true`), so there
  * is nothing to clean up unless the caller explicitly cancels.
+ *
+ * If `FLY_BUILDER_CACHE_VOLUME` is set, the volume is attached at
+ * `cacheMountPath` so the builder can reuse dockerd + buildkit state
+ * across machines. Fly Volumes are single-attach; if the previous
+ * build's machine is still detaching we retry POST /machines with
+ * exponential backoff (up to ~60s). Longer than that and we give up
+ * — the caller's dispatcher will surface the failure.
  */
 export async function spawnFlyBuilder(input: FlySpawnInput): Promise<FlySpawnResult> {
   const cfg = getFlyConfig()
 
-  const body = {
-    name: input.name,
-    region: cfg.region,
-    config: {
-      image: cfg.image,
-      auto_destroy: true,
-      restart: { policy: 'no' as const },
-      guest: {
-        cpu_kind: cfg.cpuKind,
-        cpus: cfg.cpus,
-        memory_mb: cfg.memoryMb,
-      },
-      env: input.env,
+  const baseConfig: Record<string, unknown> = {
+    image: cfg.image,
+    auto_destroy: true,
+    restart: { policy: 'no' as const },
+    guest: {
+      cpu_kind: cfg.cpuKind,
+      cpus: cfg.cpus,
+      memory_mb: cfg.memoryMb,
+    },
+    env: {
+      ...input.env,
+      // Echo mount info into the machine env so build-fly.sh doesn't
+      // have to probe `/proc/mounts` — keeps the shell side simple
+      // and makes the contract obvious: "if AF_CACHE_ROOT is set,
+      // dockerd data-root lives there."
+      ...(cfg.cacheVolumeId ? { AF_CACHE_ROOT: cfg.cacheMountPath } : {}),
     },
   }
 
-  const machine = await flyFetch<FlyMachineResponse>(cfg, '/machines', {
-    method: 'POST',
-    body: JSON.stringify(body),
-  })
+  if (cfg.cacheVolumeId) {
+    baseConfig.mounts = [
+      {
+        volume: cfg.cacheVolumeId,
+        path: cfg.cacheMountPath,
+      },
+    ]
+  }
 
-  log.info(
-    { machineId: machine.id, name: machine.name, region: machine.region, state: machine.state },
-    'Fly builder machine created',
-  )
+  const body = {
+    name: input.name,
+    region: cfg.region,
+    config: baseConfig,
+  }
 
-  return { machineId: machine.id, name: machine.name, region: machine.region }
+  // Volume-attach race. If the previous builder machine is still in
+  // `destroying`/`destroyed` state, its volume attachment lingers for
+  // a few seconds. Fly returns 409 "volume already attached to machine
+  // X" or similar; only cure is to wait. Back off 2,4,8,16,30s.
+  const delays = [2000, 4000, 8000, 16000, 30000]
+  let lastErr: unknown = null
+  for (let attempt = 0; attempt <= delays.length; attempt += 1) {
+    try {
+      const machine = await flyFetch<FlyMachineResponse>(cfg, '/machines', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      })
+      log.info(
+        {
+          machineId: machine.id,
+          name: machine.name,
+          region: machine.region,
+          state: machine.state,
+          volume: cfg.cacheVolumeId ?? null,
+          attempt,
+        },
+        'Fly builder machine created',
+      )
+      return { machineId: machine.id, name: machine.name, region: machine.region }
+    } catch (err) {
+      lastErr = err
+      const msg = err instanceof Error ? err.message : String(err)
+      const retryable =
+        cfg.cacheVolumeId !== null &&
+        (msg.includes('volume') || msg.includes('409')) &&
+        attempt < delays.length
+      if (!retryable) throw err
+      log.warn(
+        { attempt, delayMs: delays[attempt], err: msg },
+        'Fly machine spawn rejected (volume busy) — retrying',
+      )
+      await new Promise((r) => setTimeout(r, delays[attempt]))
+    }
+  }
+  throw lastErr instanceof Error ? lastErr : new Error('spawnFlyBuilder: exhausted retries')
 }
 
 /**

--- a/src/services/github/flyioBuilder.ts
+++ b/src/services/github/flyioBuilder.ts
@@ -1,0 +1,179 @@
+/**
+ * Fly.io Machines API client — alternative build executor.
+ *
+ * Replaces the in-cluster `af-builder` Kubernetes Job with an ephemeral
+ * Fly Machine for each push. Same `build.sh` contract; same callback
+ * payload; same BuildJob lifecycle. The dispatch happens in
+ * `buildSpawner.ts` based on the `BUILD_EXECUTOR` env switch.
+ *
+ * Why Fly?
+ *   - Pay-per-second billing → a 60s build costs ~$0.001 instead of
+ *     reserving a 4Gi/2vCPU pod slot in our cluster all month.
+ *   - Firecracker microVMs → real kernel, dockerd just works without
+ *     `--privileged` or a dind sidecar. One image, one process tree.
+ *   - `auto_destroy: true` → machine reaps itself the second the
+ *     script exits. Zero cleanup logic on our side.
+ *   - Hard isolation → a runaway build can't OOM `service-cloud-api`,
+ *     can't starve other tenants, can't write to our PVCs.
+ *
+ * Failure mode:
+ *   - If the Machines API returns 5xx, throw. `buildSpawner` will fall
+ *     back to the K8s Job path so a Fly outage never blocks builds
+ *     during the cutover window.
+ *
+ * The image referenced by `FLY_BUILDER_IMAGE` MUST be public on GHCR
+ * (or accompanied by Fly registry creds in `config.image_credentials`).
+ * We default to public; see infra/ for the GHCR visibility setup.
+ */
+
+import { createLogger } from '../../lib/logger.js'
+
+const log = createLogger('github.flyioBuilder')
+
+const FLY_API_BASE = process.env.FLY_API_BASE || 'https://api.machines.dev/v1'
+const FLY_TIMEOUT_MS = Number(process.env.FLY_API_TIMEOUT_MS || 30_000)
+
+export interface FlyMachineEnv {
+  [key: string]: string
+}
+
+export interface FlySpawnInput {
+  /** Stable, human-readable machine name (we use `build-<jobId>`). */
+  name: string
+  /** Env vars handed to the entrypoint. Same as the K8s Job template. */
+  env: FlyMachineEnv
+}
+
+export interface FlySpawnResult {
+  /** Fly Machine id, e.g. `91851edb1e6783`. Stored in BuildJob.k8sJobName
+   *  prefixed with `fly:` so `deleteBuildJob` can route correctly. */
+  machineId: string
+  /** Human-readable name we asked Fly to assign. */
+  name: string
+  /** Region the machine was actually placed in. */
+  region: string
+}
+
+/** Strongly-typed view of the bits of the Fly API response we read. */
+interface FlyMachineResponse {
+  id: string
+  name: string
+  region: string
+  state: string
+}
+
+interface FlyConfig {
+  app: string
+  region: string
+  image: string
+  cpuKind: 'shared' | 'performance'
+  cpus: number
+  memoryMb: number
+  apiToken: string
+}
+
+function getFlyConfig(): FlyConfig {
+  const apiToken = process.env.FLY_API_TOKEN || ''
+  const app = process.env.FLY_BUILDER_APP || ''
+  if (!apiToken) throw new Error('FLY_API_TOKEN is not set')
+  if (!app) throw new Error('FLY_BUILDER_APP is not set')
+
+  return {
+    apiToken,
+    app,
+    region: process.env.FLY_BUILDER_REGION || 'ord',
+    image: process.env.FLY_BUILDER_IMAGE || 'ghcr.io/alternatefutures/af-builder:fly-latest',
+    cpuKind: (process.env.FLY_BUILDER_CPU_KIND as 'shared' | 'performance') || 'performance',
+    cpus: Number(process.env.FLY_BUILDER_CPUS || 2),
+    memoryMb: Number(process.env.FLY_BUILDER_MEMORY_MB || 4096),
+  }
+}
+
+async function flyFetch<T>(
+  cfg: FlyConfig,
+  pathSuffix: string,
+  init: RequestInit & { method: 'GET' | 'POST' | 'DELETE' },
+): Promise<T> {
+  const url = `${FLY_API_BASE}/apps/${encodeURIComponent(cfg.app)}${pathSuffix}`
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), FLY_TIMEOUT_MS)
+  try {
+    const res = await fetch(url, {
+      ...init,
+      signal: controller.signal,
+      headers: {
+        ...(init.headers || {}),
+        Authorization: `Bearer ${cfg.apiToken}`,
+        'Content-Type': 'application/json',
+      },
+    })
+    if (!res.ok) {
+      const body = await res.text().catch(() => '<unreadable>')
+      throw new Error(`Fly API ${init.method} ${pathSuffix} failed: ${res.status} ${body}`)
+    }
+    // DELETE returns 200 with `{ ok: true }`, GET/POST return JSON; both safe to parse.
+    if (res.status === 204) return undefined as unknown as T
+    return (await res.json()) as T
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+/**
+ * Spawn a one-shot Fly Machine that runs the builder image and exits.
+ * The machine self-destructs on exit (`auto_destroy: true`), so there
+ * is nothing to clean up unless the caller explicitly cancels.
+ */
+export async function spawnFlyBuilder(input: FlySpawnInput): Promise<FlySpawnResult> {
+  const cfg = getFlyConfig()
+
+  const body = {
+    name: input.name,
+    region: cfg.region,
+    config: {
+      image: cfg.image,
+      auto_destroy: true,
+      restart: { policy: 'no' as const },
+      guest: {
+        cpu_kind: cfg.cpuKind,
+        cpus: cfg.cpus,
+        memory_mb: cfg.memoryMb,
+      },
+      env: input.env,
+    },
+  }
+
+  const machine = await flyFetch<FlyMachineResponse>(cfg, '/machines', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+
+  log.info(
+    { machineId: machine.id, name: machine.name, region: machine.region, state: machine.state },
+    'Fly builder machine created',
+  )
+
+  return { machineId: machine.id, name: machine.name, region: machine.region }
+}
+
+/**
+ * Force-destroy a Fly Machine. Idempotent — a 404 (already gone) is
+ * treated as success. Used on user-initiated cancel; happy-path teardown
+ * is handled by `auto_destroy: true`.
+ */
+export async function destroyFlyMachine(machineId: string): Promise<void> {
+  const cfg = getFlyConfig()
+  try {
+    await flyFetch<unknown>(cfg, `/machines/${encodeURIComponent(machineId)}?force=true`, {
+      method: 'DELETE',
+    })
+    log.info({ machineId }, 'Fly machine destroyed')
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    if (msg.includes(' 404 ')) {
+      log.info({ machineId }, 'Fly machine already gone (404)')
+      return
+    }
+    log.warn({ err, machineId }, 'failed to destroy Fly machine')
+  }
+}

--- a/src/services/github/webhookEndpoint.ts
+++ b/src/services/github/webhookEndpoint.ts
@@ -317,7 +317,11 @@ async function handlePushEvent(prisma: PrismaClient, payload: PushEvent): Promis
       })
       await prisma.buildJob.update({
         where: { id: buildJob.id },
-        data: { k8sJobName: spawned.k8sJobName, status: 'RUNNING' },
+        data: {
+          k8sJobName: spawned.k8sJobName,
+          status: 'RUNNING',
+          logs: spawned.initialLog,
+        },
       })
     } catch (err) {
       log.error({ err, serviceId: svc.id }, 'push-triggered rebuild failed to spawn')


### PR DESCRIPTION
## Summary

- **New Fly.io builder backend** (`flyioBuilder.ts`) as a drop-in alternative to the in-cluster K8s Job builder. Warm rebuilds land in ~20s thanks to a persistent Fly Volume holding the BuildKit layer cache. Selected via `BUILD_EXECUTOR=fly`; K8s remains the default.
- **Fixes the "deployment stuck pulling image" bug** for private GitHub-source builds. `orchestrator.ts` now emits a per-service `credentials:` block in the Akash SDL for every `ghcr.io/...` image, so decentralized providers can authenticate against our private GHCR namespace instead of silently ImagePullBackOff-ing. Replaces the flaky `PATCH /orgs/.../packages/.../visibility` approach that GitHub Team plans do not actually honor.
- **Threat-model-aware credential selection.** Prefers a dedicated read-only `GHCR_PULL_TOKEN` (scope: `read:packages`) so the token handed to whoever wins the lease cannot be turned into a supply-chain foothold. Falls back to `GHCR_PUSH_TOKEN` with a loud, rate-limited warning if ops hasn't provisioned the read-only PAT yet.
- **Builder now stamps OCI image labels** (`org.opencontainers.image.source`, `.revision`, `.created`) via new `REPO_SOURCE_URL`/`REPO_OWNER`/`REPO_NAME` env plumbed through `buildSpawner.ts`. Gets us repo auto-linking in the GHCR UI and gives us a fighting chance at per-deployment provenance later.
- **Documents `GHCR_PULL_TOKEN`** in `.env.example` including the rationale for why it *must* be separate from the push token.

## Why

Private GHCR images are the correct default (we don't want every internal template image world-pullable), but Akash providers are untrusted third parties — they can't read our PATs from Fly/K8s and they can't call GitHub's API as us. The SDL `credentials:` block is the native Akash mechanism for this exact situation; we just weren't using it. Embedding a read-only PAT there gets us working private pulls while keeping blast radius bounded: a malicious provider can, at worst, read our private container packages.

## Test plan

- [ ] Deploy a private GitHub repo end-to-end; confirm lease bid → image pull → service healthy (previously stuck in `ImagePullBackOff`).
- [ ] Check new deployment's SDL output contains `credentials:` with `host: https://ghcr.io` (scheme prefix is required).
- [ ] With `BUILD_EXECUTOR=fly`, push two commits to the same repo and confirm warm build <30s.
- [ ] `GHCR_PULL_TOKEN` unset + `GHCR_PUSH_TOKEN` set → SDL still renders, warning logged exactly once per image ref (not per SDL regen).
- [ ] Non-GHCR image (e.g. a DockerHub template) renders SDL without a `credentials:` block.

## Deploy notes

- Requires `GHCR_PULL_TOKEN` to be present in the `github-app-credentials` K8s secret. The matching manifest + secret update lives in the `infra` repo (already applied to `af-production` + `af-staging`).
- No DB migration, no breaking API changes.