### PR TITLE
fix: stream logs for non-ACTIVE deployments #230

### DIFF
--- a/src/services/logs/logStreamEndpoint.test.ts
+++ b/src/services/logs/logStreamEndpoint.test.ts
@@ -459,3 +459,162 @@ describe('LogStreamEndpoint — CORS headers on 200 SSE response', () => {
     expect(res.headers?.['Access-Control-Allow-Origin']).toBeUndefined()
   })
 })
+
+// ---------------------------------------------------------------------------
+// pickLogEligibleDeployment — issue #230
+// ---------------------------------------------------------------------------
+
+/**
+ * A Prisma stub where each findFirst call pops from a pre-seeded queue.
+ * This lets tests control the two-pass query sequence precisely:
+ *   call 1 → ACTIVE-only query
+ *   call 2 → broader log-eligible query
+ */
+function makePrismaQueued(
+  akashResults: (null | { id: string })[],
+  phalaResults: (null | { id: string })[] = []
+): any {
+  const akashQueue = [...akashResults]
+  const phalaQueue = [...phalaResults]
+  return {
+    akashDeployment: {
+      findFirst: vi.fn(() => Promise.resolve(akashQueue.shift() ?? null)),
+    },
+    phalaDeployment: {
+      findFirst: vi.fn(() => Promise.resolve(phalaQueue.shift() ?? null)),
+    },
+  }
+}
+
+describe('LogStreamEndpoint — pickLogEligibleDeployment (issue #230)', () => {
+  afterEach(() => {
+    delete process.env.APP_URL
+  })
+
+  // Each test uses a unique userId so module-level activeStreams from earlier
+  // CORS tests (also userId 'user-1') don't push us over MAX_STREAMS_PER_USER.
+
+  it('(a) streams successfully for a FAILED Akash deployment', async () => {
+    // Pass 1 (ACTIVE query) → null; Pass 2 (broader) → FAILED deployment
+    const prisma = makePrismaQueued([null, { id: 'depl-failed' }])
+    const stream = makeStream()
+    const mockProvider = {
+      displayName: 'Akash',
+      getCapabilities: () => ({ supportsLogStreaming: true }),
+      streamLogs: vi.fn().mockResolvedValue(stream),
+    }
+    const access = { ...makeSuccessAccess(), userId: 'user-230a' }
+
+    const endpoint = new LogStreamEndpoint(prisma, 'test-secret', {
+      authorize: vi.fn().mockResolvedValue(access),
+      resolveProvider: vi.fn().mockReturnValue(mockProvider),
+      emitAudit: vi.fn(),
+    })
+
+    const req = makeReq()
+    const res = makeRes()
+    await endpoint.handle(
+      req as IncomingMessage,
+      res as unknown as ServerResponse,
+      'svc-123'
+    )
+
+    expect(res.statusCode).toBe(200)
+    const written = (res.write as ReturnType<typeof vi.fn>).mock.calls
+      .map(c => c[0] as string)
+      .join('')
+    expect(written).toContain('event: ready')
+    expect(written).toContain('depl-failed')
+  })
+
+  it('(b) streams successfully for a DEPLOYING Akash deployment', async () => {
+    // Pass 1 → null; Pass 2 → DEPLOYING deployment
+    const prisma = makePrismaQueued([null, { id: 'depl-deploying' }])
+    const stream = makeStream()
+    const mockProvider = {
+      displayName: 'Akash',
+      getCapabilities: () => ({ supportsLogStreaming: true }),
+      streamLogs: vi.fn().mockResolvedValue(stream),
+    }
+    const access = { ...makeSuccessAccess(), userId: 'user-230b' }
+
+    const endpoint = new LogStreamEndpoint(prisma, 'test-secret', {
+      authorize: vi.fn().mockResolvedValue(access),
+      resolveProvider: vi.fn().mockReturnValue(mockProvider),
+      emitAudit: vi.fn(),
+    })
+
+    const req = makeReq()
+    const res = makeRes()
+    await endpoint.handle(
+      req as IncomingMessage,
+      res as unknown as ServerResponse,
+      'svc-123'
+    )
+
+    expect(res.statusCode).toBe(200)
+    const written = (res.write as ReturnType<typeof vi.fn>).mock.calls
+      .map(c => c[0] as string)
+      .join('')
+    expect(written).toContain('event: ready')
+    expect(written).toContain('depl-deploying')
+  })
+
+  it('(c) ACTIVE deployment wins over a more-recent FAILED (tiebreaker)', async () => {
+    // Pass 1 returns ACTIVE immediately — Pass 2 is never reached
+    const prisma = makePrismaQueued([{ id: 'depl-active' }])
+    const stream = makeStream()
+    const mockProvider = {
+      displayName: 'Akash',
+      getCapabilities: () => ({ supportsLogStreaming: true }),
+      streamLogs: vi.fn().mockResolvedValue(stream),
+    }
+    const access = { ...makeSuccessAccess(), userId: 'user-230c' }
+
+    const endpoint = new LogStreamEndpoint(prisma, 'test-secret', {
+      authorize: vi.fn().mockResolvedValue(access),
+      resolveProvider: vi.fn().mockReturnValue(mockProvider),
+      emitAudit: vi.fn(),
+    })
+
+    const req = makeReq()
+    const res = makeRes()
+    await endpoint.handle(
+      req as IncomingMessage,
+      res as unknown as ServerResponse,
+      'svc-123'
+    )
+
+    expect(res.statusCode).toBe(200)
+    const written = (res.write as ReturnType<typeof vi.fn>).mock.calls
+      .map(c => c[0] as string)
+      .join('')
+    expect(written).toContain('depl-active')
+    expect(written).not.toContain('depl-failed')
+    // Only one Akash findFirst call was needed (ACTIVE found on Pass 1)
+    expect(prisma.akashDeployment.findFirst).toHaveBeenCalledTimes(1)
+  })
+
+  it('(d) CLOSED/DELETED deployment returns 404 with updated message', async () => {
+    // Both passes return null for both providers — no log-eligible deployment
+    const prisma = makePrismaQueued([null, null], [null, null])
+    const access = { ...makeSuccessAccess(), userId: 'user-230d' }
+
+    const endpoint = new LogStreamEndpoint(prisma, 'test-secret', {
+      authorize: vi.fn().mockResolvedValue(access),
+      resolveProvider: vi.fn(),
+      emitAudit: vi.fn(),
+    })
+
+    const req = makeReq()
+    const res = makeRes()
+    await endpoint.handle(
+      req as IncomingMessage,
+      res as unknown as ServerResponse,
+      'svc-123'
+    )
+
+    expect(res.statusCode).toBe(404)
+    expect(res.body).toContain('No log-eligible deployment found for this service')
+  })
+})

--- a/src/services/logs/logStreamEndpoint.ts
+++ b/src/services/logs/logStreamEndpoint.ts
@@ -34,6 +34,7 @@
 
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { PrismaClient } from '@prisma/client'
+import { AkashDeploymentStatus, PhalaDeploymentStatus } from '@prisma/client'
 import { authorizeServiceAccess } from '../auth/serviceAccess.js'
 import { getProvider } from '../providers/registry.js'
 import type { LogStream } from '../providers/types.js'
@@ -159,22 +160,22 @@ function endError(
   res.end(JSON.stringify({ error: message }))
 }
 
-const AKASH_LOG_ELIGIBLE_STATUSES = [
-  'ACTIVE',
-  'DEPLOYING',
-  'SENDING_MANIFEST',
-  'CREATING_LEASE',
-  'FAILED',
-  'SUSPENDED',
-  'PERMANENTLY_FAILED',
-] as const
+const AKASH_LOG_ELIGIBLE_STATUSES: AkashDeploymentStatus[] = [
+  AkashDeploymentStatus.ACTIVE,
+  AkashDeploymentStatus.DEPLOYING,
+  AkashDeploymentStatus.SENDING_MANIFEST,
+  AkashDeploymentStatus.CREATING_LEASE,
+  AkashDeploymentStatus.FAILED,
+  AkashDeploymentStatus.SUSPENDED,
+  AkashDeploymentStatus.PERMANENTLY_FAILED,
+]
 
-const PHALA_LOG_ELIGIBLE_STATUSES = [
-  'ACTIVE',
-  'STARTING',
-  'FAILED',
-  'PERMANENTLY_FAILED',
-] as const
+const PHALA_LOG_ELIGIBLE_STATUSES: PhalaDeploymentStatus[] = [
+  PhalaDeploymentStatus.ACTIVE,
+  PhalaDeploymentStatus.STARTING,
+  PhalaDeploymentStatus.FAILED,
+  PhalaDeploymentStatus.PERMANENTLY_FAILED,
+]
 
 async function pickLogEligibleDeployment(
   prisma: PrismaClient,
@@ -199,7 +200,7 @@ async function pickLogEligibleDeployment(
   const akash = await prisma.akashDeployment.findFirst({
     where: {
       serviceId,
-      status: { in: AKASH_LOG_ELIGIBLE_STATUSES as unknown as string[] },
+      status: { in: AKASH_LOG_ELIGIBLE_STATUSES },
     },
     orderBy: { createdAt: 'desc' },
     select: { id: true },
@@ -209,7 +210,7 @@ async function pickLogEligibleDeployment(
   const phala = await prisma.phalaDeployment.findFirst({
     where: {
       serviceId,
-      status: { in: PHALA_LOG_ELIGIBLE_STATUSES as unknown as string[] },
+      status: { in: PHALA_LOG_ELIGIBLE_STATUSES },
     },
     orderBy: { createdAt: 'desc' },
     select: { id: true },

--- a/src/services/logs/logStreamEndpoint.ts
+++ b/src/services/logs/logStreamEndpoint.ts
@@ -159,23 +159,63 @@ function endError(
   res.end(JSON.stringify({ error: message }))
 }
 
-async function pickActiveDeployment(
+const AKASH_LOG_ELIGIBLE_STATUSES = [
+  'ACTIVE',
+  'DEPLOYING',
+  'SENDING_MANIFEST',
+  'CREATING_LEASE',
+  'FAILED',
+  'SUSPENDED',
+  'PERMANENTLY_FAILED',
+] as const
+
+const PHALA_LOG_ELIGIBLE_STATUSES = [
+  'ACTIVE',
+  'STARTING',
+  'FAILED',
+  'PERMANENTLY_FAILED',
+] as const
+
+async function pickLogEligibleDeployment(
   prisma: PrismaClient,
   serviceId: string
 ): Promise<{ deploymentId: string; provider: 'akash' | 'phala' } | null> {
-  const akash = await prisma.akashDeployment.findFirst({
+  // Pass 1: prefer ACTIVE deployments (tiebreaker — healthy beats stale/failed)
+  const akashActive = await prisma.akashDeployment.findFirst({
     where: { serviceId, status: 'ACTIVE' },
+    orderBy: { createdAt: 'desc' },
+    select: { id: true },
+  })
+  if (akashActive) return { deploymentId: akashActive.id, provider: 'akash' }
+
+  const phalaActive = await prisma.phalaDeployment.findFirst({
+    where: { serviceId, status: 'ACTIVE' },
+    orderBy: { createdAt: 'desc' },
+    select: { id: true },
+  })
+  if (phalaActive) return { deploymentId: phalaActive.id, provider: 'phala' }
+
+  // Pass 2: fall back to any log-eligible deployment (has a lease, can be tailed)
+  const akash = await prisma.akashDeployment.findFirst({
+    where: {
+      serviceId,
+      status: { in: AKASH_LOG_ELIGIBLE_STATUSES as unknown as string[] },
+    },
     orderBy: { createdAt: 'desc' },
     select: { id: true },
   })
   if (akash) return { deploymentId: akash.id, provider: 'akash' }
 
   const phala = await prisma.phalaDeployment.findFirst({
-    where: { serviceId, status: 'ACTIVE' },
+    where: {
+      serviceId,
+      status: { in: PHALA_LOG_ELIGIBLE_STATUSES as unknown as string[] },
+    },
     orderBy: { createdAt: 'desc' },
     select: { id: true },
   })
   if (phala) return { deploymentId: phala.id, provider: 'phala' }
+
   return null
 }
 
@@ -275,9 +315,9 @@ export class LogStreamEndpoint {
     const logServiceFilter =
       sdlServiceOverride || access.service.sdlServiceName || undefined
 
-    const target = await pickActiveDeployment(this.prisma, deploymentServiceId)
+    const target = await pickLogEligibleDeployment(this.prisma, deploymentServiceId)
     if (!target) {
-      endError(req, res, 404, 'No active deployment found for this service')
+      endError(req, res, 404, 'No log-eligible deployment found for this service')
       return
     }
 


### PR DESCRIPTION
## Summary

- Rename `pickActiveDeployment` → `pickLogEligibleDeployment` in `src/services/logs/logStreamEndpoint.ts`
- Broaden the SSE log stream status filter to all states that have a live or reachable lease (DEPLOYING, SENDING_MANIFEST, CREATING_LEASE, FAILED, SUSPENDED, PERMANENTLY_FAILED for Akash; STARTING, FAILED, PERMANENTLY_FAILED for Phala)
- Two-pass tiebreaker: ACTIVE is always preferred; fall back to the broader set ordered by `createdAt desc`
- Update 404 message: `'No active deployment found'` → `'No log-eligible deployment found for this service'`
- Add 4 new tests covering the non-ACTIVE paths and tiebreaker

## Test plan

- [x] `pnpm test src/services/logs/logStreamEndpoint.test.ts` — 26 tests, all passing
- [x] `pnpm lint` — pre-existing ESLint infrastructure failure (AJV `defaultMeta` crash), confirmed on `main` before this branch, unrelated to these changes
- [ ] Manual smoke test: trigger a FAILED/DEPLOYING deployment and verify the Logs tab now streams instead of 404ing

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)