### PR TITLE
feat: autoDeploy toggle on Service — skip auto-deploy when disabled

### DIFF
--- a/prisma/migrations/20260428120000_add_service_auto_deploy/migration.sql
+++ b/prisma/migrations/20260428120000_add_service_auto_deploy/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable: add autoDeploy flag to Service
+-- Default TRUE so all existing services continue auto-deploying on push.
+ALTER TABLE "Service" ADD COLUMN "autoDeploy" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -291,6 +291,7 @@ model Service {
   lastBuildSha      String? // Most recent built commit SHA
   lastBuildStatus   String? // 'PENDING' | 'RUNNING' | 'SUCCEEDED' | 'FAILED' | 'CANCELED'
   lastBuildAt       DateTime?
+  autoDeploy        Boolean   @default(true) // When false, pushes record lastBuildSha but skip auto-deploy; user deploys manually.
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -1610,6 +1610,7 @@ export const resolvers = {
             maxAttempts?: number
             windowHours?: number
           } | null
+          autoDeploy?: boolean | null
         }
       },
       context: Context
@@ -1656,6 +1657,7 @@ export const resolvers = {
         volumes?: any
         healthProbe?: any
         failoverPolicy?: any
+        autoDeploy?: boolean
       } = {}
 
       if (Object.prototype.hasOwnProperty.call(input, 'dockerImage')) {
@@ -1841,6 +1843,13 @@ export const resolvers = {
         } else {
           throw new GraphQLError('failoverPolicy must be an object with at least { enabled }, or null to clear.')
         }
+      }
+
+      if (Object.prototype.hasOwnProperty.call(input, 'autoDeploy')) {
+        if (typeof input.autoDeploy !== 'boolean') {
+          throw new GraphQLError('autoDeploy must be a boolean.')
+        }
+        data.autoDeploy = input.autoDeploy
       }
 
       if (Object.keys(data).length === 0) {

--- a/src/schema/typeDefs.ts
+++ b/src/schema/typeDefs.ts
@@ -486,6 +486,13 @@ export const typeDefs = /* GraphQL */ `
     failover event.
     """
     failoverPolicy: JSON
+    """
+    When false, a git push builds the image and records lastBuildSha but
+    does NOT auto-deploy. The user triggers the deploy manually. Default
+    is true (auto-deploy on every successful build). Ignored for non-git
+    services.
+    """
+    autoDeploy: Boolean
   }
 
   """
@@ -2318,5 +2325,7 @@ export const typeDefs = /* GraphQL */ `
     """One of 'PENDING' | 'RUNNING' | 'SUCCEEDED' | 'FAILED' | 'CANCELED' or null."""
     lastBuildStatus: String
     lastBuildAt: Date
+    """When false, successful builds do NOT auto-deploy; user deploys manually. Defaults to true."""
+    autoDeploy: Boolean!
   }
 `

--- a/src/services/github/buildCallbackEndpoint.ts
+++ b/src/services/github/buildCallbackEndpoint.ts
@@ -230,13 +230,19 @@ export async function handleBuildCallback(
   }
 
   // ── 4. On success, auto-deploy via existing per-deploy provider. ──
+  // Skipped when the service has autoDeploy=false — the build records the
+  // new image and lastBuildSha so the user can deploy manually from the UI.
   if (newStatus === 'SUCCEEDED' && body.imageTag) {
-    try {
-      await autoDeployAfterBuild(prisma, job.serviceId)
-    } catch (err) {
-      log.error({ err, serviceId: job.serviceId }, 'failed to dispatch deploy after build')
-      // We still 200 the callback — the BuildJob row is updated; the user
-      // can hit "Redeploy" from the UI to retry the deploy step.
+    if (job.service.autoDeploy === false) {
+      log.info({ serviceId: job.serviceId }, 'skipping auto-deploy: autoDeploy is disabled for service')
+    } else {
+      try {
+        await autoDeployAfterBuild(prisma, job.serviceId)
+      } catch (err) {
+        log.error({ err, serviceId: job.serviceId }, 'failed to dispatch deploy after build')
+        // We still 200 the callback — the BuildJob row is updated; the user
+        // can hit "Redeploy" from the UI to retry the deploy step.
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Part of alternatefutures/web-app.alternatefutures.ai#65

- Adds `autoDeploy Boolean @default(true)` to the `Service` Prisma model with a migration
- Exposes `autoDeploy` on the `Service` GraphQL type and in `UpdateServiceInput`
- `updateService` resolver validates and persists the new field
- `buildCallbackEndpoint`: gates `autoDeployAfterBuild()` behind `service.autoDeploy !== false` — when disabled, the build completes normally (image pushed, `lastBuildSha` + `lastBuildStatus` updated) but no Akash/Phala deployment is triggered

Default is `true` so all existing services keep the current behaviour with no action required.

## Test plan

- [ ] `pnpm build` passes (no TypeScript errors)
- [ ] `pnpm test` — all 847 tests pass
- [ ] Migration: `ALTER TABLE "Service" ADD COLUMN "autoDeploy" BOOLEAN NOT NULL DEFAULT true`
- [ ] Set `autoDeploy=false` on a service, push a commit — confirm build runs but deploy is skipped (log line: "skipping auto-deploy: autoDeploy is disabled for service")
- [ ] Set `autoDeploy=true` — confirm push triggers deploy as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)