### PR TITLE
enforce membership-based authz on every install-touching resolver

### DIFF
--- a/src/resolvers/github.ts
+++ b/src/resolvers/github.ts
@@ -128,6 +128,65 @@ function normalizeShellCommand(
   return trimmed
 }
 
+/**
+ * Throws unless the caller is a member of the AF org that owns the
+ * given GitHub installation.
+ *
+ * Use this on every read/mutation that derives data from (or attaches
+ * downstream resources to) a `GithubInstallation` row. The row's
+ * `organizationId` is the only authoritative tenant boundary —
+ * `context.organizationId` (header-derived) cannot be trusted for
+ * GitHub-related authz because:
+ *
+ *   1. Many legitimate code paths don't set `X-Organization-Id`
+ *      (web-app's `services/github/actions.ts`, CLI, PAT users).
+ *      Falsy `context.organizationId` previously short-circuited the
+ *      check `if (context.organizationId && install.organizationId !== context.organizationId)`,
+ *      letting any authenticated user fetch any install's repos.
+ *   2. `githubInstallations(orgId: X)` historically returned the
+ *      install's local cuid id without verifying the caller's org
+ *      membership, giving an attacker the cuid needed to call
+ *      `githubInstallationRepos`.
+ *
+ * Combining (1) and (2) gave a fully-closed exploit chain. This helper
+ * shuts both halves: every GitHub resolver derives the required org
+ * from the install row itself and verifies membership against
+ * `OrganizationMember` directly, ignoring the request header.
+ */
+async function assertInstallationAccess(
+  context: Context,
+  install: { organizationId: string },
+): Promise<void> {
+  const userId = requireAuth(context)
+  const member = await context.prisma.organizationMember.findFirst({
+    where: { organizationId: install.organizationId, userId },
+    select: { id: true },
+  })
+  if (!member) {
+    throw new GraphQLError('not authorized for this GitHub installation', {
+      extensions: { code: 'FORBIDDEN' },
+    })
+  }
+}
+
+/**
+ * Throws unless the caller is a member of the given AF organization.
+ * Lighter-weight cousin of `assertInstallationAccess` for queries that
+ * take an `orgId` arg directly (e.g. `githubInstallations`).
+ */
+async function assertOrgMembership(context: Context, orgId: string): Promise<void> {
+  const userId = requireAuth(context)
+  const member = await context.prisma.organizationMember.findFirst({
+    where: { organizationId: orgId, userId },
+    select: { id: true },
+  })
+  if (!member) {
+    throw new GraphQLError('not a member of this organization', {
+      extensions: { code: 'FORBIDDEN' },
+    })
+  }
+}
+
 function imageTagFor(userId: string, owner: string, repo: string, sha: string): string {
   const cfg = getGithubAppConfig()
   // Docker registry refs MUST be all lowercase. Prisma cuid userIds like
@@ -220,6 +279,10 @@ export const githubQueries = {
     assertGithubConfigured()
     const orgId = args.orgId || context.organizationId
     if (!orgId) throw new GraphQLError('orgId required')
+    // Without this membership check, any authenticated user could pass
+    // an arbitrary `orgId` and enumerate every GithubInstallation row
+    // (including the local cuid used as input to githubInstallationRepos).
+    await assertOrgMembership(context, orgId)
     return context.prisma.githubInstallation.findMany({
       where: { organizationId: orgId },
       orderBy: { createdAt: 'desc' },
@@ -237,9 +300,9 @@ export const githubQueries = {
       where: { id: args.installationId },
     })
     if (!install) throw new GraphQLError('installation not found')
-    if (context.organizationId && install.organizationId !== context.organizationId) {
-      throw new GraphQLError('not authorized', { extensions: { code: 'FORBIDDEN' } })
-    }
+    // Authoritative tenant boundary is the install row itself, not
+    // the caller's request header — see assertInstallationAccess docs.
+    await assertInstallationAccess(context, install)
     const repos = await listInstallationRepos(install.installationId)
     return repos.map((r) => ({
       id: String(r.id),
@@ -266,9 +329,7 @@ export const githubQueries = {
       where: { id: args.installationId },
     })
     if (!install) throw new GraphQLError('installation not found')
-    if (context.organizationId && install.organizationId !== context.organizationId) {
-      throw new GraphQLError('not authorized', { extensions: { code: 'FORBIDDEN' } })
-    }
+    await assertInstallationAccess(context, install)
     const branches = await listRepoBranches(install.installationId, args.owner, args.repo)
     return branches.map((b) => ({ name: b.name, sha: b.commit.sha, protected: b.protected }))
   },
@@ -605,6 +666,22 @@ export const githubMutations = {
       where: { id: input.installationId },
     })
     if (!install) throw new GraphQLError('installation not found')
+    // Even though `assertProjectAccess` proved the caller owns the
+    // project, that says nothing about whether they're allowed to
+    // attach THIS installation to it. Without this check a caller
+    // could enumerate any install's local cuid (until the
+    // githubInstallations membership check landed in the same diff)
+    // and bridge a victim's GitHub repo into their own project,
+    // triggering a build that pulls private source from GitHub via
+    // the install token. Require the install's org match the
+    // project's org (and the caller be a member of that org).
+    await assertInstallationAccess(context, install)
+    if (install.organizationId !== project.organizationId) {
+      throw new GraphQLError(
+        'GitHub installation belongs to a different organization than this project',
+        { extensions: { code: 'INSTALL_ORG_MISMATCH' } },
+      )
+    }
     if (install.suspendedAt) throw new GraphQLError('installation is suspended on GitHub')
 
     // Confirm the repo + branch are real (live API call)
@@ -723,6 +800,16 @@ export const githubMutations = {
       where: { id: input.installationId },
     })
     if (!install) throw new GraphQLError('installation not found')
+    // Same reasoning as createGithubService — the project ownership
+    // check doesn't authorize the install. Require both: caller is a
+    // member of install's org AND that org owns the project.
+    await assertInstallationAccess(context, install)
+    if (install.organizationId !== service.project.organizationId) {
+      throw new GraphQLError(
+        'GitHub installation belongs to a different organization than this service',
+        { extensions: { code: 'INSTALL_ORG_MISMATCH' } },
+      )
+    }
     if (install.suspendedAt) throw new GraphQLError('installation is suspended on GitHub')
 
     const repo = await getRepo(install.installationId, input.owner, input.repo)

--- a/src/resolvers/github.ts
+++ b/src/resolvers/github.ts
@@ -28,7 +28,6 @@ import { createLogger } from '../lib/logger.js'
 import { getGithubAppConfig, isGithubAppConfigured } from '../services/github/config.js'
 import {
   getInstallation,
-  listAllInstallations,
   listInstallationRepos,
   listRepoBranches,
   getRepo,
@@ -429,13 +428,40 @@ export const githubMutations = {
     const orgId = args.orgId || context.organizationId
     if (!orgId) throw new GraphQLError('orgId required')
 
-    // Verify ownership of the org
     const member = await context.prisma.organizationMember.findFirst({
       where: { organizationId: orgId, userId },
     })
     if (!member) throw new GraphQLError('not a member of this org', { extensions: { code: 'FORBIDDEN' } })
 
     const installIdNum = BigInt(args.installationId)
+
+    // Tenant-ownership check: if a row already exists for this
+    // installationId, it can only be (re-)synced by its owning org.
+    // The previous upsert-by-installationId would silently run the
+    // `update` branch and return the row to the caller — exposing
+    // the install's account metadata even though downstream
+    // resolvers (githubInstallationRepos etc.) would 403. We now
+    // fail loud instead.
+    const existing = await context.prisma.githubInstallation.findUnique({
+      where: { installationId: installIdNum },
+      select: { id: true, organizationId: true },
+    })
+    if (existing && existing.organizationId !== orgId) {
+      log.warn(
+        {
+          installationId: args.installationId,
+          callingOrgId: orgId,
+          ownedByOrgId: existing.organizationId,
+          userId,
+        },
+        'syncGithubInstallation refused: install already owned by another tenant',
+      )
+      throw new GraphQLError(
+        'this GitHub installation is already connected to a different AlternateFutures organization',
+        { extensions: { code: 'INSTALL_OWNED_BY_OTHER_ORG' } },
+      )
+    }
+
     const meta = await getInstallation(installIdNum)
 
     return context.prisma.githubInstallation.upsert({
@@ -461,60 +487,76 @@ export const githubMutations = {
   },
 
   /**
-   * Live-sync ALL App installations from GitHub into the local DB and
-   * return the org's installations after the sync. Slow path (one
-   * /app/installations call + N upserts) — only invoked by the UI's
-   * "Refresh" button or after the user installs the App in a popup.
-   * The plain `githubInstallations` query stays a pure DB read.
+   * Re-sync **the caller's own** installations' metadata from GitHub.
+   *
+   * History: this mutation used to call `listAllInstallations()` (which
+   * returns every install of the App across ALL of GitHub, via the App
+   * JWT) and then upsert every row with `organizationId = caller's org`.
+   * That made the **first AF tenant to hit Refresh** silently claim
+   * every installation in the world into their tenant — a critical
+   * multi-tenant data leak the moment the App went public on
+   * 2026-04-22.
+   *
+   * Fixed shape:
+   *  1. Read the caller org's existing installations from the DB.
+   *  2. For each, hit `GET /app/installations/{id}` to refresh metadata
+   *     (suspended_at, repository_selection, account rename, etc.).
+   *  3. Never create a new row here. New installs are claimed exactly
+   *     once, by `syncGithubInstallation`, which is called from the
+   *     post-install setup_url hook with the exact install_id GitHub
+   *     redirected with. That path verifies org membership and uses
+   *     `installationId` as the unique key, so an installation can
+   *     only be claimed by one AF tenant for its lifetime.
+   *
+   * If you need to re-discover installs that are known to GitHub but
+   * missing locally (e.g. webhook delivery failed), the intended UX is
+   * to have the user click "Install" again — GitHub routes them to the
+   * configure page, which triggers a fresh setup_url redirect and
+   * therefore a fresh `syncGithubInstallation` call.
    */
   refreshGithubInstallations: async (
     _: unknown,
     args: { orgId?: string },
     context: Context,
   ) => {
-    const userId = requireAuth(context)
+    requireAuth(context)
     assertGithubConfigured()
     const orgId = args.orgId || context.organizationId
     if (!orgId) throw new GraphQLError('orgId required')
 
-    try {
-      const live = await listAllInstallations()
-      for (const inst of live) {
-        const accountLogin = inst.account?.login ?? 'unknown'
-        const accountId = BigInt(inst.account?.id ?? 0)
-        const accountType = inst.account?.type ?? 'User'
-        const targetType = inst.repository_selection === 'selected' ? 'selected' : 'all'
-        const suspendedAt = inst.suspended_at ? new Date(inst.suspended_at) : null
-        await context.prisma.githubInstallation.upsert({
-          where: { installationId: BigInt(inst.id) },
-          create: {
-            installationId: BigInt(inst.id),
-            organizationId: orgId,
-            installedByUserId: userId,
-            accountLogin,
-            accountId,
-            accountType,
-            targetType,
-            suspendedAt,
-          },
-          update: {
-            accountLogin,
-            accountId,
-            accountType,
-            targetType,
-            suspendedAt,
-          },
-        })
-      }
-    } catch (err) {
-      log.warn(
-        { err: err instanceof Error ? err.message : String(err) },
-        'live installation sync failed',
-      )
-      throw new GraphQLError('failed to sync installations from GitHub', {
-        extensions: { code: 'GITHUB_SYNC_FAILED' },
-      })
-    }
+    const owned = await context.prisma.githubInstallation.findMany({
+      where: { organizationId: orgId },
+      select: { id: true, installationId: true },
+    })
+
+    await Promise.all(
+      owned.map(async (row) => {
+        try {
+          const meta = await getInstallation(row.installationId)
+          await context.prisma.githubInstallation.update({
+            where: { id: row.id },
+            data: {
+              accountLogin: meta.account.login,
+              accountId: BigInt(meta.account.id),
+              accountType: meta.account.type,
+              targetType: meta.repository_selection,
+              suspendedAt: meta.suspended_at ? new Date(meta.suspended_at) : null,
+            },
+          })
+        } catch (err) {
+          // Per-row failure is expected (install deleted out-of-band,
+          // transient GitHub 5xx, etc.). Log + move on; caller still
+          // gets the DB view below.
+          log.warn(
+            {
+              installationId: String(row.installationId),
+              err: err instanceof Error ? err.message : String(err),
+            },
+            'per-installation refresh failed',
+          )
+        }
+      }),
+    )
 
     return context.prisma.githubInstallation.findMany({
       where: { organizationId: orgId },


### PR DESCRIPTION
cd service-cloud-api
git add src/resolvers/github.ts
git commit -m "$(cat <<'EOF'
fix(github): enforce membership-based authz on every install-touching resolver

Audit after the v1 cross-tenant claim fix surfaced three further
holes in the GitHub GraphQL surface:

  1. githubInstallations(orgId) had no membership check at all. Any
     authenticated user could pass an arbitrary orgId and enumerate
     every GithubInstallation row for that org — including the local
     cuid id used as the input to githubInstallationRepos.

  2. githubInstallationRepos(installationId) and githubRepoBranches(...)
     gated only via `if (context.organizationId && install.organizationId
     !== context.organizationId)`. When `context.organizationId` was
     undefined (PAT users, CLI, or any caller that didn't send
     X-Organization-Id — which includes web-app's own
     services/github/actions.ts), the check was skipped entirely and
     the resolver fetched repo data from GitHub using the install
     token. Combined with (1) this was a fully-closed exploit chain
     for reading any install's repo list / branches once the GitHub
     App went public on 2026-04-22.

  3. createGithubService and connectGithubRepo verified project
     ownership but did not verify that the supplied installationId
     belonged to the same org as the project. A caller with their
     own project could attach a victim's install (cuid obtained via
     #1) and trigger a builder Job that pulls the victim's private
     source via the install token, producing a GHCR image owned by
     the attacker.

This commit:
  - Adds assertOrgMembership(context, orgId) and
    assertInstallationAccess(context, install) helpers that derive
    the required org from the install row itself and verify
    membership against OrganizationMember directly. Header-derived
    context.organizationId is no longer the tenant boundary for
    GitHub authz — the install row is.
  - Applies the helpers to all five install-touching resolvers
    (queries + the two attach mutations). redeployGithubService is
    unchanged because it derives the install from the previously-
    attached service.gitInstallation, which the create/connect
    paths now guarantee belongs to the same org.
  - Adds INSTALL_ORG_MISMATCH error code for create/connect when
    install.organizationId !== project.organizationId.

Live prod DB audit before patching: 1 row (alternatefutures install
on the only AF org). No historical contamination — the v1 bug was
latent because the App was private until 2026-04-22 ~17:00.

No schema changes.
EOF
)"