### PR TITLE
feat: n8n workflow JSON import at deploy time

### DIFF
--- a/prisma/migrations/20260428000000_add_service_workflow_json/migration.sql
+++ b/prisma/migrations/20260428000000_add_service_workflow_json/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Service" ADD COLUMN "workflowJson" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -261,6 +261,7 @@ model Service {
   flavor           String? // Create-time discriminator: 'docker' | 'server' | 'function' | 'template'. Null = legacy row. Immutable post-creation. (Phase 39)
   containerPort    Int? // Port the container listens on (default: 80). Used in SDL generation.
   volumes          Json? // Persistent volumes for raw Docker images: Array<{ name: string; mountPath: string; size: string }>. Templates use template.persistentStorage instead. (Phase 38)
+  workflowJson     Json? // n8n only: imported workflow definition. Stored for reference; base64-encoded as N8N_IMPORT_WORKFLOW_B64 env var and run via `n8n import:workflow` on first boot.
   healthProbe      Json? // Optional application HTTP health probe: { path: string; port?: number; expectStatus?: number; intervalSec?: number; timeoutSec?: number }. (Phase 42)
   failoverPolicy   Json? // Optional health-aware auto-failover policy: { enabled: boolean; maxAttempts?: number; windowHours?: number }. Defaults applied at runtime when null. (Phase 43)
   internalHostname String? // Deterministic hostname: {slug}.{project-slug}.internal

--- a/src/resolvers/akash.ts
+++ b/src/resolvers/akash.ts
@@ -290,7 +290,7 @@ export const akashMutations = {
    */
   deployToAkash: async (
     _: unknown,
-    { input }: { input: { serviceId: string; depositUakt?: number; sdlContent?: string; sourceCode?: string; policy?: DeploymentPolicyInput; resourceOverrides?: { cpu?: number; memory?: string; storage?: string; gpu?: { units: number; vendor: string; model?: string } | null }; baseImage?: string } },
+    { input }: { input: { serviceId: string; depositUakt?: number; sdlContent?: string; sourceCode?: string; policy?: DeploymentPolicyInput; resourceOverrides?: { cpu?: number; memory?: string; storage?: string; gpu?: { units: number; vendor: string; model?: string } | null }; baseImage?: string; workflowJson?: unknown } },
     context: Context
   ) => {
     if (!context.userId) {
@@ -322,6 +322,26 @@ export const akashMutations = {
         data: { sourceCode: input.sourceCode },
       })
       log.info(`Updated function source code for: ${service.afFunction.id}`)
+    }
+
+    // ── Upsert n8n workflow import env var ───────────────────
+    // When workflowJson is provided for an n8n service, store it as
+    // N8N_IMPORT_WORKFLOW_B64.  The existing injectPersistedEnvVars pipeline
+    // picks it up automatically and merges it into the SDL env block.
+    if (input.workflowJson && service.templateId === 'n8n') {
+      const b64 = Buffer.from(JSON.stringify(input.workflowJson)).toString('base64')
+      await context.prisma.serviceEnvVar.upsert({
+        where: {
+          serviceId_key: { serviceId: service.id, key: 'N8N_IMPORT_WORKFLOW_B64' },
+        },
+        update: { value: b64 },
+        create: { serviceId: service.id, key: 'N8N_IMPORT_WORKFLOW_B64', value: b64, secret: false },
+      })
+      await context.prisma.service.update({
+        where: { id: service.id },
+        data: { workflowJson: JSON.parse(JSON.stringify(input.workflowJson)) },
+      })
+      log.info(`Upserted n8n workflow import for service: ${service.id}`)
     }
 
     // ── Validate and create deployment policy ────────────────

--- a/src/resolvers/templates.ts
+++ b/src/resolvers/templates.ts
@@ -342,6 +342,7 @@ export const templateMutations = {
           gpu?: { units: number; vendor: string; model?: string } | null
         }
         policy?: DeploymentPolicyInput
+        workflowJson?: unknown
       }
     },
     context: Context
@@ -400,6 +401,7 @@ export const templateMutations = {
         templateId: input.templateId,
         createdByUserId: context.userId ?? null,
         internalHostname: generateInternalHostname(slug, project.slug),
+        workflowJson: input.workflowJson != null ? JSON.parse(JSON.stringify(input.workflowJson)) : null,
       },
     })
 
@@ -417,6 +419,19 @@ export const templateMutations = {
           })
         )
       )
+    }
+
+    // ── Inject workflow import env var for n8n ───────────────
+    if (input.workflowJson && input.templateId === 'n8n') {
+      const b64 = Buffer.from(JSON.stringify(input.workflowJson)).toString('base64')
+      await context.prisma.serviceEnvVar.create({
+        data: {
+          serviceId: service.id,
+          key: 'N8N_IMPORT_WORKFLOW_B64',
+          value: b64,
+          secret: false,
+        },
+      })
     }
     if (template.ports?.length) {
       await context.prisma.$transaction(

--- a/src/schema/typeDefs.ts
+++ b/src/schema/typeDefs.ts
@@ -718,6 +718,10 @@ export const typeDefs = /* GraphQL */ `
     resourceOverrides: ResourceOverrideInput
     # Optional base Docker image for raw services without a template or custom image (e.g. "ubuntu:24.04")
     baseImage: String
+    # n8n only: workflow JSON to import at container startup via the n8n CLI.
+    # Stored as N8N_IMPORT_WORKFLOW_B64 ServiceEnvVar and injected into the SDL at deploy time.
+    # Ignored for all other service types.
+    workflowJson: JSON
   }
 
   """
@@ -1800,6 +1804,10 @@ export const typeDefs = /* GraphQL */ `
     envOverrides: [EnvOverrideInput!]
     resourceOverrides: ResourceOverrideInput
     policy: DeploymentPolicyInput
+    # n8n only: workflow JSON to import at container startup via the n8n CLI.
+    # Stored on the Service record and injected as N8N_IMPORT_WORKFLOW_B64 env var.
+    # Ignored for all other templates.
+    workflowJson: JSON
   }
 
   input ComponentTargetInput {

--- a/src/templates/definitions/n8n.ts
+++ b/src/templates/definitions/n8n.ts
@@ -71,4 +71,10 @@ export const n8nServer: Template = {
     },
   ],
   pricingUakt: 2000,
+  // Import a user-supplied workflow on first boot.
+  // If N8N_IMPORT_WORKFLOW_B64 is set, decode it to a temp file and run
+  // `n8n import:workflow` before starting the server.  When the env var is
+  // absent the command is a no-op and n8n starts normally — no behaviour
+  // change for existing deployments.
+  startCommand: `[ -n "$N8N_IMPORT_WORKFLOW_B64" ] && (printf '%s' "$N8N_IMPORT_WORKFLOW_B64" | base64 -d > /tmp/wf.json && n8n import:workflow --input=/tmp/wf.json); exec n8n start`,
 }


### PR DESCRIPTION
## Summary

- Adds `workflowJson Json?` field to the `Service` Prisma model (migration included)
- Updates `n8n` template definition with a `startCommand` wrapper that decodes `N8N_IMPORT_WORKFLOW_B64` env var, runs `n8n import:workflow --input=/tmp/wf.json`, then `exec n8n start`. No behaviour change when env var is absent.
- Adds `workflowJson: JSON` field to `DeployFromTemplateInput` and `DeployToAkashInput` GraphQL types
- `deployFromTemplate` resolver: stores `workflowJson` on the service and creates a `N8N_IMPORT_WORKFLOW_B64` `ServiceEnvVar` (base64-encoded JSON) when the template is `n8n`
- `deployToAkash` resolver: upserts `N8N_IMPORT_WORKFLOW_B64` when `workflowJson` is supplied at (re)deploy time — the existing `injectPersistedEnvVars` pipeline merges it into the SDL env block automatically

## Test plan

- [ ] All 847 existing tests pass (`pnpm test`)
- [ ] TypeScript build passes (`pnpm build`)
- [ ] Deploy n8n template without `workflowJson` — container starts normally, no import step
- [ ] Deploy n8n template with a valid workflow JSON — container imports the workflow and starts

Part of https://github.com/alternatefutures/web-app.alternatefutures.ai/issues/64

🤖 Generated with [Claude Code](https://claude.com/claude-code)