### PR TITLE
volume pool + build timeout cap for Fly executor

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -178,16 +178,21 @@ FLY_BUILDER_IMAGE=ghcr.io/alternatefutures/af-builder:fly-latest
 FLY_BUILDER_CPU_KIND=performance
 FLY_BUILDER_CPUS=2
 FLY_BUILDER_MEMORY_MB=4096
-# Persistent buildkit/dockerd cache volume. Attach an already-created
-# Fly Volume (same app + region as the builders) to every spawned
-# machine so base images, pnpm/pip/cargo stores, and buildkit
-# snapshotter state survive machine reaps. This is what makes repeat
-# builds ~15-30s instead of 5+ minutes. Create once with:
-#   fly volumes create af_build_cache_0 -a af-builders --region ord --size 20
-# then paste the returned id below. Leave unset to fall back to
-# ephemeral per-machine state (correct, just slow).
+# Persistent buildkit/dockerd cache volume(s). Comma-separated list of
+# Fly Volume ids — flyioBuilder.ts picks one at random per spawn and
+# rotates through the pool on 409 volume-busy (enables concurrent builds).
+# Create volumes with:
+#   flyctl volumes create af_build_cache_0 -a af-builders --region ord --size 20
+# then prime each before it serves real traffic (cuts cold build ~3-4min → ~60-90s):
+#   ./admin/cloud/scripts/prime-fly-cache.sh --volume vol_xxx
+# Leave unset to fall back to ephemeral per-machine state (slow but functional).
 # FLY_BUILDER_CACHE_VOLUME=vol_xxxxxxxxxxxxxxxx
 # FLY_BUILDER_CACHE_MOUNT=/var/lib/af-cache
+# Hard runtime cap per build. build-fly.sh enforces via `timeout(1)`;
+# on expiry posts FAILED callback → Fly auto_destroy reaps the VM.
+# Default 900s (15 min). Without this, a runaway build (infinite loop,
+# OOM thrash) runs until you manually `flyctl machines destroy --force`.
+# FLY_BUILDER_MAX_RUNTIME_SECONDS=900
 # Advanced overrides — leave unset to use defaults baked into flyioBuilder.ts.
 # FLY_API_BASE=https://api.machines.dev/v1
 # FLY_API_TIMEOUT_MS=30000

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ RUN apt-get update && \
     ca-certificates \
     curl \
     dumb-init \
+    jq \
     unzip && \
     curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y --no-install-recommends nodejs && \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -31,22 +31,85 @@ if [ -n "$AKASH_MNEMONIC" ]; then
         echo "Certificate generation failed (non-fatal, may already exist)"
 
       if [ -f "$CERT_PATH" ]; then
+        # Publish on-chain. Critical: parse the JSON tx response and retry
+        # on non-zero `code`. The CLI exits 0 on a *broadcast* but the tx
+        # itself can fail (sequence mismatch / out-of-gas / mempool full).
+        # Previously we used `... && echo "published" || echo "failed (non-
+        # fatal)"` which silently swallowed code-32 (account sequence) and
+        # left a local cert that didn't exist on-chain — every subsequent
+        # `akash tx deployment create` then errored "certificate has not
+        # been committed to blockchain". See incident 2026-04-22.
         echo "Publishing certificate on-chain..."
-        akash tx cert publish client \
-          --from "$KEY_NAME" \
-          --keyring-backend test \
-          --node "$AKASH_NODE" \
-          --chain-id "${AKASH_CHAIN_ID:-akashnet-2}" \
-          --gas-prices 0.025uakt \
-          --gas auto \
-          --gas-adjustment 1.5 \
-          -y 2>&1 && \
-          echo "Certificate published on-chain" || \
-          echo "Certificate publish failed (non-fatal, may already be on-chain)"
-        sleep 5
+        PUBLISH_OK=0
+        for attempt in 1 2 3 4 5; do
+          PUBLISH_OUT=$(akash tx cert publish client \
+            --from "$KEY_NAME" \
+            --keyring-backend test \
+            --node "$AKASH_NODE" \
+            --chain-id "${AKASH_CHAIN_ID:-akashnet-2}" \
+            --gas-prices 0.025uakt \
+            --gas auto \
+            --gas-adjustment 1.5 \
+            -o json -y 2>&1) || true
+          PUBLISH_CODE=$(echo "$PUBLISH_OUT" | jq -r '.code // 99' 2>/dev/null || echo 99)
+          PUBLISH_HASH=$(echo "$PUBLISH_OUT" | jq -r '.txhash // empty' 2>/dev/null)
+          if [ "$PUBLISH_CODE" = "0" ] && [ -n "$PUBLISH_HASH" ]; then
+            echo "Certificate published on-chain (txhash=$PUBLISH_HASH, attempt=$attempt)"
+            PUBLISH_OK=1
+            break
+          fi
+          # Treat "already exists" (code 11) as success — another pod beat
+          # us to it, our local key matches the on-chain cert.
+          if echo "$PUBLISH_OUT" | grep -qiE 'certificate.*already exists|already exists.*certificate'; then
+            echo "Certificate already on-chain — skipping (attempt=$attempt)"
+            PUBLISH_OK=1
+            break
+          fi
+          echo "Certificate publish attempt $attempt failed (code=$PUBLISH_CODE):"
+          echo "$PUBLISH_OUT" | head -c 600
+          echo
+          sleep $((attempt * 3))
+        done
+        if [ "$PUBLISH_OK" != "1" ]; then
+          # Fail loud — without a published cert the API can't broadcast
+          # *any* deployment tx. Better to crashloop and surface the issue
+          # than to start serving traffic that 100% errors at submit time.
+          echo "FATAL: certificate publish failed after 5 attempts. Refusing to start."
+          echo "Removing local PEM so the next pod retries cleanly."
+          rm -f "$CERT_PATH"
+          exit 71
+        fi
+        # Wait a couple of blocks (~12s) so the cert is queryable before
+        # we accept traffic. Akash blocks ~6s; 12s gives a safety margin.
+        sleep 12
       fi
     else
-      echo "Akash certificate PEM exists at ${CERT_PATH}"
+      # Local PEM exists. The pod is being recycled with a persistent
+      # state, OR the Dockerfile/entrypoint produced the same key+cert
+      # bytes. Verify the on-chain side still has a matching valid cert
+      # — if it doesn't (revoked, missed broadcast, etc.) republish.
+      echo "Akash certificate PEM exists at ${CERT_PATH}, verifying on-chain..."
+      LOCAL_HEX=$(openssl x509 -in "$CERT_PATH" -noout -serial 2>/dev/null | cut -d= -f2 || echo "")
+      if [ -n "$LOCAL_HEX" ]; then
+        LOCAL_DEC=$(printf "%d\n" 0x"$LOCAL_HEX" 2>/dev/null || echo "")
+        if [ -n "$LOCAL_DEC" ]; then
+          MATCH=$(akash query cert list --owner "$AKASH_ADDR" --serial "$LOCAL_DEC" \
+            --node "${RPC_ENDPOINT:-https://rpc.akashnet.net:443}" -o json 2>/dev/null \
+            | jq -r '.certificates[]?.certificate.state // empty' 2>/dev/null || echo "")
+          if [ "$MATCH" = "valid" ]; then
+            echo "On-chain cert matches local PEM (state=valid)."
+          else
+            echo "WARNING: local PEM serial $LOCAL_DEC not found on-chain (state=$MATCH). Republishing."
+            akash tx cert publish client \
+              --from "$KEY_NAME" --keyring-backend test \
+              --node "${RPC_ENDPOINT:-https://rpc.akashnet.net:443}" \
+              --chain-id "${AKASH_CHAIN_ID:-akashnet-2}" \
+              --gas-prices 0.025uakt --gas auto --gas-adjustment 1.5 \
+              -o json -y 2>&1 | head -c 600 || true
+            sleep 12
+          fi
+        fi
+      fi
     fi
   fi
 fi

--- a/src/services/github/flyioBuilder.test.ts
+++ b/src/services/github/flyioBuilder.test.ts
@@ -1,14 +1,12 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
 import { __test__ } from './flyioBuilder.js'
 
-const { parseVolumeList } = __test__
+const { parseVolumeList, parseCpuKind, parseEnvInt, redactFlyErrorBody } = __test__
 
 /**
- * `FLY_BUILDER_CACHE_VOLUME` is parsed by `parseVolumeList` into the
- * volume pool that `spawnFlyBuilder` rotates through on 409 volume-busy.
- * These are thin tests but they pin the contract because mis-parsing is
- * silent: an extra space in the configmap would drop every build back to
- * ephemeral state and nothing would alert.
+ * These helpers gate every spawn — a mis-parse is silent (builds quietly
+ * slide to ephemeral dockerd or a 422 at POST time), so the tests exist
+ * less for logic coverage and more as a contract pin.
  */
 describe('parseVolumeList', () => {
   it('returns an empty list when the env var is unset', () => {
@@ -19,22 +17,182 @@ describe('parseVolumeList', () => {
     expect(parseVolumeList('')).toEqual([])
   })
 
-  it('parses a single volume id', () => {
-    expect(parseVolumeList('vol_abc')).toEqual(['vol_abc'])
+  it('parses a single well-formed volume id', () => {
+    expect(parseVolumeList('vol_abc123')).toEqual(['vol_abc123'])
   })
 
   it('parses multiple comma-separated ids', () => {
-    expect(parseVolumeList('vol_a,vol_b,vol_c')).toEqual(['vol_a', 'vol_b', 'vol_c'])
+    expect(parseVolumeList('vol_aaaaaa,vol_bbbbbb,vol_cccccc')).toEqual([
+      'vol_aaaaaa',
+      'vol_bbbbbb',
+      'vol_cccccc',
+    ])
   })
 
-  it('trims surrounding whitespace around each id (YAML users love spaces after commas)', () => {
-    expect(parseVolumeList(' vol_a , vol_b ,vol_c ')).toEqual(['vol_a', 'vol_b', 'vol_c'])
+  it('trims surrounding whitespace (YAML users love spaces after commas)', () => {
+    expect(parseVolumeList(' vol_aaaaaa , vol_bbbbbb ,vol_cccccc ')).toEqual([
+      'vol_aaaaaa',
+      'vol_bbbbbb',
+      'vol_cccccc',
+    ])
   })
 
   it('filters out empty entries from trailing or doubled commas', () => {
-    // Defensive: a user who leaves a trailing comma shouldn't get an
-    // empty string routed to Fly's mounts[].volume — that would fail
-    // with a confusing "volume '' not found" error on every spawn.
-    expect(parseVolumeList('vol_a,,vol_b,')).toEqual(['vol_a', 'vol_b'])
+    expect(parseVolumeList('vol_aaaaaa,,vol_bbbbbb,')).toEqual(['vol_aaaaaa', 'vol_bbbbbb'])
+  })
+
+  it('rejects entries that do not match the Fly volume id shape', () => {
+    // Typos we expect to see in the wild: hyphen instead of underscore,
+    // missing prefix, pasted k8s PVC name, pasted Akash dseq.
+    expect(parseVolumeList('vol-abc123,volume_42,1234567890,vol_valid12')).toEqual(['vol_valid12'])
+  })
+
+  it('rejects the prefix alone (no id body)', () => {
+    expect(parseVolumeList('vol_')).toEqual([])
+  })
+
+  it('rejects ids with illegal characters', () => {
+    expect(parseVolumeList('vol_abc/def,vol_abc.def,vol_abc def')).toEqual([])
+  })
+})
+
+describe('parseCpuKind', () => {
+  it('returns the fallback when unset', () => {
+    expect(parseCpuKind(undefined, 'performance')).toBe('performance')
+  })
+
+  it('returns the fallback for an empty string', () => {
+    expect(parseCpuKind('', 'shared')).toBe('shared')
+  })
+
+  it('accepts shared', () => {
+    expect(parseCpuKind('shared', 'performance')).toBe('shared')
+  })
+
+  it('accepts performance', () => {
+    expect(parseCpuKind('performance', 'shared')).toBe('performance')
+  })
+
+  it('falls back (rather than blindly casting) on a typo', () => {
+    // Previously `as 'shared' | 'performance'` would happily hand Fly
+    // the string "perfromance" and eat a 400 at spawn time.
+    expect(parseCpuKind('perfromance', 'performance')).toBe('performance')
+  })
+
+  it('is case-sensitive — Fly is too', () => {
+    expect(parseCpuKind('Performance', 'shared')).toBe('shared')
+  })
+})
+
+describe('parseEnvInt', () => {
+  it('returns the fallback when unset', () => {
+    expect(parseEnvInt('X', undefined, 42, { min: 0, max: 100 })).toBe(42)
+  })
+
+  it('returns the fallback for empty string', () => {
+    expect(parseEnvInt('X', '', 42, { min: 0, max: 100 })).toBe(42)
+  })
+
+  it('parses a clean integer', () => {
+    expect(parseEnvInt('X', '17', 0, { min: 0, max: 100 })).toBe(17)
+  })
+
+  it('parses leading-integer strings like "4096"', () => {
+    expect(parseEnvInt('X', '4096', 0, { min: 0, max: 65_536 })).toBe(4096)
+  })
+
+  it('falls back when the input is non-numeric ("4gb")', () => {
+    // Number('4gb') === NaN; the old code passed NaN to Fly and got a
+    // 400 response. Here we refuse to propagate NaN.
+    expect(parseEnvInt('X', 'nonsense', 2, { min: 1, max: 16 })).toBe(2)
+  })
+
+  it('falls back below min', () => {
+    expect(parseEnvInt('X', '-5', 2, { min: 1, max: 16 })).toBe(2)
+  })
+
+  it('falls back above max', () => {
+    expect(parseEnvInt('X', '99999', 2, { min: 1, max: 16 })).toBe(2)
+  })
+
+  it('accepts the min boundary', () => {
+    expect(parseEnvInt('X', '1', 2, { min: 1, max: 16 })).toBe(1)
+  })
+
+  it('accepts the max boundary', () => {
+    expect(parseEnvInt('X', '16', 2, { min: 1, max: 16 })).toBe(16)
+  })
+})
+
+describe('redactFlyErrorBody', () => {
+  it('returns empty string for empty input', () => {
+    expect(redactFlyErrorBody('')).toBe('')
+  })
+
+  it('leaves short, secret-free bodies intact', () => {
+    expect(redactFlyErrorBody('volume in use')).toBe('volume in use')
+  })
+
+  it('redacts Bearer tokens', () => {
+    const input = 'err: Authorization: Bearer fo1_AbCdEfGhIjKlMnOpQrStUvWxYz123456'
+    const out = redactFlyErrorBody(input)
+    expect(out).toContain('[REDACTED]')
+    expect(out).not.toContain('fo1_AbCdEfGhIjKlMnOpQrStUvWxYz')
+  })
+
+  it('redacts long base64-like blobs (RSA keys, long tokens)', () => {
+    const blob = 'A'.repeat(80)
+    expect(redactFlyErrorBody(`value: ${blob}`)).toContain('[REDACTED]')
+  })
+
+  it('scrubs echoed-back env JSON blocks', () => {
+    const body = '{"error":"invalid","env":{"GITHUB_APP_PRIVATE_KEY":"super-secret","X":"1"}}'
+    const out = redactFlyErrorBody(body)
+    expect(out).not.toContain('super-secret')
+    expect(out).toContain('"env":"[REDACTED]"')
+  })
+
+  it('truncates very long bodies', () => {
+    // Use short words + spaces so we exercise the length cap rather
+    // than the base64 redactor (which would collapse a 2000-char
+    // `xxxxx…` run into a single [REDACTED] token).
+    const long = 'err '.repeat(500)
+    const out = redactFlyErrorBody(long)
+    expect(out.length).toBeLessThan(500)
+    expect(out).toContain('truncated')
+  })
+})
+
+/**
+ * Logger side-effect assertions. The invalid inputs above should surface
+ * to operators as one warn line each — silent rejection is the footgun
+ * that the whole "validate at parse time" story is meant to prevent.
+ */
+describe('parse helpers emit operator-visible warnings', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    // createLogger returns a pino child, which has .warn at runtime.
+    // We spy on the module-scoped logger used in flyioBuilder by
+    // hooking global console.warn; pino in non-production emits via
+    // pino-pretty, which writes to stdout, so this mainly guards
+    // against regressions in pino config. No-op if logs are silent.
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('does not throw on invalid volume ids (just filters + warns)', () => {
+    expect(() => parseVolumeList('vol-wrong,not_a_vol,vol_ok12345')).not.toThrow()
+  })
+
+  it('does not throw on unknown cpu kind', () => {
+    expect(() => parseCpuKind('ultra-premium', 'performance')).not.toThrow()
+  })
+
+  it('does not throw on non-numeric int env', () => {
+    expect(() => parseEnvInt('X', 'not-a-number', 5, { min: 0, max: 10 })).not.toThrow()
   })
 })

--- a/src/services/github/flyioBuilder.test.ts
+++ b/src/services/github/flyioBuilder.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { __test__ } from './flyioBuilder.js'
+
+const { parseVolumeList } = __test__
+
+/**
+ * `FLY_BUILDER_CACHE_VOLUME` is parsed by `parseVolumeList` into the
+ * volume pool that `spawnFlyBuilder` rotates through on 409 volume-busy.
+ * These are thin tests but they pin the contract because mis-parsing is
+ * silent: an extra space in the configmap would drop every build back to
+ * ephemeral state and nothing would alert.
+ */
+describe('parseVolumeList', () => {
+  it('returns an empty list when the env var is unset', () => {
+    expect(parseVolumeList(undefined)).toEqual([])
+  })
+
+  it('returns an empty list for an empty string', () => {
+    expect(parseVolumeList('')).toEqual([])
+  })
+
+  it('parses a single volume id', () => {
+    expect(parseVolumeList('vol_abc')).toEqual(['vol_abc'])
+  })
+
+  it('parses multiple comma-separated ids', () => {
+    expect(parseVolumeList('vol_a,vol_b,vol_c')).toEqual(['vol_a', 'vol_b', 'vol_c'])
+  })
+
+  it('trims surrounding whitespace around each id (YAML users love spaces after commas)', () => {
+    expect(parseVolumeList(' vol_a , vol_b ,vol_c ')).toEqual(['vol_a', 'vol_b', 'vol_c'])
+  })
+
+  it('filters out empty entries from trailing or doubled commas', () => {
+    // Defensive: a user who leaves a trailing comma shouldn't get an
+    // empty string routed to Fly's mounts[].volume — that would fail
+    // with a confusing "volume '' not found" error on every spawn.
+    expect(parseVolumeList('vol_a,,vol_b,')).toEqual(['vol_a', 'vol_b'])
+  })
+})

--- a/src/services/github/flyioBuilder.ts
+++ b/src/services/github/flyioBuilder.ts
@@ -31,7 +31,42 @@ import { createLogger } from '../../lib/logger.js'
 const log = createLogger('github.flyioBuilder')
 
 const FLY_API_BASE = process.env.FLY_API_BASE || 'https://api.machines.dev/v1'
-const FLY_TIMEOUT_MS = Number(process.env.FLY_API_TIMEOUT_MS || 30_000)
+
+/**
+ * Parse an integer env var with bounds + a fallback. Crucially we reject
+ * NaN (e.g. `Number('4gb')` → NaN silently passed to Fly's API, which
+ * then returns a cryptic 400) and clamp out-of-range values so a typo
+ * like `FLY_BUILDER_CPUS=99999` doesn't try to rent a machine Fly won't
+ * sell us. Returns `fallback` on any invalid input and logs a warning
+ * so the operator can fix the configmap instead of silently running
+ * with a surprise default.
+ */
+function parseEnvInt(
+  name: string,
+  raw: string | undefined,
+  fallback: number,
+  opts: { min: number; max: number },
+): number {
+  if (raw === undefined || raw === '') return fallback
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed) || Number.isNaN(parsed)) {
+    log.warn({ name, raw, fallback }, 'env var not a valid integer — using fallback')
+    return fallback
+  }
+  if (parsed < opts.min || parsed > opts.max) {
+    log.warn(
+      { name, raw, parsed, min: opts.min, max: opts.max, fallback },
+      'env var out of allowed range — using fallback',
+    )
+    return fallback
+  }
+  return parsed
+}
+
+const FLY_TIMEOUT_MS = parseEnvInt('FLY_API_TIMEOUT_MS', process.env.FLY_API_TIMEOUT_MS, 30_000, {
+  min: 1_000,
+  max: 300_000,
+})
 
 export interface FlyMachineEnv {
   [key: string]: string
@@ -103,12 +138,55 @@ interface FlyConfig {
   maxRuntimeSeconds: number
 }
 
+/**
+ * Fly Volume IDs have a fixed shape: `vol_` followed by 12–24 alphanumeric
+ * characters (they're k-sortable base62 identifiers from Fly's side).
+ * Accepting any non-empty string here means a configmap typo (`vol-abc`
+ * with a hyphen, a stray quote, an Akash lease dseq pasted in) lands in
+ * the POST /machines request body where Fly rejects it with a generic
+ * 422 "invalid input" — easy to miss when chasing a build failure.
+ * Validating at parse time means the bad entry never joins the pool and
+ * we log it exactly once with the env var name.
+ */
+const FLY_VOLUME_ID_PATTERN = /^vol_[a-zA-Z0-9]{6,32}$/
+
 function parseVolumeList(raw: string | undefined): string[] {
   if (!raw) return []
-  return raw
-    .split(',')
-    .map((v) => v.trim())
-    .filter((v) => v.length > 0)
+  const out: string[] = []
+  for (const segment of raw.split(',')) {
+    const id = segment.trim()
+    if (id.length === 0) continue
+    if (!FLY_VOLUME_ID_PATTERN.test(id)) {
+      log.warn(
+        { invalidVolumeId: id },
+        'FLY_BUILDER_CACHE_VOLUME contains an entry that does not match vol_<alnum> — ignoring',
+      )
+      continue
+    }
+    out.push(id)
+  }
+  return out
+}
+
+/**
+ * Validate the CPU-kind env input against Fly's fixed enum instead of
+ * casting blindly. A typo ("perfromance") previously produced a
+ * `cpu_kind: "perfromance"` request that Fly rejects with a 400 at
+ * spawn time — minutes after the pod started. Validating at config
+ * load means the service either boots with a known-good value or
+ * logs one warning and falls back to `performance`.
+ */
+const VALID_CPU_KINDS = ['shared', 'performance'] as const
+type CpuKind = (typeof VALID_CPU_KINDS)[number]
+
+function parseCpuKind(raw: string | undefined, fallback: CpuKind): CpuKind {
+  if (raw === undefined || raw === '') return fallback
+  if ((VALID_CPU_KINDS as readonly string[]).includes(raw)) return raw as CpuKind
+  log.warn(
+    { raw, allowed: VALID_CPU_KINDS, fallback },
+    'FLY_BUILDER_CPU_KIND is not a recognised Fly enum — using fallback',
+  )
+  return fallback
 }
 
 function getFlyConfig(): FlyConfig {
@@ -122,22 +200,58 @@ function getFlyConfig(): FlyConfig {
     app,
     region: process.env.FLY_BUILDER_REGION || 'ord',
     image: process.env.FLY_BUILDER_IMAGE || 'ghcr.io/alternatefutures/af-builder:fly-latest',
-    cpuKind: (process.env.FLY_BUILDER_CPU_KIND as 'shared' | 'performance') || 'performance',
-    cpus: Number(process.env.FLY_BUILDER_CPUS || 2),
-    memoryMb: Number(process.env.FLY_BUILDER_MEMORY_MB || 4096),
+    cpuKind: parseCpuKind(process.env.FLY_BUILDER_CPU_KIND, 'performance'),
+    cpus: parseEnvInt('FLY_BUILDER_CPUS', process.env.FLY_BUILDER_CPUS, 2, { min: 1, max: 16 }),
+    memoryMb: parseEnvInt('FLY_BUILDER_MEMORY_MB', process.env.FLY_BUILDER_MEMORY_MB, 4096, {
+      min: 256,
+      max: 65_536,
+    }),
     cacheVolumeIds: parseVolumeList(process.env.FLY_BUILDER_CACHE_VOLUME),
     cacheMountPath: process.env.FLY_BUILDER_CACHE_MOUNT || '/var/lib/af-cache',
-    maxRuntimeSeconds: Number(process.env.FLY_BUILDER_MAX_RUNTIME_SECONDS || 900),
+    maxRuntimeSeconds: parseEnvInt(
+      'FLY_BUILDER_MAX_RUNTIME_SECONDS',
+      process.env.FLY_BUILDER_MAX_RUNTIME_SECONDS,
+      900,
+      { min: 60, max: 14_400 },
+    ),
   }
 }
 
 /** Exported for testability — see flyioBuilder.test.ts. */
-export const __test__ = { parseVolumeList }
+export const __test__ = { parseVolumeList, parseCpuKind, parseEnvInt, redactFlyErrorBody }
+
+/**
+ * Strip anything that looks like a bearer token or long hex secret out
+ * of a Fly error body before it's embedded in an Error.message that
+ * may end up in Sentry, logs, or downstream webhook payloads. The body
+ * is also truncated to keep log lines bounded. We also collapse the
+ * request body we posted (machine config) out of echo-back fields,
+ * since `env:` contains things like GITHUB_APP_PRIVATE_KEY values that
+ * should NEVER round-trip through an exception message.
+ */
+export function redactFlyErrorBody(body: string): string {
+  if (!body) return ''
+  const MAX = 400
+  let out = body
+    // bearer-ish tokens / API keys
+    .replace(/(Bearer\s+|fo[a-z]*_)[A-Za-z0-9_\-.]{16,}/gi, '$1[REDACTED]')
+    // base64-shaped secrets ≥ 40 chars (matches RSA keys, tokens)
+    .replace(/[A-Za-z0-9+/_-]{40,}={0,2}/g, '[REDACTED]')
+    // JSON env blobs the server echoes back on 422 — scrub the whole
+    // value side of any `"env": { ... }` to avoid leaking per-job secrets.
+    .replace(/"env"\s*:\s*\{[^}]*\}/g, '"env":"[REDACTED]"')
+  if (out.length > MAX) out = `${out.slice(0, MAX)}…(truncated ${out.length - MAX} chars)`
+  return out
+}
 
 /**
  * Returns parsed JSON for 2xx-with-body responses, or `undefined` for
  * 204 No Content. Callers that depend on a body should narrow with a
  * runtime check rather than assuming non-null.
+ *
+ * Errors throw with a *redacted* + truncated body — the full body is
+ * only emitted through the structured logger where we can scope it
+ * (and rely on pino's redact config in prod).
  */
 async function flyFetch<T>(
   cfg: FlyConfig,
@@ -159,7 +273,13 @@ async function flyFetch<T>(
     })
     if (!res.ok) {
       const body = await res.text().catch(() => '<unreadable>')
-      throw new Error(`Fly API ${init.method} ${pathSuffix} failed: ${res.status} ${body}`)
+      log.warn(
+        { status: res.status, method: init.method, pathSuffix, bodyLen: body.length },
+        'Fly API non-2xx response',
+      )
+      throw new Error(
+        `Fly API ${init.method} ${pathSuffix} failed: ${res.status} ${redactFlyErrorBody(body)}`,
+      )
     }
     // DELETE returns 200 with `{ ok: true }`, GET/POST return JSON; both safe to parse.
     if (res.status === 204) return undefined
@@ -204,9 +324,17 @@ export async function spawnFlyBuilder(input: FlySpawnInput): Promise<FlySpawnRes
   // their retries. With a multi-volume pool we also rotate the chosen
   // volume on each attempt, so attempt=0 may succeed immediately on a
   // free slot even if pool[startIndex] was busy.
+  //
+  // Total attempts = initial + baseDelays.length retries = 6.
+  // The old loop used `<= baseDelays.length` with an inline
+  // `attempt < baseDelays.length` guard inside the catch — correct in
+  // practice but one refactor away from `baseDelays[attempt] = undefined`
+  // → `setTimeout(r, NaN)` → zero-delay retry storm. Pin the bound
+  // explicitly and only index baseDelays when we know we have budget.
   const baseDelays = [2000, 4000, 8000, 16000, 30000]
+  const MAX_ATTEMPTS = baseDelays.length + 1
   let lastErr: unknown = null
-  for (let attempt = 0; attempt <= baseDelays.length; attempt += 1) {
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
     const chosenVolume =
       poolSize > 0 ? cfg.cacheVolumeIds[(startIndex + attempt) % poolSize] : null
 
@@ -276,14 +404,12 @@ export async function spawnFlyBuilder(input: FlySpawnInput): Promise<FlySpawnRes
     } catch (err) {
       lastErr = err
       const msg = err instanceof Error ? err.message : String(err)
+      const hasRetryBudget = attempt < baseDelays.length
       // Retry only on volume-attach conflicts. When a pool is configured
       // we always have somewhere else to try; rotating the volume choice
       // above usually avoids the backoff wait entirely by the second attempt.
-      const retryable =
-        poolSize > 0 &&
-        (msg.includes('volume') || msg.includes('409')) &&
-        attempt < baseDelays.length
-      if (!retryable) throw err
+      const isRetryable = poolSize > 0 && (msg.includes('volume') || msg.includes('409'))
+      if (!hasRetryBudget || !isRetryable) throw err
       const jitter = 0.75 + Math.random() * 0.5 // [0.75, 1.25]
       const delayMs = Math.round(baseDelays[attempt] * jitter)
       log.warn(

--- a/src/services/github/flyioBuilder.ts
+++ b/src/services/github/flyioBuilder.ts
@@ -71,22 +71,44 @@ interface FlyConfig {
   memoryMb: number
   apiToken: string
   /**
-   * Fly Volume id (e.g. `vol_42kg90p00e8ywj14`) that backs the persistent
-   * buildkit/dockerd state. Set via FLY_BUILDER_CACHE_VOLUME. When set,
-   * every spawned machine attaches this volume at `cacheMountPath` and
-   * `build-fly.sh` points `dockerd --data-root` into a subdir of that
-   * mount. Result: base images, cache mounts (pnpm/pip/cargo stores),
-   * and buildkit snapshotter state all survive machine reaping.
+   * Fly Volume ids (e.g. `vol_42kg90p00e8ywj14`) that back the persistent
+   * buildkit/dockerd state. Set via FLY_BUILDER_CACHE_VOLUME as a
+   * comma-separated list. When non-empty, each spawned machine attaches
+   * ONE volume from the pool at `cacheMountPath` and `build-fly.sh`
+   * points `dockerd --data-root` into a subdir of that mount. Result:
+   * base images, cache mounts (pnpm/pip/cargo stores), and buildkit
+   * snapshotter state all survive machine reaping.
    *
    * Fly Volumes are single-attach. We spawn machines with `auto_destroy:
    * true`, so the previous machine's volume detaches when it exits —
    * but there's a small window where the new machine's POST /machines
-   * returns 409 "volume in use." Spawn retries with exp backoff.
+   * returns 409 "volume in use." With multiple volumes we pick a random
+   * one first, then rotate through the list on each 409 retry so N
+   * concurrent builds proceed fully warm instead of serializing on one
+   * volume and mostly falling back to ephemeral.
    *
-   * Leaving this unset falls back to ephemeral state (slow but works).
+   * Leaving this unset (empty list) falls back to ephemeral state
+   * (slow but works).
    */
-  cacheVolumeId: string | null
+  cacheVolumeIds: string[]
   cacheMountPath: string
+  /**
+   * Hard cap on how long `build-fly.sh` lets `/app/build.sh` run before
+   * SIGTERM + SIGKILL. Passed into the machine as AF_BUILD_TIMEOUT_SECONDS
+   * so the timeout wrapper lives in the builder image (closer to the
+   * actual process tree) rather than polling Fly from here. A 15-min cap
+   * means a runaway build costs at most ~$0.09 instead of the $0.11+
+   * zombies we saw in §5 of HANDOFF.md.
+   */
+  maxRuntimeSeconds: number
+}
+
+function parseVolumeList(raw: string | undefined): string[] {
+  if (!raw) return []
+  return raw
+    .split(',')
+    .map((v) => v.trim())
+    .filter((v) => v.length > 0)
 }
 
 function getFlyConfig(): FlyConfig {
@@ -103,10 +125,14 @@ function getFlyConfig(): FlyConfig {
     cpuKind: (process.env.FLY_BUILDER_CPU_KIND as 'shared' | 'performance') || 'performance',
     cpus: Number(process.env.FLY_BUILDER_CPUS || 2),
     memoryMb: Number(process.env.FLY_BUILDER_MEMORY_MB || 4096),
-    cacheVolumeId: process.env.FLY_BUILDER_CACHE_VOLUME || null,
+    cacheVolumeIds: parseVolumeList(process.env.FLY_BUILDER_CACHE_VOLUME),
     cacheMountPath: process.env.FLY_BUILDER_CACHE_MOUNT || '/var/lib/af-cache',
+    maxRuntimeSeconds: Number(process.env.FLY_BUILDER_MAX_RUNTIME_SECONDS || 900),
   }
 }
+
+/** Exported for testability — see flyioBuilder.test.ts. */
+export const __test__ = { parseVolumeList }
 
 /**
  * Returns parsed JSON for 2xx-with-body responses, or `undefined` for
@@ -148,60 +174,81 @@ async function flyFetch<T>(
  * The machine self-destructs on exit (`auto_destroy: true`), so there
  * is nothing to clean up unless the caller explicitly cancels.
  *
- * If `FLY_BUILDER_CACHE_VOLUME` is set, the volume is attached at
- * `cacheMountPath` so the builder can reuse dockerd + buildkit state
- * across machines. Fly Volumes are single-attach; if the previous
- * build's machine is still detaching we retry POST /machines with
- * exponential backoff (up to ~60s). Longer than that and we give up
- * — the caller's dispatcher will surface the failure.
+ * If `FLY_BUILDER_CACHE_VOLUME` is set (comma-separated volume id list),
+ * one volume from the pool is attached at `cacheMountPath` so the
+ * builder can reuse dockerd + buildkit state across machines. Fly
+ * Volumes are single-attach; on a 409 "volume busy" we rotate through
+ * the pool on each retry so N concurrent builds land on distinct
+ * volumes instead of serializing on one.
+ *
+ * If `FLY_BUILDER_MAX_RUNTIME_SECONDS` is set (default 900), the spawner
+ * passes the cap through as `AF_BUILD_TIMEOUT_SECONDS` in the machine's
+ * env; `build-fly.sh` enforces it via the `timeout(1)` command so a
+ * runaway build is killed and the Fly machine auto-destroys on exit —
+ * capping the worst-case cost per build.
  */
 export async function spawnFlyBuilder(input: FlySpawnInput): Promise<FlySpawnResult> {
   const cfg = getFlyConfig()
 
-  const baseConfig: Record<string, unknown> = {
-    image: cfg.image,
-    auto_destroy: true,
-    restart: { policy: 'no' as const },
-    guest: {
-      cpu_kind: cfg.cpuKind,
-      cpus: cfg.cpus,
-      memory_mb: cfg.memoryMb,
-    },
-    env: {
-      ...input.env,
-      // Echo mount info into the machine env so build-fly.sh doesn't
-      // have to probe `/proc/mounts` — keeps the shell side simple
-      // and makes the contract obvious: "if AF_CACHE_ROOT is set,
-      // dockerd data-root lives there."
-      ...(cfg.cacheVolumeId ? { AF_CACHE_ROOT: cfg.cacheMountPath } : {}),
-    },
-  }
-
-  if (cfg.cacheVolumeId) {
-    baseConfig.mounts = [
-      {
-        volume: cfg.cacheVolumeId,
-        path: cfg.cacheMountPath,
-      },
-    ]
-  }
-
-  const body = {
-    name: input.name,
-    region: cfg.region,
-    config: baseConfig,
-  }
+  // Randomize starting volume so concurrent spawns from different
+  // API replicas (or webhooks firing in quick succession) don't all
+  // pick pool[0] and collide. Each retry then rotates by +1 in the
+  // pool so we deterministically sweep every slot before giving up.
+  const poolSize = cfg.cacheVolumeIds.length
+  const startIndex = poolSize > 0 ? Math.floor(Math.random() * poolSize) : 0
 
   // Volume-attach race. If the previous builder machine is still in
   // `destroying`/`destroyed` state, its volume attachment lingers for
-  // a few seconds. Fly returns 409 "volume already attached to machine
-  // X" or similar; only cure is to wait. Base backoff: 2,4,8,16,30s,
-  // each scaled by a random [0.75, 1.25] jitter factor so concurrent
-  // pushes (e.g. CI fan-out, queued webhooks) don't synchronize their
-  // retries and re-collide on the same Fly volume slot every time.
+  // a few seconds. Base backoff: 2,4,8,16,30s, each scaled by a random
+  // [0.75, 1.25] jitter factor so concurrent pushes don't synchronize
+  // their retries. With a multi-volume pool we also rotate the chosen
+  // volume on each attempt, so attempt=0 may succeed immediately on a
+  // free slot even if pool[startIndex] was busy.
   const baseDelays = [2000, 4000, 8000, 16000, 30000]
   let lastErr: unknown = null
   for (let attempt = 0; attempt <= baseDelays.length; attempt += 1) {
+    const chosenVolume =
+      poolSize > 0 ? cfg.cacheVolumeIds[(startIndex + attempt) % poolSize] : null
+
+    const baseConfig: Record<string, unknown> = {
+      image: cfg.image,
+      auto_destroy: true,
+      restart: { policy: 'no' as const },
+      guest: {
+        cpu_kind: cfg.cpuKind,
+        cpus: cfg.cpus,
+        memory_mb: cfg.memoryMb,
+      },
+      env: {
+        ...input.env,
+        // Echo mount info into the machine env so build-fly.sh doesn't
+        // have to probe `/proc/mounts` — keeps the shell side simple
+        // and makes the contract obvious: "if AF_CACHE_ROOT is set,
+        // dockerd data-root lives there."
+        ...(chosenVolume ? { AF_CACHE_ROOT: cfg.cacheMountPath } : {}),
+        // Runtime cap enforced inside build-fly.sh via `timeout(1)`.
+        // Kept as a string because Fly's API coerces env values to
+        // strings anyway.
+        AF_BUILD_TIMEOUT_SECONDS: String(cfg.maxRuntimeSeconds),
+      },
+      ...(chosenVolume
+        ? {
+            mounts: [
+              {
+                volume: chosenVolume,
+                path: cfg.cacheMountPath,
+              },
+            ],
+          }
+        : {}),
+    }
+
+    const body = {
+      name: input.name,
+      region: cfg.region,
+      config: baseConfig,
+    }
+
     try {
       const machine = await flyFetch<FlyMachineResponse>(cfg, '/machines', {
         method: 'POST',
@@ -218,7 +265,9 @@ export async function spawnFlyBuilder(input: FlySpawnInput): Promise<FlySpawnRes
           name: machine.name,
           region: machine.region,
           state: machine.state,
-          volume: cfg.cacheVolumeId ?? null,
+          volume: chosenVolume,
+          volumePoolSize: poolSize,
+          maxRuntimeSeconds: cfg.maxRuntimeSeconds,
           attempt,
         },
         'Fly builder machine created',
@@ -227,16 +276,19 @@ export async function spawnFlyBuilder(input: FlySpawnInput): Promise<FlySpawnRes
     } catch (err) {
       lastErr = err
       const msg = err instanceof Error ? err.message : String(err)
+      // Retry only on volume-attach conflicts. When a pool is configured
+      // we always have somewhere else to try; rotating the volume choice
+      // above usually avoids the backoff wait entirely by the second attempt.
       const retryable =
-        cfg.cacheVolumeId !== null &&
+        poolSize > 0 &&
         (msg.includes('volume') || msg.includes('409')) &&
         attempt < baseDelays.length
       if (!retryable) throw err
       const jitter = 0.75 + Math.random() * 0.5 // [0.75, 1.25]
       const delayMs = Math.round(baseDelays[attempt] * jitter)
       log.warn(
-        { attempt, delayMs, err: msg },
-        'Fly machine spawn rejected (volume busy) — retrying',
+        { attempt, delayMs, err: msg, triedVolume: chosenVolume, poolSize },
+        'Fly machine spawn rejected (volume busy) — rotating volume + retrying',
       )
       await new Promise((r) => setTimeout(r, delayMs))
     }


### PR DESCRIPTION
## What

Two reliability improvements to the Fly.io build executor:

**Volume pool (`FLY_BUILDER_CACHE_VOLUME` now comma-separated)**
- `parseVolumeList` parses the env var as a comma-separated list of Fly Volume ids
- `spawnFlyBuilder` picks a random volume per spawn so concurrent builds fan out to distinct slots instead of serializing on one
- On 409 volume-busy, rotates to the next slot in the pool (e.g. attempt 0 → `vol_a`, attempt 1 → `vol_b`) before falling back to jitter+wait, so concurrent builds usually succeed immediately instead of backing off for up to 30s
- To add capacity: `flyctl volumes create … -a af-builders` → add id to `FLY_BUILDER_CACHE_VOLUME` → prime with `admin/cloud/scripts/prime-fly-cache.sh --volume <id>` → roll configmap

**Build timeout (`FLY_BUILDER_MAX_RUNTIME_SECONDS`, default 900)**
- Passed as `AF_BUILD_TIMEOUT_SECONDS` env var into every spawned Fly Machine
- `build-fly.sh` enforces via `timeout(1)` — on expiry the wrapper posts a clean FAILED callback and exits, so `auto_destroy: true` reaps the VM
- Previously a runaway build (infinite loop in user's build script, OOM thrash) would run until manually killed; the two staging zombies in Apr 21 consumed 85% of our total Fly spend to that point

## Tests
