### PR TITLE
feat: add serviceGitHead query for source-differs banner

### DIFF
--- a/src/resolvers/github.ts
+++ b/src/resolvers/github.ts
@@ -329,6 +329,62 @@ export const githubQueries = {
   },
 
   /**
+   * Return the current HEAD SHA of the service's tracked git branch.
+   *
+   * Used by the source-differs banner: the frontend compares this against
+   * `lastBuildSha` to decide whether to show "Source has changed since last
+   * deploy — Redeploy?" on the service Overview panel.
+   *
+   * Returns null for:
+   *   - Non-git services (gitProvider != 'github' or missing install/owner/repo/branch)
+   *   - GitHub App not configured on this server
+   *   - Any GitHub API error (network timeout, 404 if repo/branch deleted, etc.)
+   *
+   * Failing open (null) is intentional: the banner must not block access to the
+   * panel when the API is unreachable. Callers treat null as "unknown".
+   */
+  serviceGitHead: async (
+    _: unknown,
+    args: { serviceId: string },
+    context: Context,
+  ): Promise<string | null> => {
+    requireAuth(context)
+    const service = await context.prisma.service.findUnique({
+      where: { id: args.serviceId },
+      include: { project: true },
+    })
+    if (!service) throw new GraphQLError('service not found')
+    assertProjectAccess(context, service.project)
+    if (
+      service.gitProvider !== 'github' ||
+      !service.gitInstallationId ||
+      !service.gitOwner ||
+      !service.gitRepo ||
+      !service.gitBranch
+    ) {
+      return null
+    }
+    if (!isGithubAppConfigured()) return null
+    const install = await context.prisma.githubInstallation.findUnique({
+      where: { id: service.gitInstallationId },
+      select: { installationId: true },
+    })
+    if (!install) return null
+    try {
+      const commit = await getCommit(
+        install.installationId,
+        service.gitOwner,
+        service.gitRepo,
+        service.gitBranch,
+      )
+      return commit.sha
+    } catch {
+      // GitHub API unreachable, repo deleted, branch deleted, etc.
+      return null
+    }
+  },
+
+  /**
    * Pure DB read — fast (<10ms). The picker mounts on every panel open
    * and we used to live-sync to GitHub here, which on a cold module
    * load (tsx-watch + jsonwebtoken + GitHub TLS + sequential upserts)

--- a/src/schema/typeDefs.ts
+++ b/src/schema/typeDefs.ts
@@ -2282,6 +2282,8 @@ export const typeDefs = /* GraphQL */ `
     buildJob(id: ID!): BuildJob
     """List recent BuildJobs for a service, newest first. Logs blob omitted — fetch it via buildJob(id) on demand. Used by the Source-tab build-history list (polled every 3s while a build is in flight)."""
     serviceBuildJobs(serviceId: ID!, limit: Int): [BuildJob!]!
+    """Return the current HEAD SHA of the service's tracked git branch (null for non-git services or when the GitHub App is unavailable). Used by the source-differs banner to compare against lastBuildSha."""
+    serviceGitHead(serviceId: ID!): String
   }
 
   extend type Mutation {


### PR DESCRIPTION
## Summary

- Add `serviceGitHead(serviceId: ID!): String` GraphQL query to `typeDefs.ts`
- Add the resolver to `githubQueries` in `resolvers/github.ts`

The query fetches the current HEAD SHA of a GitHub-sourced service's tracked branch via the existing `getCommit()` GitHub App client. Returns `null` for non-git services, missing config, or any GitHub API error (graceful degradation — the source-differs banner simply won't show if GitHub is unreachable).

Auth-checked: caller must have project access.

This is a targeted, on-demand endpoint (not a field resolver on Service) so that `GET_SERVICE_REGISTRY` doesn't trigger parallel GitHub API calls for every git-sourced service in the registry.

## Test plan

- [x] All 847 existing tests pass (`pnpm test --run`)
- [ ] Manual: open a service panel for a github-sourced service with commits ahead of `lastBuildSha` — banner should appear
- [ ] Manual: open a service panel where HEAD == lastBuildSha — no banner

Part of alternatefutures/web-app.alternatefutures.ai#62

🤖 Generated with [Claude Code](https://claude.com/claude-code)