### PR TITLE
fix: skip signedBy auditor filter for GPU custom Docker deployments

### DIFF
--- a/src/services/akash/buildCustomDockerPlacementBlock.test.ts
+++ b/src/services/akash/buildCustomDockerPlacementBlock.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { buildCustomDockerPlacementBlock } from './orchestrator.js'
+
+/**
+ * Regression tests for issue #233:
+ *   "RTX 4060 shows 1 provider / $0.00 but deploys fail with
+ *    'No bids received within timeout'"
+ *
+ * Root cause: generateCustomDockerSDL always included the `signedBy`
+ * auditor filter, even for GPU deployments. The bid probe (probeBidSdl.ts)
+ * uses `placement: any` with NO signedBy filter — so a non-audited GPU
+ * provider (common for less-popular models like RTX 4060) would bid on the
+ * probe, appear in the UI, but then be excluded by signedBy on the real
+ * deployment SDL. Result: 0 bids → timeout.
+ *
+ * The fix mirrors the identical conditional in generateSDLFromTemplate
+ * (src/templates/sdl.ts): omit signedBy when the deployment uses GPU.
+ */
+describe('buildCustomDockerPlacementBlock — signedBy conditional (issue #233)', () => {
+  const AUDITOR = 'akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63'
+
+  it('omits signedBy for GPU deployments so non-audited providers can bid', () => {
+    const block = buildCustomDockerPlacementBlock('my-gpu-svc', true, 1_000_000)
+    expect(block).not.toContain('signedBy')
+    expect(block).not.toContain(AUDITOR)
+  })
+
+  it('includes signedBy for non-GPU deployments', () => {
+    const block = buildCustomDockerPlacementBlock('my-web-svc', false, 1_000)
+    expect(block).toContain('signedBy')
+    expect(block).toContain(AUDITOR)
+  })
+
+  it('emits the correct denom and amount for GPU', () => {
+    const block = buildCustomDockerPlacementBlock('svc', true, 1_000_000)
+    expect(block).toContain('denom: uact')
+    expect(block).toContain('amount: 1000000')
+  })
+
+  it('emits the correct denom and amount for non-GPU', () => {
+    const block = buildCustomDockerPlacementBlock('svc', false, 1_000)
+    expect(block).toContain('denom: uact')
+    expect(block).toContain('amount: 1000')
+  })
+
+  it('uses the provided service name in the pricing block', () => {
+    const block = buildCustomDockerPlacementBlock('rtx4060-svc', true, 1_000_000)
+    expect(block).toContain('rtx4060-svc:')
+  })
+
+  it('produces valid YAML indentation with signedBy (non-GPU)', () => {
+    const block = buildCustomDockerPlacementBlock('svc', false, 500)
+    // signedBy must be a child of dcloud (6-space indent)
+    expect(block).toContain('      signedBy:')
+    // anyOf must be a child of signedBy (8-space indent)
+    expect(block).toContain('        anyOf:')
+    // auditor entry must be under anyOf (10-space indent)
+    expect(block).toContain(`          - ${AUDITOR}`)
+  })
+
+  it('produces valid YAML indentation without signedBy (GPU)', () => {
+    const block = buildCustomDockerPlacementBlock('svc', true, 1_000_000)
+    // pricing must be a direct child of dcloud (6-space indent)
+    expect(block).toContain('      pricing:')
+  })
+})

--- a/src/services/akash/orchestrator.ts
+++ b/src/services/akash/orchestrator.ts
@@ -482,6 +482,41 @@ export function buildGhcrCredentialsBlock(image: string): string {
 }
 
 /**
+ * Build the placement block for a custom-Docker SDL.
+ *
+ * GPU deployments skip the `signedBy` auditor filter because many GPU
+ * providers (especially those offering less-common models like RTX 4060)
+ * are not on the Akash auditor list. Including the filter caused the
+ * following failure mode: the bid probe (which has NO signedBy filter)
+ * recorded the provider and surfaced it in the UI, but the real
+ * deployment SDL silently excluded the same provider — producing the
+ * "1 provider shown, $0.00, No bids received within timeout" bug.
+ *
+ * This mirrors the identical conditional in `generateSDLFromTemplate`
+ * (src/templates/sdl.ts) and must stay in sync with it.
+ *
+ * Exported for unit testing; not part of the public API surface.
+ */
+export function buildCustomDockerPlacementBlock(
+  serviceName: string,
+  hasGpu: boolean,
+  pricingUact: number
+): string {
+  const signedByLines = hasGpu
+    ? ''
+    : `
+      signedBy:
+        anyOf:
+          - akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63`
+  return `  placement:
+    dcloud:${signedByLines}
+      pricing:
+        ${serviceName}:
+          denom: uact
+          amount: ${pricingUact}`
+}
+
+/**
  * Bounded TTL map so the GHCR_PUSH_TOKEN fallback warning doesn't spam logs
  * AND doesn't grow unbounded across many image refs in long-running
  * processes. Values are timestamps (ms epoch) of the last warn for that key.
@@ -1745,15 +1780,7 @@ profiles:
           size: ${memory}
 ${storageProfile}${gpuBlock}
 
-  placement:
-    dcloud:
-      signedBy:
-        anyOf:
-          - akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63
-      pricing:
-        ${name}:
-          denom: uact
-          amount: ${resolveSdlPricingUact(!!(gpu && gpu.units > 0))}
+${buildCustomDockerPlacementBlock(name, !!(gpu && gpu.units > 0), resolveSdlPricingUact(!!(gpu && gpu.units > 0)))}
 
 deployment:
   ${name}:


### PR DESCRIPTION
## Summary

- **Root cause of #233**: `generateCustomDockerSDL` always included the `signedBy` auditor filter, even for GPU deployments
- The bid probe SDL (`probeBidSdl.ts`) has **no** `signedBy` filter — so a non-audited GPU provider (e.g. an RTX 4060 operator) bidded on the probe, appeared in the UI as "1 provider / $0.00", but was then silently excluded by `signedBy` on the real deployment SDL
- Result: 0 bids → timeout → "No bids received within timeout"

**Fix**: Extract `buildCustomDockerPlacementBlock()` helper (exported, tested) that omits `signedBy` when `hasGpu=true`. This mirrors the identical conditional already present in `generateSDLFromTemplate` (`src/templates/sdl.ts:149`), which correctly omits `signedBy` for GPU deploys with a comment explaining why.

## Changes

- `src/services/akash/orchestrator.ts`: extract `buildCustomDockerPlacementBlock()` as an exported pure function; use it in `generateCustomDockerSDL`. GPU path emits no `signedBy`; non-GPU path keeps the auditor filter.
- `src/services/akash/buildCustomDockerPlacementBlock.test.ts`: 7 regression tests verifying signedBy presence/absence for GPU vs non-GPU, YAML indentation correctness, pricing passthrough.

## Test plan

- [x] `pnpm test src/services/akash/buildCustomDockerPlacementBlock.test.ts` — 7/7 pass
- [ ] Manual: deploy a custom Docker image with `gpu: { units: 1, vendor: 'nvidia', model: 'rtx4060' }` — should now receive bids from non-audited providers
- [ ] Confirm `generateSDLFromTemplate` and `generateCompositeSDL` are unaffected (they have their own logic, not touched here)

## Not addressed in this PR (separate issues if needed)

- Bid timeout calibration for uncommon GPU classes (secondary contributing factor, not needed once signedBy is fixed)
- UI warning when `providerCount=1` + `$0.00` (display improvement, separate concern)

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)